### PR TITLE
Improve developer build and docker-compose experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,16 @@ docker compose up
 
 This will mount the plugin JAR into the Keycloak container as configured in the compose file.
 
+By default the compose file mounts `keycloak-oid4vp-plugin-999.0.0-SNAPSHOT.jar`. If you built a different version,
+set `VERSION` when starting compose:
+
+```sh
+VERSION=1.0.0-SNAPSHOT docker compose up
+```
+
 Once the container is up, you can access the Keycloak Admin Console at:
 
-- `http://localhost:8080/admin/master/console/`
+- URL:`http://localhost:8080/admin/master/console/`
 - Username: `admin`
 - Password: `admin`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./target/keycloak-oid4vp-plugin-999.0.0-SNAPSHOT.jar:/opt/keycloak/providers/keycloak-oid4vp-plugin-999.0.0-SNAPSHOT.jar
+      - ./target/keycloak-oid4vp-plugin-${VERSION:-999.0.0-SNAPSHOT}.jar:/opt/keycloak/providers/keycloak-oid4vp-plugin-${VERSION:-999.0.0-SNAPSHOT}.jar


### PR DESCRIPTION
### Summary

- Updated the README to recommend ./mvnw clean package -DskipTests for first-time builds and to clearly state that Docker must be installed and running when executing tests via Testcontainers (./mvnw clean verify).

- Fixed the mismatch between the Maven revision (999.0.0-SNAPSHOT) and the JAR name expected by docker-compose.yml so that docker compose up works out of the box.

- Extended the Docker Compose documentation with the Keycloak admin console URL, bootstrap credentials (admin / admin), and a link to the Keycloak Server Administration Guide to help new developers with next steps.

Closes https://github.com/ADORSYS-GIS/digital-identity-arch-review-mab/issues/4 