### PR TITLE
Advertise schemed client IDs by default

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ClientMetadata.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ClientMetadata.java
@@ -1,8 +1,10 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.ClaimFormat;
+import java.util.Optional;
 
 /**
  * Model for Client Metadata.
@@ -27,6 +29,13 @@ public class ClientMetadata {
     public ClientMetadata setClientId(String clientId) {
         this.clientId = clientId;
         return this;
+    }
+
+    @JsonIgnore
+    public String getSchemelessClientId() {
+        return Optional.ofNullable(clientId)
+                .map(id -> id.substring(id.indexOf(':') + 1))
+                .orElse(null);
     }
 
     public VpFormat getVpFormat() {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -174,12 +174,9 @@ public class AuthorizationRequestService {
         var clientId = clientMetadata.getClientId();
         var requestUri = openID4VPRootUrl + "%s/%s".formatted(OID4VPUserAuthEndpoint.REQUEST_JWT_PATH, requestId);
 
-        // For x509_san_dns scheme, the client ID must be prefixed with the scheme
-        var prefixedClientId = ClientIdScheme.X509_SAN_DNS.getValue() + ":" + clientId;
-
         return String.format(
                 "openid4vp://authorize?client_id=%s&request_uri=%s",
-                URLEncoder.encode(prefixedClientId, StandardCharsets.UTF_8),
+                URLEncoder.encode(clientId, StandardCharsets.UTF_8),
                 URLEncoder.encode(requestUri, StandardCharsets.UTF_8));
     }
 
@@ -201,7 +198,7 @@ public class AuthorizationRequestService {
             throw new IllegalStateException("Signing key has no certificate");
         }
 
-        String clientId = clientMetadata.getClientId();
+        String clientId = clientMetadata.getSchemelessClientId();
         PublicKey publicKey = (PublicKey) signingKey.getPublicKey();
         PrivateKey privateKey = (PrivateKey) signingKey.getPrivateKey();
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/VerifierDiscoveryService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/VerifierDiscoveryService.java
@@ -1,6 +1,7 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service;
 
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPUserAuthEndpointFactory;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientIdScheme;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientMetadata;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.SdGenericFormat;
 import java.util.List;
@@ -27,6 +28,8 @@ import org.keycloak.urls.UrlType;
 public class VerifierDiscoveryService {
 
     private static final Logger logger = Logger.getLogger(VerifierDiscoveryService.class);
+
+    public static final String CLIENT_ID_SCHEME = ClientIdScheme.X509_SAN_DNS.getValue();
 
     private final KeycloakSession session;
 
@@ -88,7 +91,9 @@ public class VerifierDiscoveryService {
 
     private String getClientId() {
         // The client ID is typically the hostname of the Keycloak server.
-        return session.getContext().getUri().getBaseUri().getHost();
+        String clientId = session.getContext().getUri().getBaseUri().getHost();
+        // Prefix with scheme as per spec requirements
+        return String.join(":", CLIENT_ID_SCHEME, clientId);
     }
 
     private SdGenericFormat getSdJwtVpFormat() {

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -27,7 +27,6 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.SdJwtVPTestUti
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -84,25 +83,15 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseKeycloakTest {
         // The authorization request must be a valid URL of scheme "openid4vp".
         URI authRequest = new URI(authContext.getAuthorizationRequest());
         assertEquals("openid4vp", authRequest.getScheme());
-    }
-
-    @Test
-    public void shouldProduceAuthorizationRequestsWithSchemedClientId() throws Exception {
-        AuthorizationContext authContext = requestAuthorizationRequest();
-
-        URI authRequest = new URI(authContext.getAuthorizationRequest());
 
         // Parse query parameters
         ResteasyUriInfo uriInfo = new ResteasyUriInfo(authRequest);
         String clientIdParam = uriInfo.getQueryParameters().getFirst("client_id");
         assertNotNull(clientIdParam, "client_id parameter should be present");
 
-        // Decode URL-encoded client ID
-        String decodedClientId = URLDecoder.decode(clientIdParam, StandardCharsets.UTF_8);
-
         // Assert full expected format
         String expectedClientId = "x509_san_dns:" + getVerifierClientId();
-        assertEquals(expectedClientId, decodedClientId, "Client ID should be correctly prefixed with scheme");
+        assertEquals(expectedClientId, clientIdParam, "Client ID should be correctly prefixed with scheme");
     }
 
     @Test
@@ -124,6 +113,12 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseKeycloakTest {
                 List.of(VCT_CONFIG_DEFAULT, VCT_CONFIG_ALT), List.of(JsonWebToken.SUBJECT, OAuth2Constants.USERNAME));
         SdJwtCredentialConstrainerTest.assertDcqlQuery(requestObject.getDcqlQuery(), queryMap);
         SdJwtCredentialConstrainerTest.assertPrexQuery(requestObject.getPresentationDefinition(), queryMap);
+
+        // Assert: client IDs are schemed across the request object
+        String schemedClientId = "x509_san_dns:" + getVerifierClientId();
+        assertEquals(schemedClientId, requestObject.getIssuer());
+        assertEquals(schemedClientId, requestObject.getClientId());
+        assertEquals(schemedClientId, requestObject.getClientMetadata().getClientId());
     }
 
     @Test


### PR DESCRIPTION
Schemed client IDs should be used in more places, beyond the authorization request link.

https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-syntax
> In the client_id Authorization Request parameter and other places where the Client Identifier is used, the Client Identifier Prefixes are prefixed to the usual Client Identifier

Check examples of advertised request objects
https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-examples
