### PR TITLE
Temporary username fallback in SD‑JWT user binding

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticator.java
@@ -117,24 +117,35 @@ public class SdJwtAuthenticator implements Authenticator {
 
         String subject = readSubjectFromCredential(sdJwt);
         if (StringUtil.isBlank(subject)) {
-            logger.warn("Presented SD-JWT is missing required subject claim");
-            failRejectingPresentedSdJwtToken(context, "Missing subject claim");
-            return null;
+            logger.warn("Presented SD-JWT is missing subject claim");
+        } else {
+            logger.debugf("Presented subject: %s", subject);
         }
-        logger.debugf("Presented subject: %s", subject);
-
-        UserModel user = context.getSession().users().getUserById(context.getRealm(), subject);
-        if (user == null) {
-            logger.debugf("Authentication passed but authenticating user is unknown");
-            failDenyingAuthenticatingUser(context);
-            return null;
-        }
-        logger.debugf("Resolved user id: %s", user.getId());
 
         String presentedUsername = readUsernameFromCredential(sdJwt);
         if (StringUtil.isBlank(presentedUsername)) {
             logger.warn("Presented SD-JWT is missing required username claim");
             failRejectingPresentedSdJwtToken(context, "Missing username claim");
+            return null;
+        }
+
+        UserModel user = null;
+        if (!StringUtil.isBlank(subject)) {
+            user = context.getSession().users().getUserById(context.getRealm(), subject);
+            if (user != null) {
+                logger.debugf("Resolved user id: %s", user.getId());
+            }
+        }
+
+        if (user == null) {
+            // TODO: Remove username-only fallback once SubjectID mapper is fixed and stable.
+            logger.warn("Subject did not resolve to a user. Falling back to username lookup.");
+            user = context.getSession().users().getUserByUsername(context.getRealm(), presentedUsername);
+        }
+
+        if (user == null) {
+            logger.debugf("Authentication passed but authenticating user is unknown");
+            failDenyingAuthenticatingUser(context);
             return null;
         }
 

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -470,6 +470,15 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseKeycloakTest {
     }
 
     @Test
+    public void shouldAuthenticateSuccessfully_WithUsernameFallback() throws Exception {
+        // Request SD-JWT credentials with an unknown subject but valid username
+        String testSubject = "unknown-user-id";
+        String sdJwt = sdJwtVPTestUtils.requestSdJwtCredential(VCT_CONFIG_DEFAULT, testSubject, TEST_USER);
+
+        testSuccessfulAuthentication(sdJwt, TestOpts.getDefault());
+    }
+
+    @Test
     public void shouldFailAuthentication_SdJwtWithMismatchedUsername() throws Exception {
         // Request SD-JWT credentials from Keycloak with a correct subject but mismatched username
         String sdJwt = sdJwtVPTestUtils.requestSdJwtCredential(VCT_CONFIG_DEFAULT, TEST_USER_ID, "other-user");


### PR DESCRIPTION
Adds a short‑term fallback in recoverAuthenticatingUser to resolve users by username when the subject ID doesn’t map, with a clear TODO to remove once the SubjectID mapper is fixed. This unblocks current flows while keeping username checks intact.