### PR TITLE
Do not log authorization codes and other sensitive secrets

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -181,7 +181,8 @@ public class AuthorizationRequestService {
     }
 
     private String signRequestObject(RequestObject requestObject) {
-        logger.debugf("Signing request object (%s)", requestObject.getState());
+        // Request "state" is an opaque value; do not log it.
+        logger.debug("Signing request object");
         Long expiration = Instant.now().plusSeconds(authSessionLifespanSecs).getEpochSecond();
         requestObject.issuedNow().exp(expiration);
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -181,6 +181,7 @@ public class AuthorizationRequestService {
     }
 
     private String signRequestObject(RequestObject requestObject) {
+        logger.debug("Signing request object");
         Long expiration = Instant.now().plusSeconds(authSessionLifespanSecs).getEpochSecond();
         requestObject.issuedNow().exp(expiration);
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -181,8 +181,6 @@ public class AuthorizationRequestService {
     }
 
     private String signRequestObject(RequestObject requestObject) {
-        // Request "state" is an opaque value; do not log it.
-        logger.debug("Signing request object");
         Long expiration = Instant.now().plusSeconds(authSessionLifespanSecs).getEpochSecond();
         requestObject.issuedNow().exp(expiration);
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oidc/OID4VPLoginActionsService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oidc/OID4VPLoginActionsService.java
@@ -107,7 +107,7 @@ public class OID4VPLoginActionsService extends LoginActionsService implements Re
         AuthenticationSessionModel authSession = checks.getAuthenticationSession();
 
         // Validate authorization code
-        logger.debugf("Validating authorization code: %s", authorizationCode);
+        logger.debug("Validating authorization code");
         OAuth2CodeParser.ParseResult result = OAuth2CodeParser.parseCode(session, authorizationCode, realm, event);
         if (result.isIllegalCode() || result.isExpiredCode()) {
             String errorMessage = "Authorization code not valid";


### PR DESCRIPTION
#### Summary

- Remove debug log interpolation of the OAuth2 authorization code in OID4VPLoginActionsService.
- Avoid logging the request state value when signing the request object in AuthorizationRequestService.

#### Why

Authorization codes and other opaque auth-flow values should not appear in logs, even in debug mode, to reduce risk of credential leakage.

Closes https://github.com/ADORSYS-GIS/digital-identity-arch-review-mab/issues/8