### PR TITLE
Add support for passing externally-signed certificates and response encryption

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/crypto/EphemeralKeyUtils.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/crypto/EphemeralKeyUtils.java
@@ -1,3 +1,87 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.crypto;
 
-public class EphemeralKeyUtils {}
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import org.keycloak.common.crypto.CryptoConstants;
+import org.keycloak.crypto.KeyType;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.jose.jwe.JWE;
+import org.keycloak.jose.jwe.JWEException;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.JWKBuilder;
+
+/**
+ * Utility class for handling ephemeral ECDH keys and JWE decryption.
+ */
+public class EphemeralKeyUtils {
+
+    private EphemeralKeyUtils() {
+        // Private constructor to prevent instantiation
+    }
+
+    /**
+     * Generates an ephemeral ECDH key pair on curve P-256.
+     *
+     * @return The generated JWK containing both public and private parts.
+     */
+    public static EphemeralKey generateEphemeralECDHKey() {
+        try {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance(KeyType.EC);
+            ECGenParameterSpec ecSpec = new ECGenParameterSpec(CryptoConstants.EC_KEY_SECP256R1);
+            kpg.initialize(ecSpec);
+
+            KeyPair kp = kpg.generateKeyPair();
+            JWK pubJwk = JWKBuilder.create().ec(kp.getPublic(), KeyUse.ENC);
+
+            return new EphemeralKey((ECPrivateKey) kp.getPrivate(), pubJwk);
+        } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
+            throw new RuntimeException("Failed to generate ephemeral ECDH key", e);
+        }
+    }
+
+    /**
+     * Decrypts a JWE encrypted message using the provided EC private key.
+     *
+     * @param encryptedMessage The JWE string.
+     * @param privateKey       The EC private key for decryption.
+     * @return The decrypted message as a String.
+     * @throws JWEException If decryption fails.
+     */
+    public static String decrypt(String encryptedMessage, ECPrivateKey privateKey) throws JWEException {
+        JWE jwe = new JWE();
+        jwe.getKeyStorage().setDecryptionKey(privateKey);
+        jwe.verifyAndDecodeJwe(encryptedMessage);
+        return new String(jwe.getContent(), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Converts a private key to a flat Base64 string (no headers, no newlines).
+     */
+    public static String toBase64String(ECPrivateKey privateKey) {
+        return Base64.getEncoder().encodeToString(privateKey.getEncoded());
+    }
+
+    /**
+     * Restores an ECPrivateKey from a flat Base64 string.
+     */
+    public static ECPrivateKey privateKeyFromBase64(String base64) {
+        try {
+            byte[] decoded = Base64.getDecoder().decode(base64.trim());
+            KeyFactory kf = KeyFactory.getInstance(KeyType.EC);
+            return (ECPrivateKey) kf.generatePrivate(new PKCS8EncodedKeySpec(decoded));
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new RuntimeException("Failed to restore private key from Base64", e);
+        }
+    }
+
+    public record EphemeralKey(ECPrivateKey privateKey, JWK publicKey) {}
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/crypto/EphemeralKeyUtils.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/crypto/EphemeralKeyUtils.java
@@ -1,0 +1,3 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.crypto;
+
+public class EphemeralKeyUtils {}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpoint.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpoint.java
@@ -1,7 +1,7 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.VerifierConfig;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseObject;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.AuthenticationSessionStore;
@@ -212,11 +212,11 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
         ClientModel client = checkClient(clientId);
         AuthenticationSessionModel authSession = createAuthSession(client);
         AuthenticatorConfigModel authConfig = getSdjwtAuthenticatorConfig();
-        SdJwtAuthRequirements authReqs = new SdJwtAuthRequirements(session.getContext(), authConfig);
+        VerifierConfig config = new VerifierConfig(session.getContext(), authConfig);
 
         // Call delegate service to create an authorization request
         AuthorizationContext authorizationContext =
-                authorizationRequestService.createAuthorizationRequest(authReqs, authSession, parentAuthSessionId);
+                authorizationRequestService.createAuthorizationRequest(config, authSession, parentAuthSessionId);
 
         return new AuthorizationContext()
                 .setAuthorizationRequest(authorizationContext.getAuthorizationRequest())

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpoint.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpoint.java
@@ -149,7 +149,8 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
                     ? new ResponseObject(vpToken, presentationSubmission, state)
                     : decryptResponse(encryptedResponse, ephemeralKey);
 
-            if (!requestId.equals(responseObject.getState())) {
+            String parsedState = responseObject.getState();
+            if (StringUtils.isNotBlank(parsedState) && !requestId.equals(parsedState)) {
                 throw new IllegalArgumentException(String.format(
                         "State param must match requestId. requestId: %s, state: %s",
                         requestId, responseObject.getState()));
@@ -284,7 +285,8 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
             String decryptedResponse = EphemeralKeyUtils.decrypt(encryptedResponse, privKey);
             return JsonSerialization.readValue(decryptedResponse, ResponseObject.class);
         } catch (JWEException | IOException e) {
-            throw new IllegalArgumentException("Failed to decrypt response", e);
+            logger.error("Failed to decrypt response", e);
+            throw new IllegalArgumentException("Failed to decrypt and parse response", e);
         }
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpoint.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpoint.java
@@ -1,6 +1,8 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp;
 
+import com.apicatalog.jsonld.StringUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.crypto.EphemeralKeyUtils;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.VerifierConfig;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseObject;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
@@ -21,18 +23,22 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.security.interfaces.ECPrivateKey;
 import java.util.Map;
 import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.events.EventBuilder;
+import org.keycloak.jose.jwe.JWEException;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.services.resource.RealmResourceProvider;
 import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.util.JsonSerialization;
 
 /**
  * Endpoint class for user authentication over
@@ -99,21 +105,7 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
     @Produces(MediaType.TEXT_PLAIN)
     public Response getSignedRequestObject(@PathParam("requestId") String requestId) {
         logger.debug("Resolving request URI to signed request object...");
-        AuthorizationContext authorizationContext;
-
-        try {
-            var authSession = this.recoverAuthenticationSession(requestId);
-            authorizationContext =
-                    new AuthenticationSessionStore(authSession).getAuthorizationContextByRequestId(requestId);
-        } catch (IllegalArgumentException e) {
-            throw new NotFoundException(
-                    errorResponse(
-                            Response.Status.NOT_FOUND,
-                            OAuthErrorException.INVALID_REQUEST,
-                            "Authorization context not found for request ID: " + requestId),
-                    e);
-        }
-
+        AuthorizationContext authorizationContext = recoverAuthorizationContextByRequestId(requestId);
         String requestObjectJwt = authorizationContext.getRequestObjectJwt();
         return CorsService.open().add(Response.ok(requestObjectJwt));
     }
@@ -122,41 +114,52 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
      * Processes authentication responses from the wallet toward user authentication.
      */
     @POST
-    @Path(RESPONSE_URI_PATH)
+    @Path(RESPONSE_URI_PATH + "/{requestId}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.APPLICATION_JSON)
     public Response processAuthorizationResponse(
+            @PathParam("requestId") String requestId,
+            @FormParam("response") String encryptedResponse,
             @FormParam(ResponseObject.VP_TOKEN_KEY) String vpToken,
             @FormParam(ResponseObject.PRESENTATION_SUBMISSION_KEY) String presentationSubmission,
             @FormParam(ResponseObject.STATE_KEY) String state) {
         logger.debug("Processing authorization response for user authentication...");
 
+        // Recover the auth session and context given the request ID param
+        AuthorizationContext authorizationContext = recoverAuthorizationContextByRequestId(requestId);
+        AuthenticationSessionModel authSession = recoverAuthenticationSession(requestId);
+
+        // Validate that response is encrypted if required
+        String ephemeralKey = authorizationContext.getEphemeralKey();
+        boolean expectsEncrypted = StringUtils.isNotBlank(ephemeralKey);
+        boolean hasEncrypted = StringUtils.isNotBlank(encryptedResponse);
+        if (expectsEncrypted != hasEncrypted) {
+            throw new BadRequestException(errorResponse(
+                    Response.Status.BAD_REQUEST,
+                    OAuthErrorException.INVALID_REQUEST,
+                    String.format(
+                            "Authorization context expects %s response",
+                            StringUtils.isBlank(encryptedResponse) ? "encrypted" : "unencrypted")));
+        }
+
         // Parse a response object from the request parameters
         ResponseObject responseObject;
         try {
-            responseObject = new ResponseObject(vpToken, presentationSubmission, state);
+            responseObject = StringUtils.isBlank(encryptedResponse)
+                    ? new ResponseObject(vpToken, presentationSubmission, state)
+                    : decryptResponse(encryptedResponse, ephemeralKey);
+
+            if (!requestId.equals(responseObject.getState())) {
+                throw new IllegalArgumentException(String.format(
+                        "State param must match requestId. requestId: %s, state: %s",
+                        requestId, responseObject.getState()));
+            }
         } catch (IllegalArgumentException | JsonProcessingException e) {
             throw new BadRequestException(
                     errorResponse(
                             Response.Status.BAD_REQUEST,
                             OAuthErrorException.INVALID_REQUEST,
                             String.format("Unparseable response params (%s)", e.getMessage())),
-                    e);
-        }
-
-        // Recover the auth session and context given the state field
-        AuthenticationSessionModel authSession;
-        AuthorizationContext authorizationContext;
-        try {
-            authSession = this.recoverAuthenticationSession(state);
-            authorizationContext =
-                    new AuthenticationSessionStore(authSession).getAuthorizationContextByRequestId(state);
-        } catch (IllegalArgumentException e) {
-            throw new BadRequestException(
-                    errorResponse(
-                            Response.Status.BAD_REQUEST,
-                            OAuthErrorException.INVALID_REQUEST,
-                            "Authorization context not found for state (request ID): " + state),
                     e);
         }
 
@@ -241,6 +244,23 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
     }
 
     /**
+     * Recovers the authorization context linked to a request ID.
+     */
+    private AuthorizationContext recoverAuthorizationContextByRequestId(String requestId) throws NotFoundException {
+        try {
+            var authSession = this.recoverAuthenticationSession(requestId);
+            return new AuthenticationSessionStore(authSession).getAuthorizationContextByRequestId(requestId);
+        } catch (IllegalArgumentException e) {
+            throw new NotFoundException(
+                    errorResponse(
+                            Response.Status.NOT_FOUND,
+                            OAuthErrorException.INVALID_REQUEST,
+                            "Authorization context not found for request ID: " + requestId),
+                    e);
+        }
+    }
+
+    /**
      * Recovers the authentication session linked to a possibly extended ID.
      */
     private AuthenticationSessionModel recoverAuthenticationSession(String extAuthSessionId) {
@@ -251,6 +271,21 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
 
         session.getContext().setAuthenticationSession(authSession);
         return authSession;
+    }
+
+    /**
+     * Decrypt response to authorization request.
+     * @param encryptedResponse the assumed JWE encrypted response string
+     * @param ephemeralKey the ephemeral key generated for the authentication session
+     */
+    private ResponseObject decryptResponse(String encryptedResponse, String ephemeralKey) {
+        try {
+            ECPrivateKey privKey = EphemeralKeyUtils.privateKeyFromBase64(ephemeralKey);
+            String decryptedResponse = EphemeralKeyUtils.decrypt(encryptedResponse, privKey);
+            return JsonSerialization.readValue(decryptedResponse, ResponseObject.class);
+        } catch (JWEException | IOException e) {
+            throw new IllegalArgumentException("Failed to decrypt response", e);
+        }
     }
 
     /**

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthRequirements.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthRequirements.java
@@ -97,10 +97,6 @@ public class SdJwtAuthRequirements {
         return enforceRevocationStatus;
     }
 
-    public boolean shouldVerifyIssuerClaim() {
-        return verifyIssuerClaim;
-    }
-
     /**
      * Constructs presentation definition as supported by keycloak-core.
      */

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
@@ -1,6 +1,7 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator;
 
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPEnvironmentProviderFactory;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.TrustedStatusListJwtFetcher;
 import java.util.ArrayList;
@@ -40,6 +41,16 @@ public class SdJwtAuthenticatorFactory implements AuthenticatorFactory, OID4VPEn
 
     public static final String ENFORCE_REVOCATION_STATUS_CONFIG = "enforceRevocationStatus";
     public static final boolean ENFORCE_REVOCATION_STATUS_CONFIG_DEFAULT = false;
+
+    public static final String RESPONSE_MODE_CONFIG = "responseMode";
+    public static final String RESPONSE_MODE_CONFIG_DEFAULT = ResponseMode.DIRECT_POST.getValue();
+
+    public static final String CUSTOM_URL_SCHEME_CONFIG = "customUrlScheme";
+    public static final String CUSTOM_URL_SCHEME_CONFIG_DEFAULT = "openid4vp://";
+
+    public static final String ACCESS_CERTIFICATE_CONFIG = "accessCertificate";
+
+    public static final String REGISTRATION_CERTIFICATE_CONFIG = "registrationCertificate";
 
     static {
         ProviderConfigProperty property;
@@ -86,6 +97,38 @@ public class SdJwtAuthenticatorFactory implements AuthenticatorFactory, OID4VPEn
         property.setDefaultValue(KBJWT_MAX_AGE_CONFIG_DEFAULT);
         property.setHelpText(
                 "Define a maximum age of accepted key-binding JWTs as part of measures to protect against replay.");
+        configProperties.add(property);
+
+        property = new ProviderConfigProperty();
+        property.setName(RESPONSE_MODE_CONFIG);
+        property.setLabel("Response mode");
+        property.setType(ProviderConfigProperty.LIST_TYPE);
+        property.setDefaultValue(RESPONSE_MODE_CONFIG_DEFAULT);
+        property.setOptions(List.of(ResponseMode.DIRECT_POST.getValue(), ResponseMode.DIRECT_POST_JWT.getValue()));
+        property.setHelpText("How wallets should respond to authorization requests.");
+        configProperties.add(property);
+
+        property = new ProviderConfigProperty();
+        property.setName(CUSTOM_URL_SCHEME_CONFIG);
+        property.setLabel("Custom URL scheme");
+        property.setType(ProviderConfigProperty.STRING_TYPE);
+        property.setDefaultValue(CUSTOM_URL_SCHEME_CONFIG_DEFAULT);
+        property.setHelpText("Custom URL scheme for authorization requests.");
+        configProperties.add(property);
+
+        property = new ProviderConfigProperty();
+        property.setName(ACCESS_CERTIFICATE_CONFIG);
+        property.setLabel("Access certificate");
+        property.setType(ProviderConfigProperty.STRING_TYPE);
+        property.setHelpText(
+                "PEM-encoded certificate to include in the X5C header of request objects. Do not include PEM delimiters.");
+        configProperties.add(property);
+
+        property = new ProviderConfigProperty();
+        property.setName(REGISTRATION_CERTIFICATE_CONFIG);
+        property.setLabel("Registration certificate");
+        property.setType(ProviderConfigProperty.STRING_TYPE);
+        property.setHelpText("Opaque string to advertise under the verifier_info claim of request objects.");
         configProperties.add(property);
 
         property = new ProviderConfigProperty();

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
@@ -58,11 +58,11 @@ public class VerifierConfig {
 
     private static ResponseMode validateResponseMode(String responseMode) {
         try {
-            return ResponseMode.valueOf(responseMode);
+            return ResponseMode.fromValue(responseMode);
         } catch (IllegalArgumentException e) {
             String defaultResponseMode = SdJwtAuthenticatorFactory.RESPONSE_MODE_CONFIG_DEFAULT;
             logger.warnf("Invalid response mode: %s. Defaulting to %s", responseMode, defaultResponseMode);
-            return ResponseMode.valueOf(defaultResponseMode);
+            return ResponseMode.fromValue(defaultResponseMode);
         }
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
@@ -1,0 +1,119 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config;
+
+import com.apicatalog.jsonld.StringUtils;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactory;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
+import java.io.ByteArrayInputStream;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Map;
+import org.jboss.logging.Logger;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakContext;
+
+/**
+ * Access configurations that modulate the verifier's behavior.
+ * <p></p>
+ * Read full descriptions of configurations in {@link SdJwtAuthenticatorFactory}.
+ */
+public class VerifierConfig {
+
+    private static final Logger logger = Logger.getLogger(VerifierConfig.class);
+
+    private final SdJwtAuthRequirements authRequirements;
+
+    private final ResponseMode responseMode;
+    private final String authReqUrlScheme;
+    private final X509Certificate accessCertificate;
+    private final String registrationCertificate;
+
+    public VerifierConfig(KeycloakContext context, AuthenticatorConfigModel authConfig) {
+        logger.debugf("Collecting verifier config properties");
+
+        Map<String, String> config =
+                (authConfig != null && authConfig.getConfig() != null) ? authConfig.getConfig() : Map.of();
+
+        // TODO: Relocate these non-SD-JWT-specific configurations.
+        //  They should normally not be exposed through SdJwtAuthenticatorFactory.
+
+        this.responseMode = validateResponseMode(config.getOrDefault(
+                SdJwtAuthenticatorFactory.RESPONSE_MODE_CONFIG,
+                SdJwtAuthenticatorFactory.RESPONSE_MODE_CONFIG_DEFAULT));
+
+        this.authReqUrlScheme = validateCustomUrlScheme(config.getOrDefault(
+                SdJwtAuthenticatorFactory.CUSTOM_URL_SCHEME_CONFIG,
+                SdJwtAuthenticatorFactory.CUSTOM_URL_SCHEME_CONFIG_DEFAULT));
+
+        this.accessCertificate =
+                validateX5CCertificate(config.get(SdJwtAuthenticatorFactory.ACCESS_CERTIFICATE_CONFIG));
+
+        this.registrationCertificate = config.get(SdJwtAuthenticatorFactory.REGISTRATION_CERTIFICATE_CONFIG);
+
+        // Collect authentication requirements
+        this.authRequirements = new SdJwtAuthRequirements(context, authConfig);
+    }
+
+    private static ResponseMode validateResponseMode(String responseMode) {
+        try {
+            return ResponseMode.valueOf(responseMode);
+        } catch (IllegalArgumentException e) {
+            String defaultResponseMode = SdJwtAuthenticatorFactory.RESPONSE_MODE_CONFIG_DEFAULT;
+            logger.warnf("Invalid response mode: %s. Defaulting to %s", responseMode, defaultResponseMode);
+            return ResponseMode.valueOf(defaultResponseMode);
+        }
+    }
+
+    private static String validateCustomUrlScheme(String customUrlScheme) {
+        String defaultCustomUrlScheme = SdJwtAuthenticatorFactory.RESPONSE_MODE_CONFIG_DEFAULT;
+        if (StringUtils.isBlank(customUrlScheme)) {
+            return defaultCustomUrlScheme;
+        }
+
+        if (!customUrlScheme.endsWith("://")) {
+            logger.warnf(
+                    "Custom URL scheme '%s' does not end with '://'. Defaulting to %s",
+                    customUrlScheme, defaultCustomUrlScheme);
+            return defaultCustomUrlScheme;
+        }
+
+        return customUrlScheme;
+    }
+
+    private static X509Certificate validateX5CCertificate(String certificate) {
+        if (StringUtils.isBlank(certificate)) {
+            return null;
+        }
+
+        try {
+            byte[] certBytes = Base64.getDecoder().decode(certificate);
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            return (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(certBytes));
+        } catch (CertificateException e) {
+            logger.warnf(e, "Invalid X5C certificate '%s'", certificate);
+            return null;
+        }
+    }
+
+    public SdJwtAuthRequirements getAuthRequirements() {
+        return authRequirements;
+    }
+
+    public ResponseMode getResponseMode() {
+        return responseMode;
+    }
+
+    public String getAuthReqUrlScheme() {
+        return authReqUrlScheme;
+    }
+
+    public X509Certificate getAccessCertificate() {
+        return accessCertificate;
+    }
+
+    public String getRegistrationCertificate() {
+        return registrationCertificate;
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
@@ -5,7 +5,6 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtA
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactory;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
 import java.io.ByteArrayInputStream;
-import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
@@ -67,7 +66,7 @@ public class VerifierConfig {
     }
 
     private static String validateCustomUrlScheme(String customUrlScheme) {
-        String defaultCustomUrlScheme = SdJwtAuthenticatorFactory.RESPONSE_MODE_CONFIG_DEFAULT;
+        String defaultCustomUrlScheme = SdJwtAuthenticatorFactory.CUSTOM_URL_SCHEME_CONFIG_DEFAULT;
         if (StringUtils.isBlank(customUrlScheme)) {
             return defaultCustomUrlScheme;
         }
@@ -91,10 +90,12 @@ public class VerifierConfig {
             byte[] certBytes = Base64.getDecoder().decode(certificate);
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
             return (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(certBytes));
-        } catch (CertificateException e) {
-            logger.warnf(e, "Invalid X5C certificate '%s'", certificate);
-            return null;
+        } catch (Exception e) {
+            throw new IllegalStateException(String.format("Invalid X5C certificate '%s'", certificate), e);
         }
+
+        // TODO: Validate that the configured certificate matches the current active
+        //  key that will be used for signing authorization requests.
     }
 
     public SdJwtAuthRequirements getAuthRequirements() {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ClientMetadata.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ClientMetadata.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.ClaimFormat;
 import java.util.Optional;
+import org.keycloak.jose.jwk.JSONWebKeySet;
 
 /**
  * Model for Client Metadata.
@@ -21,6 +22,9 @@ public class ClientMetadata {
 
     @JsonProperty("vp_formats")
     private VpFormat vpFormat;
+
+    @JsonProperty("jwks")
+    private JSONWebKeySet jwks;
 
     public String getClientId() {
         return clientId;
@@ -44,6 +48,15 @@ public class ClientMetadata {
 
     public ClientMetadata setVpFormat(VpFormat vpFormat) {
         this.vpFormat = vpFormat;
+        return this;
+    }
+
+    public JSONWebKeySet getJwks() {
+        return jwks;
+    }
+
+    public ClientMetadata setJwks(JSONWebKeySet jwks) {
+        this.jwks = jwks;
         return this;
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/RequestObject.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/RequestObject.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.PresentationDefinition;
+import java.util.List;
 import org.keycloak.representations.JsonWebToken;
 
 /**
@@ -52,6 +53,9 @@ public class RequestObject extends JsonWebToken {
 
     @JsonProperty("client_metadata")
     private ClientMetadata clientMetadata;
+
+    @JsonProperty("verifier_info")
+    private List<VerifierInfo> verifierInfo;
 
     public String getState() {
         return state;
@@ -158,6 +162,15 @@ public class RequestObject extends JsonWebToken {
 
     public RequestObject setClientMetadata(ClientMetadata clientMetadata) {
         this.clientMetadata = clientMetadata;
+        return this;
+    }
+
+    public List<VerifierInfo> getVerifierInfo() {
+        return verifierInfo;
+    }
+
+    public RequestObject setVerifierInfo(List<VerifierInfo> verifierInfo) {
+        this.verifierInfo = verifierInfo;
         return this;
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ResponseMode.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ResponseMode.java
@@ -26,4 +26,14 @@ public enum ResponseMode {
     public String getValue() {
         return value;
     }
+
+    public static ResponseMode fromValue(String value) {
+        for (ResponseMode mode : ResponseMode.values()) {
+            if (mode.value.equalsIgnoreCase(value)) {
+                return mode;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown response mode: " + value);
+    }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ResponseObject.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ResponseObject.java
@@ -2,9 +2,14 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.PresentationSubmission;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.keycloak.util.JsonSerialization;
@@ -27,9 +32,11 @@ public class ResponseObject {
     // This field is a String in Draft 20, and a Map<String, List<String>> in 1.0 final.
     // We use Object here to support both formats for now.
     @JsonProperty(VP_TOKEN_KEY)
+    @JsonDeserialize(using = VpTokenDeserializer.class)
     private Object vpToken;
 
     @JsonProperty(PRESENTATION_SUBMISSION_KEY)
+    @JsonDeserialize(using = PresentationSubmissionDeserializer.class)
     @Deprecated
     private PresentationSubmission presentationSubmission;
 
@@ -37,20 +44,16 @@ public class ResponseObject {
     private String state;
 
     public ResponseObject(String vpToken, String presentationSubmission, String state) throws JsonProcessingException {
-        this.vpToken = parseVpToken(requireNonBlank(vpToken, VP_TOKEN_KEY));
+        this.vpToken = parseVpToken(vpToken);
         this.presentationSubmission = parsePresentationSubmission(presentationSubmission);
-        this.state = requireNonBlank(state, STATE_KEY);
+        this.state = state;
     }
 
-    private static String requireNonBlank(String value, String fieldName) {
-        if (StringUtil.isBlank(value)) {
-            throw new IllegalArgumentException(fieldName + " must not be null or blank");
+    private static Object parseVpToken(String vpToken) throws JsonProcessingException {
+        if (StringUtil.isBlank(vpToken)) {
+            throw new IllegalArgumentException("vp_token must not be null or blank");
         }
 
-        return value;
-    }
-
-    public static Object parseVpToken(String vpToken) throws JsonProcessingException {
         if (vpToken.trim().startsWith("{")) {
             return JsonSerialization.mapper.readValue(vpToken, new TypeReference<Map<String, List<String>>>() {});
         } else {
@@ -92,5 +95,23 @@ public class ResponseObject {
     public ResponseObject setState(String state) {
         this.state = state;
         return this;
+    }
+
+    private static class VpTokenDeserializer extends JsonDeserializer<Object> {
+
+        @Override
+        public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            String raw = p.getValueAsString();
+            return parseVpToken(raw);
+        }
+    }
+
+    private static class PresentationSubmissionDeserializer extends JsonDeserializer<Object> {
+
+        @Override
+        public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            String raw = p.getValueAsString();
+            return parsePresentationSubmission(raw);
+        }
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ResponseObject.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ResponseObject.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.PresentationSubmission;
 import java.io.IOException;
@@ -42,6 +43,8 @@ public class ResponseObject {
 
     @JsonProperty(STATE_KEY)
     private String state;
+
+    ResponseObject() {}
 
     public ResponseObject(String vpToken, String presentationSubmission, String state) throws JsonProcessingException {
         this.vpToken = parseVpToken(vpToken);
@@ -101,7 +104,7 @@ public class ResponseObject {
 
         @Override
         public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-            String raw = p.getValueAsString();
+            String raw = getValueAsString(p);
             return parseVpToken(raw);
         }
     }
@@ -110,8 +113,13 @@ public class ResponseObject {
 
         @Override
         public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-            String raw = p.getValueAsString();
+            String raw = getValueAsString(p);
             return parsePresentationSubmission(raw);
         }
+    }
+
+    private static String getValueAsString(JsonParser p) throws IOException {
+        JsonNode node = p.readValueAsTree();
+        return node.isTextual() ? node.asText() : JsonSerialization.writeValueAsString(node);
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/VerifierInfo.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/VerifierInfo.java
@@ -1,0 +1,48 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * VerifierInfo for OpenID4VP Authorization Request
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class VerifierInfo {
+
+    @JsonProperty("format")
+    private String format;
+
+    @JsonProperty("data")
+    private String data;
+
+    @JsonProperty("credential_ids")
+    private List<String> credentialIds;
+
+    public String getFormat() {
+        return format;
+    }
+
+    public VerifierInfo setFormat(String format) {
+        this.format = format;
+        return this;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public VerifierInfo setData(String data) {
+        this.data = data;
+        return this;
+    }
+
+    public List<String> getCredentialIds() {
+        return credentialIds;
+    }
+
+    public VerifierInfo setCredentialIds(List<String> credentialIds) {
+        this.credentialIds = credentialIds;
+        return this;
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dto/AuthorizationContext.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dto/AuthorizationContext.java
@@ -64,6 +64,7 @@ public class AuthorizationContext {
     /**
      * An optional ephemeral key for encrypting responses.
      */
+    @JsonProperty("ephemeral_key")
     private String ephemeralKey;
 
     /**

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dto/AuthorizationContext.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dto/AuthorizationContext.java
@@ -62,6 +62,11 @@ public class AuthorizationContext {
     private String requestObjectJwt;
 
     /**
+     * An optional ephemeral key for encrypting responses.
+     */
+    private String ephemeralKey;
+
+    /**
      * An authorization code upon successful authorization.
      */
     @JsonProperty("authorization_code")
@@ -139,6 +144,15 @@ public class AuthorizationContext {
 
     public AuthorizationContext setRequestObjectJwt(String requestObjectJwt) {
         this.requestObjectJwt = requestObjectJwt;
+        return this;
+    }
+
+    public String getEphemeralKey() {
+        return ephemeralKey;
+    }
+
+    public AuthorizationContext setEphemeralKey(String ephemeralKey) {
+        this.ephemeralKey = ephemeralKey;
         return this;
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -1,5 +1,8 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service;
 
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.crypto.EphemeralKeyUtils.EphemeralKey;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.crypto.EphemeralKeyUtils;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.crypto.ExtendedCertificateUtils;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPUserAuthEndpoint;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPUserAuthEndpointBase;
@@ -9,6 +12,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.VerifierConfi
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientIdScheme;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientMetadata;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseType;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.VerifierInfo;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
@@ -33,6 +37,8 @@ import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.jose.jwe.JWEUtils;
+import org.keycloak.jose.jwk.JSONWebKeySet;
+import org.keycloak.jose.jwk.JWK;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.SessionExpiration;
@@ -96,6 +102,10 @@ public class AuthorizationRequestService {
         String requestId = generateRequestOrTransactionId(authSession);
         String transactionId = generateRequestOrTransactionId(authSession);
 
+        // Generate ephemeral encryption keys if direct_post.jwt. Must be done before creating
+        // the request object, so updated client metadata are picked up as intended.
+        EphemeralKey encryptionKey = generateEncryptionKeyIfNeeded(config.getResponseMode());
+
         // Load query map for SD-JWT authentication
         SdJwtAuthRequirements authReqs = config.getAuthRequirements();
         var queryMap = authReqs.getSdJwtQueryMap();
@@ -127,6 +137,12 @@ public class AuthorizationRequestService {
                 .setRequestObjectJwt(requestObjectJwt)
                 .setAuthorizationRequest(authorizationRequestLink);
 
+        // Attach ephemeral key if generated
+        if (encryptionKey != null) {
+            String privKey = EphemeralKeyUtils.toBase64String(encryptionKey.privateKey());
+            authorizationContext.setAuthorizationCode(privKey);
+        }
+
         // Store authorization context in the authentication session
         AuthenticationSessionStore store = new AuthenticationSessionStore(authSession);
         store.storeAuthorizationContext(authorizationContext);
@@ -153,6 +169,24 @@ public class AuthorizationRequestService {
 
         // Convert the random number to a Base64 string
         return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+    }
+
+    /**
+     * Generates ephemeral key for response encryption.
+     */
+    private EphemeralKey generateEncryptionKeyIfNeeded(ResponseMode responseMode) {
+        if (!ResponseMode.DIRECT_POST_JWT.equals(responseMode)) {
+            return null;
+        }
+
+        EphemeralKey key = EphemeralKeyUtils.generateEphemeralECDHKey();
+
+        // Update client metadata to advertise the encryption key
+        JSONWebKeySet jwks = new JSONWebKeySet();
+        jwks.setKeys(new JWK[] {key.publicKey()});
+        clientMetadata.setJwks(jwks);
+
+        return key;
     }
 
     /**

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -5,11 +5,12 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPUserAuthEndpoi
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPUserAuthEndpointBase;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtCredentialConstrainer;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.VerifierConfig;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientIdScheme;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientMetadata;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseType;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.VerifierInfo;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContextStatus;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.SpacephobicJwsBuilder;
@@ -22,6 +23,7 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.naming.ldap.LdapName;
@@ -47,6 +49,7 @@ public class AuthorizationRequestService {
 
     public static final String AUTH_REQ_JWT = "oauth-authz-req+jwt";
     public static final String X509_ATTR_CN = "CN";
+    public static final String REGISTRATION_CERT_FORMAT = "registration_cert";
 
     // The number of bytes to generate for secure random strings,
     // including request IDs, transaction IDs, and nonces (doubled).
@@ -85,7 +88,7 @@ public class AuthorizationRequestService {
      * Creates a fresh authorization request for user authentication.
      */
     public AuthorizationContext createAuthorizationRequest(
-            SdJwtAuthRequirements authReqs, AuthenticationSessionModel authSession, String parentAuthSessionId) {
+            VerifierConfig config, AuthenticationSessionModel authSession, String parentAuthSessionId) {
         logger.debug("Creating a fresh authorization request for user authentication...");
 
         // Generate random request and transaction IDs.
@@ -94,21 +97,25 @@ public class AuthorizationRequestService {
         String transactionId = generateRequestOrTransactionId(authSession);
 
         // Load query map for SD-JWT authentication
+        SdJwtAuthRequirements authReqs = config.getAuthRequirements();
         var queryMap = authReqs.getSdJwtQueryMap();
 
         // Build request object
         var constrainer = new SdJwtCredentialConstrainer();
-        RequestObject requestObject = bootstrapRequestObject()
+        RequestObject requestObject = bootstrapRequestObject(config)
                 .setState(requestId)
                 .setDcqlQuery(constrainer.generateDcqlQuery(queryMap))
                 // Kept for backward compatibility with Draft 20 wallets
                 .setPresentationDefinition(constrainer.generatePresentationDefinition(queryMap));
 
         // Sign request object
-        String requestObjectJwt = signRequestObject(requestObject);
+        X509Certificate certificate =
+                Optional.ofNullable(config.getAccessCertificate()).orElse(getSelfSignedCertificate());
+        String requestObjectJwt = signRequestObject(requestObject, certificate);
 
         // Build authorization request link
-        String authorizationRequestLink = buildAuthorizationRequestLink(requestId);
+        String scheme = config.getAuthReqUrlScheme();
+        String authorizationRequestLink = buildAuthorizationRequestLink(scheme, requestId);
 
         // Gather authorization context
         AuthorizationContext authorizationContext = new AuthorizationContext()
@@ -151,7 +158,7 @@ public class AuthorizationRequestService {
     /**
      * Returns a starter for building request objects.
      */
-    private RequestObject bootstrapRequestObject() {
+    private RequestObject bootstrapRequestObject(VerifierConfig config) {
         String clientId = clientMetadata.getClientId();
         String responseUri = openID4VPRootUrl + OID4VPUserAuthEndpoint.RESPONSE_URI_PATH;
 
@@ -159,36 +166,46 @@ public class AuthorizationRequestService {
                 .limit(2)
                 .collect(Collectors.joining("."));
 
+        // If registration certificate configured, expose it under verifier info.
+        // See https://bmi.usercontent.opencode.de/eudi-wallet/developer-guide/rp/onboarding/Example_BDB/
+        String registrationCertificate = config.getRegistrationCertificate();
+        List<VerifierInfo> verifierInfo = Optional.ofNullable(registrationCertificate)
+                .map(rc -> new VerifierInfo().setData(rc).setFormat(REGISTRATION_CERT_FORMAT))
+                .map(List::of)
+                .orElse(null);
+
         return new RequestObject()
                 .setIssuer(clientId)
-                .setResponseMode(ResponseMode.DIRECT_POST)
+                .setResponseMode(config.getResponseMode())
                 .setResponseUri(responseUri)
                 .setResponseType(ResponseType.VP_TOKEN)
                 .setClientId(clientId)
                 .setClientIdScheme(ClientIdScheme.X509_SAN_DNS)
                 .setNonce(nonce)
                 .setAudience(SYMBOLIC_AUD)
-                .setClientMetadata(clientMetadata);
+                .setClientMetadata(clientMetadata)
+                .setVerifierInfo(verifierInfo);
     }
 
-    private String buildAuthorizationRequestLink(String requestId) {
+    private String buildAuthorizationRequestLink(String scheme, String requestId) {
         var clientId = clientMetadata.getClientId();
         var requestUri = openID4VPRootUrl + "%s/%s".formatted(OID4VPUserAuthEndpoint.REQUEST_JWT_PATH, requestId);
 
         return String.format(
-                "openid4vp://authorize?client_id=%s&request_uri=%s",
+                "%sauthorize?client_id=%s&request_uri=%s",
+                scheme,
                 URLEncoder.encode(clientId, StandardCharsets.UTF_8),
                 URLEncoder.encode(requestUri, StandardCharsets.UTF_8));
     }
 
-    private String signRequestObject(RequestObject requestObject) {
+    private String signRequestObject(RequestObject requestObject, X509Certificate certificate) {
         logger.debug("Signing request object");
         Long expiration = Instant.now().plusSeconds(authSessionLifespanSecs).getEpochSecond();
         requestObject.issuedNow().exp(expiration);
 
         return new SpacephobicJwsBuilder()
                 .type(AUTH_REQ_JWT)
-                .x5c(List.of(getSelfSignedCertificate()))
+                .x5c(List.of(certificate))
                 .jsonContent(requestObject)
                 .sign(signer);
     }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 import org.jboss.logging.Logger;
+import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureSignerContext;
@@ -66,6 +67,7 @@ public class AuthorizationRequestService {
     // without SIOPv2.
     public static final String SYMBOLIC_AUD = "https://self-issued.me/v2";
 
+    private final SdJwtCredentialConstrainer constrainer;
     private final ClientMetadata clientMetadata;
     private final String openID4VPRootUrl;
     private final KeyWrapper signingKey;
@@ -73,6 +75,8 @@ public class AuthorizationRequestService {
     private final int authSessionLifespanSecs;
 
     public AuthorizationRequestService(KeycloakSession session) {
+        this.constrainer = new SdJwtCredentialConstrainer();
+
         // Discover client metadata and signing key
         VerifierDiscoveryService verifierDiscoveryService = new VerifierDiscoveryService(session);
         this.clientMetadata = verifierDiscoveryService.getClientMetadata();
@@ -111,12 +115,7 @@ public class AuthorizationRequestService {
         var queryMap = authReqs.getSdJwtQueryMap();
 
         // Build request object
-        var constrainer = new SdJwtCredentialConstrainer();
-        RequestObject requestObject = bootstrapRequestObject(config)
-                .setState(requestId)
-                .setDcqlQuery(constrainer.generateDcqlQuery(queryMap))
-                // Kept for backward compatibility with Draft 20 wallets
-                .setPresentationDefinition(constrainer.generatePresentationDefinition(queryMap));
+        RequestObject requestObject = buildRequestObject(config, queryMap, requestId);
 
         // Sign request object
         X509Certificate certificate =
@@ -192,10 +191,16 @@ public class AuthorizationRequestService {
     /**
      * Returns a starter for building request objects.
      */
-    private RequestObject bootstrapRequestObject(VerifierConfig config) {
+    private RequestObject buildRequestObject(
+            VerifierConfig config, SdJwtCredentialConstrainer.QueryMap queryMap, String requestId) {
         String clientId = clientMetadata.getClientId();
-        String responseUri = openID4VPRootUrl + OID4VPUserAuthEndpoint.RESPONSE_URI_PATH;
+        String responseUri = KeycloakUriBuilder.fromUri(openID4VPRootUrl)
+                .path(OID4VPUserAuthEndpoint.RESPONSE_URI_PATH)
+                .path(requestId)
+                .build()
+                .toString();
 
+        // Generate nonce
         String nonce = Stream.generate(AuthorizationRequestService::generateRandomString)
                 .limit(2)
                 .collect(Collectors.joining("."));
@@ -216,14 +221,22 @@ public class AuthorizationRequestService {
                 .setClientId(clientId)
                 .setClientIdScheme(ClientIdScheme.X509_SAN_DNS)
                 .setNonce(nonce)
+                .setState(requestId)
                 .setAudience(SYMBOLIC_AUD)
                 .setClientMetadata(clientMetadata)
-                .setVerifierInfo(verifierInfo);
+                .setVerifierInfo(verifierInfo)
+                .setDcqlQuery(constrainer.generateDcqlQuery(queryMap))
+                // Kept for backward compatibility with Draft 20 wallets
+                .setPresentationDefinition(constrainer.generatePresentationDefinition(queryMap));
     }
 
     private String buildAuthorizationRequestLink(String scheme, String requestId) {
         var clientId = clientMetadata.getClientId();
-        var requestUri = openID4VPRootUrl + "%s/%s".formatted(OID4VPUserAuthEndpoint.REQUEST_JWT_PATH, requestId);
+        var requestUri = KeycloakUriBuilder.fromUri(openID4VPRootUrl)
+                .path(OID4VPUserAuthEndpoint.REQUEST_JWT_PATH)
+                .path(requestId)
+                .build()
+                .toString();
 
         return String.format(
                 "%sauthorize?client_id=%s&request_uri=%s",

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -139,7 +139,7 @@ public class AuthorizationRequestService {
         // Attach ephemeral key if generated
         if (encryptionKey != null) {
             String privKey = EphemeralKeyUtils.toBase64String(encryptionKey.privateKey());
-            authorizationContext.setAuthorizationCode(privKey);
+            authorizationContext.setEphemeralKey(privKey);
         }
 
         // Store authorization context in the authentication session

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/BaseKeycloakTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/BaseKeycloakTest.java
@@ -3,8 +3,10 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import dasniko.testcontainers.keycloak.KeycloakContainer;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,7 +43,9 @@ public abstract class BaseKeycloakTest {
     public static final String TEST_KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:26.5.6";
 
     public static final String TEST_REALM_NAME = "test";
+    public static final String TEST_REALM_HAIP_NAME = "test-haip";
     public static final String TEST_REALM_V2_NAME = "test-v2";
+
     public static final String TEST_USER = "test-user";
     public static final String TEST_USER_ID = "test-user-id";
     public static final String TEST_USER_PASSWORD = "password";
@@ -61,6 +65,7 @@ public abstract class BaseKeycloakTest {
                 .withProviderClassesFrom("target/classes", "target/test-classes")
                 .withFeaturesEnabled("oid4vc-vci")
                 .withRealmImportFile("/realms/test-realm.json")
+                .withRealmImportFile("/realms/test-realm-haip.json")
                 .withRealmImportFile("/realms/test-realm-v2.json")
                 .withEnv("KC_SPI_REALM_RESTAPI_EXTENSION_OID4VP_AUTH_VERBOSE_ERRORS", "true")
                 .withEnv("KC_LOG_LEVEL", "INFO,io.github.adorsysgis:DEBUG");
@@ -103,6 +108,14 @@ public abstract class BaseKeycloakTest {
                 .path("/protocol/openid-connect/token")
                 .build()
                 .toString();
+    }
+
+    protected ObjectNode getTestResourceJson(String filename) {
+        try (InputStream stream = BaseKeycloakTest.class.getResourceAsStream(filename)) {
+            return (ObjectNode) JsonSerialization.mapper.readTree(stream);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     protected List<NameValuePair> getDefaultHttpParams() {

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/crypto/EphemeralKeyUtilsTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/crypto/EphemeralKeyUtilsTest.java
@@ -1,0 +1,50 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.crypto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.ECTestUtils;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.jose.jwe.JWEConstants;
+import org.keycloak.jose.jwk.JWKParser;
+
+class EphemeralKeyUtilsTest {
+
+    @BeforeAll
+    static void setup() {
+        CryptoIntegration.init(ExtendedCertificateUtilsTest.class.getClassLoader());
+    }
+
+    static Stream<Arguments> jweEncryptionAlgorithms() {
+        return Stream.of(
+                Arguments.of(JWEConstants.ECDH_ES, JWEConstants.A128GCM),
+                Arguments.of(JWEConstants.ECDH_ES, JWEConstants.A192GCM),
+                Arguments.of(JWEConstants.ECDH_ES, JWEConstants.A256GCM),
+                Arguments.of(JWEConstants.ECDH_ES_A128KW, JWEConstants.A128GCM),
+                Arguments.of(JWEConstants.ECDH_ES_A192KW, JWEConstants.A256GCM));
+    }
+
+    @ParameterizedTest
+    @MethodSource("jweEncryptionAlgorithms")
+    public void testEncryptDecryptMessage(String jweAlg, String jweEncAlg) throws Exception {
+        String message = "123456789";
+
+        // Generate key
+        EphemeralKeyUtils.EphemeralKey key = EphemeralKeyUtils.generateEphemeralECDHKey();
+        ECPublicKey publicKey = (ECPublicKey) JWKParser.create(key.publicKey()).toPublicKey();
+        ECPrivateKey privateKey = key.privateKey();
+
+        // Encrypt message
+        String encMsg = ECTestUtils.encryptMessage(message, publicKey, jweAlg, jweEncAlg);
+
+        // Decrypt message
+        String decMsg = EphemeralKeyUtils.decrypt(encMsg, privateKey);
+        assertEquals(message, decMsg);
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/crypto/EphemeralKeyUtilsTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/crypto/EphemeralKeyUtilsTest.java
@@ -7,6 +7,7 @@ import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -15,6 +16,13 @@ import org.keycloak.jose.jwe.JWEConstants;
 import org.keycloak.jose.jwk.JWKParser;
 
 class EphemeralKeyUtilsTest {
+
+    public final String MESSAGE = """
+        Morning spills gold across quiet streets,
+        A stray breeze hums through half-open doors.
+        Footsteps echo stories never finished,
+        While shadows stretch, reluctant to fade.
+        """;
 
     @BeforeAll
     static void setup() {
@@ -33,18 +41,35 @@ class EphemeralKeyUtilsTest {
     @ParameterizedTest
     @MethodSource("jweEncryptionAlgorithms")
     public void testEncryptDecryptMessage(String jweAlg, String jweEncAlg) throws Exception {
-        String message = "123456789";
-
         // Generate key
         EphemeralKeyUtils.EphemeralKey key = EphemeralKeyUtils.generateEphemeralECDHKey();
         ECPublicKey publicKey = (ECPublicKey) JWKParser.create(key.publicKey()).toPublicKey();
         ECPrivateKey privateKey = key.privateKey();
 
         // Encrypt message
-        String encMsg = ECTestUtils.encryptMessage(message, publicKey, jweAlg, jweEncAlg);
+        String encMsg = ECTestUtils.encryptMessage(MESSAGE, publicKey, jweAlg, jweEncAlg);
 
         // Decrypt message
         String decMsg = EphemeralKeyUtils.decrypt(encMsg, privateKey);
-        assertEquals(message, decMsg);
+        assertEquals(MESSAGE, decMsg);
+    }
+
+    @Test
+    public void testEncryptDecryptMessage_WithBase64RoundTrip() throws Exception {
+        // Generate key
+        EphemeralKeyUtils.EphemeralKey key = EphemeralKeyUtils.generateEphemeralECDHKey();
+        ECPublicKey publicKey = (ECPublicKey) JWKParser.create(key.publicKey()).toPublicKey();
+        ECPrivateKey privateKey = key.privateKey();
+
+        // Round-trip conversion of private key
+        String base64 = EphemeralKeyUtils.toBase64String(privateKey);
+        ECPrivateKey roundTrippedPrivateKey = EphemeralKeyUtils.privateKeyFromBase64(base64);
+
+        // Encrypt message
+        String encMsg = ECTestUtils.encryptMessage(MESSAGE, publicKey);
+
+        // Decrypt message
+        assertEquals(MESSAGE, EphemeralKeyUtils.decrypt(encMsg, privateKey));
+        assertEquals(MESSAGE, EphemeralKeyUtils.decrypt(encMsg, roundTrippedPrivateKey));
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPBaseUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPBaseUserAuthEndpointTest.java
@@ -17,9 +17,11 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.InputDesc
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.PresentationDefinition;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.PresentationSubmission;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.AuthorizationResponseService;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.ECTestUtils;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.SdJwtVPTestUtils;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.interfaces.ECPublicKey;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -34,6 +36,7 @@ import org.apache.http.message.BasicNameValuePair;
 import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
 import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.JWKParser;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.util.JsonSerialization;
@@ -214,7 +217,10 @@ public abstract class OID4VPBaseUserAuthEndpointTest extends OID4VPBaseKeycloakT
             String sdJwtVpToken, RequestObject requestObject, TestOpts opts) throws Exception {
         // Wrap the SD-JWT VP in an OpenID4VP response
         List<BasicNameValuePair> oid4vpResponse;
-        if (opts.shouldPrepareLegacyResponse()) {
+        if (!opts.shouldForceUnencryptedResponse()
+                && requestObject.getClientMetadata().getJwks() != null) {
+            oid4vpResponse = prepareEncryptedOpenID4VPResponse(sdJwtVpToken, requestObject);
+        } else if (opts.shouldPrepareLegacyResponse()) {
             oid4vpResponse = prepareLegacyOpenID4VPResponse(sdJwtVpToken, requestObject, opts);
         } else {
             oid4vpResponse = prepareOpenID4VPResponse(sdJwtVpToken, requestObject);
@@ -236,14 +242,46 @@ public abstract class OID4VPBaseUserAuthEndpointTest extends OID4VPBaseKeycloakT
     private List<BasicNameValuePair> prepareOpenID4VPResponse(String sdJwtVpToken, RequestObject requestObject)
             throws IOException {
         // Build presentation submission
-        DcqlQuery dcqlQuery = requestObject.getDcqlQuery();
-        Credential credentialQuery = dcqlQuery.getCredentials().getFirst();
-        var vpTokenMap = Map.of(credentialQuery.getId(), List.of(sdJwtVpToken));
+        var vpTokenMap = prepareVpTokenMap(sdJwtVpToken, requestObject);
 
         // Compose the response object as form-urlencoded parameters
         return new ArrayList<>(List.of(
                 new BasicNameValuePair(ResponseObject.VP_TOKEN_KEY, JsonSerialization.writeValueAsString(vpTokenMap)),
                 new BasicNameValuePair(ResponseObject.STATE_KEY, requestObject.getState())));
+    }
+
+    /**
+     * Prepare an encrypted OpenID4VP response object to be sent to Keycloak.
+     *
+     * @param sdJwtVpToken  the SD-JWT verifiable presentation token
+     * @param requestObject the request object containing the presentation definition
+     */
+    private List<BasicNameValuePair> prepareEncryptedOpenID4VPResponse(String sdJwtVpToken, RequestObject requestObject)
+            throws IOException {
+        // Build presentation submission
+        var vpTokenMap = prepareVpTokenMap(sdJwtVpToken, requestObject);
+        var respMap = Map.of(ResponseObject.VP_TOKEN_KEY, vpTokenMap);
+        String resp = JsonSerialization.writeValueAsString(respMap);
+        System.out.println(resp);
+
+        // Read encryption key from request object
+        JWK encJwk = requestObject.getClientMetadata().getJwks().getKeys()[0];
+        ECPublicKey encKey = (ECPublicKey) JWKParser.create(encJwk).toPublicKey();
+
+        // Encrypt the vpTokenMap
+        String encResp = ECTestUtils.encryptMessage(resp, encKey);
+
+        // Compose the response object as form-urlencoded parameters
+        return new ArrayList<>(List.of(new BasicNameValuePair("response", encResp)));
+    }
+
+    /**
+     * Maps VP token to credential query ID.
+     */
+    private Map<String, List<String>> prepareVpTokenMap(String sdJwtVpToken, RequestObject requestObject) {
+        DcqlQuery dcqlQuery = requestObject.getDcqlQuery();
+        Credential credentialQuery = dcqlQuery.getCredentials().getFirst();
+        return Map.of(credentialQuery.getId(), List.of(sdJwtVpToken));
     }
 
     /**
@@ -298,6 +336,7 @@ public abstract class OID4VPBaseUserAuthEndpointTest extends OID4VPBaseKeycloakT
         private boolean shouldRetrieveAccessToken = true;
         private boolean shouldPrepareLegacyResponse = true;
         private boolean shouldEnforceRedirectUri = false;
+        private boolean shouldForceUnencryptedResponse = false;
         private String overridePresentationDefinitionId;
         private String overridePresentationAud;
         private Descriptor.Format overrideDescriptorFormat;
@@ -358,6 +397,15 @@ public abstract class OID4VPBaseUserAuthEndpointTest extends OID4VPBaseKeycloakT
 
         public TestOpts setShouldEnforceRedirectUri(boolean shouldEnforceRedirectUri) {
             this.shouldEnforceRedirectUri = shouldEnforceRedirectUri;
+            return this;
+        }
+
+        public boolean shouldForceUnencryptedResponse() {
+            return shouldForceUnencryptedResponse;
+        }
+
+        public TestOpts setShouldForceUnencryptedResponse(boolean shouldForceUnencryptedResponse) {
+            this.shouldForceUnencryptedResponse = shouldForceUnencryptedResponse;
             return this;
         }
 

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPBaseUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPBaseUserAuthEndpointTest.java
@@ -262,7 +262,6 @@ public abstract class OID4VPBaseUserAuthEndpointTest extends OID4VPBaseKeycloakT
         var vpTokenMap = prepareVpTokenMap(sdJwtVpToken, requestObject);
         var respMap = Map.of(ResponseObject.VP_TOKEN_KEY, vpTokenMap);
         String resp = JsonSerialization.writeValueAsString(respMap);
-        System.out.println(resp);
 
         // Read encryption key from request object
         JWK encJwk = requestObject.getClientMetadata().getJwks().getKeys()[0];

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPBaseUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPBaseUserAuthEndpointTest.java
@@ -221,7 +221,7 @@ public abstract class OID4VPBaseUserAuthEndpointTest extends OID4VPBaseKeycloakT
         }
 
         // Send the OpenID4VP response to Keycloak
-        String url = getOid4vpEndpoint("/response");
+        String url = requestObject.getResponseUri();
         HttpPost httpPost = new HttpPost(url);
         httpPost.setEntity(new UrlEncodedFormEntity(oid4vpResponse));
         return httpClient.execute(httpPost);

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointHAIPTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointHAIPTest.java
@@ -1,0 +1,119 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp;
+
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactory.ACCESS_CERTIFICATE_CONFIG;
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactory.REGISTRATION_CERTIFICATE_CONFIG;
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactory.VCT_CONFIG_DEFAULT;
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.AuthorizationRequestService.REGISTRATION_CERT_FORMAT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.VerifierInfo;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.ECTestUtils;
+import java.net.URI;
+import java.util.List;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.crypto.KeyType;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.jose.jwk.JSONWebKeySet;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
+
+/**
+ * Testing compliance of the flow with requirements from the German wallet.
+ * @see <a href="https://bmi.usercontent.opencode.de/eudi-wallet/wallet-development-documentation-public/latest/architecture-concept/flows/22-pid-presentation">PID Presentation</a>
+ */
+public class OID4VPUserAuthEndpointHAIPTest extends OID4VPBaseUserAuthEndpointTest {
+
+    public static final String CUSTOM_URL_SCHEME = "haip-vp";
+
+    // For some reasons, you can't have users across realms with the same ID
+    public static final String TEST_USER_HAIP = "test-user-haip";
+
+    @Override
+    public String getActiveTestRealm() {
+        return TEST_REALM_HAIP_NAME;
+    }
+
+    @Test
+    public void shouldProduceValidAuthorizationRequests() throws Exception {
+        AuthorizationContext authContext = requestAuthorizationRequest();
+        String authRequest = authContext.getAuthorizationRequest();
+        String signedReqJwt = resolveSignedRequestObject(authRequest);
+        JWSInput jwsInput = new JWSInput(signedReqJwt);
+        RequestObject requestObject = jwsInput.readJsonContent(RequestObject.class);
+
+        // Must use configured custom URL scheme
+        assertEquals(CUSTOM_URL_SCHEME, new URI(authRequest).getScheme());
+
+        // Request object must use configured response mode
+        assertEquals(ResponseMode.DIRECT_POST_JWT, requestObject.getResponseMode());
+
+        // Signed request object must embed access certificate in X5C header
+        ObjectNode authConfig = getAuthConfig();
+        String accessCertificate = authConfig.get(ACCESS_CERTIFICATE_CONFIG).asText();
+        assertTrue(accessCertificate.startsWith("MIIB2DCCAX6gAwIBAgIVAJ/cbtVmxliKj42QvoeUp"));
+        assertEquals(List.of(accessCertificate), jwsInput.getHeader().getX5c());
+
+        // Request object must advertise registration certificate
+        List<VerifierInfo> verifierInfo = requestObject.getVerifierInfo();
+        assertEquals(1, verifierInfo.size());
+        assertEquals(REGISTRATION_CERT_FORMAT, verifierInfo.getFirst().getFormat());
+        assertEquals(
+                authConfig.get(REGISTRATION_CERTIFICATE_CONFIG).asText(),
+                verifierInfo.getFirst().getData());
+
+        // Request object must advertise an ephemeral key for response encryption
+        JSONWebKeySet jwks = requestObject.getClientMetadata().getJwks();
+        assertEquals(1, jwks.getKeys().length);
+        JWK jwk = jwks.getKeys()[0];
+        assertNotNull(jwk.getKeyId(), "A key ID is mandatory");
+        assertEquals(KeyType.EC, jwk.getKeyType());
+        assertEquals(KeyUse.ENC.getSpecName(), jwk.getPublicKeyUse());
+        assertNull(jwk.getOtherClaims().get(ECTestUtils.JWK_SECRET_D_FIELD));
+    }
+
+    @Test
+    public void shouldAuthenticateSuccessfully() throws Exception {
+        // Request a valid SD-JWT credential from Keycloak to use for authentication
+        String sdJwt = sdJwtVPTestUtils.requestSdJwtCredential(VCT_CONFIG_DEFAULT, TEST_USER_HAIP);
+
+        // Proceed to authentication
+        var opts = TestOpts.getDefault().setTestUser(TEST_USER_HAIP);
+        testSuccessfulAuthentication(sdJwt, opts);
+    }
+
+    @Test
+    public void shouldRejectUnencryptedResponses() throws Exception {
+        // Retrieve an authorization request
+        AuthorizationContext authContext = requestAuthorizationRequest();
+        RequestObject requestObject = resolveRequestObject(authContext.getAuthorizationRequest());
+
+        // Prepare and send an OpenID4VP response without encryption
+        String vpToken = "sd-jwt-vp-token";
+        var opts = TestOpts.getDefault().setShouldForceUnencryptedResponse(true);
+        HttpResponse response = sendAuthorizationResponseWithVPToken(vpToken, requestObject, opts);
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusLine().getStatusCode());
+
+        // Assert error response
+        OAuth2ErrorRepresentation errorRep = parseErrorResponse(response);
+        assertEquals(OAuthErrorException.INVALID_REQUEST, errorRep.getError());
+        assertTrue(errorRep.getErrorDescription().contains("Authorization context expects encrypted response"));
+    }
+
+    private ObjectNode getAuthConfig() {
+        ObjectNode json = getTestResourceJson("/realms/test-realm-haip.json");
+        ArrayNode config = (ArrayNode) json.get("authenticatorConfig");
+        return (ObjectNode) config.get(0).get("config");
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -298,17 +298,17 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
 
         // Associate with an unknown session ID
         requestObject.setState("unknown-session-id");
+        requestObject.setResponseUri(getOid4vpEndpoint("/response/unknown-session-id"));
 
         // Prepare and send the OpenID4VP response to Keycloak
         HttpResponse response =
                 sendAuthorizationResponseWithVPToken("sd-jwt-vptoken", requestObject, TestOpts.getDefault());
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusLine().getStatusCode());
+        assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusLine().getStatusCode());
 
         // Assert error response
         OAuth2ErrorRepresentation errorRep = parseErrorResponse(response);
         assertEquals(
-                "Authorization context not found for state (request ID): unknown-session-id",
-                errorRep.getErrorDescription());
+                "Authorization context not found for request ID: unknown-session-id", errorRep.getErrorDescription());
     }
 
     @Test

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtCredentialConstrainerTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtCredentialConstrainerTest.java
@@ -3,7 +3,6 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtCredentialConstrainer.QueryMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.Constraints;
@@ -12,7 +11,6 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.Presentat
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.keycloak.protocol.oid4vc.model.Format;
-import org.keycloak.util.JsonSerialization;
 
 public class SdJwtCredentialConstrainerTest {
 
@@ -28,12 +26,11 @@ public class SdJwtCredentialConstrainerTest {
     }
 
     @Test
-    void testGeneratePresentationDefinition() throws JsonProcessingException {
+    void testGeneratePresentationDefinition() {
         List<String> vcts = List.of("vct1", "vct2");
         List<String> claims = List.of("name", "email");
         QueryMap queryMap = new QueryMap(vcts, claims);
         PresentationDefinition def = constrainer.generatePresentationDefinition(queryMap);
-        System.out.println(JsonSerialization.mapper.writeValueAsString(def));
         assertPrexQuery(def, queryMap);
     }
 

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/utils/ECTestUtils.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/utils/ECTestUtils.java
@@ -1,18 +1,28 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.AlgorithmParameters;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Objects;
+import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.KeyType;
 import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jwe.JWE;
+import org.keycloak.jose.jwe.JWEConstants;
+import org.keycloak.jose.jwe.JWEException;
+import org.keycloak.jose.jwe.JWEHeader;
+import org.keycloak.jose.jwe.alg.JWEAlgorithmProvider;
+import org.keycloak.jose.jwe.enc.AesGcmJWEEncryptionProvider;
+import org.keycloak.jose.jwe.enc.JWEEncryptionProvider;
 import org.keycloak.jose.jwk.ECPublicJWK;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.util.JWKSUtils;
@@ -22,7 +32,7 @@ import org.keycloak.util.JWKSUtils;
  */
 public class ECTestUtils {
 
-    private static final String JWK_SECRET_D_FIELD = "d";
+    public static final String JWK_SECRET_D_FIELD = "d";
 
     public static JWK getECPublicJwk(JWK jwk) {
         jwk.setOtherClaims(ECTestUtils.JWK_SECRET_D_FIELD, null);
@@ -69,6 +79,28 @@ public class ECTestUtils {
             params.init(new ECGenParameterSpec(crvStdName));
             return params.getParameterSpec(ECParameterSpec.class);
         } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String encryptMessage(String payload, ECPublicKey publicKey) {
+        return encryptMessage(payload, publicKey, JWEConstants.ECDH_ES, JWEConstants.A128GCM);
+    }
+
+    public static String encryptMessage(
+            String payload, ECPublicKey publicKey, String jweAlgorithmName, String jweEncryptionName) {
+        JWEAlgorithmProvider jweAlgorithmProvider =
+                CryptoIntegration.getProvider().getAlgorithmProvider(JWEAlgorithmProvider.class, jweAlgorithmName);
+        JWEEncryptionProvider jweEncryptionProvider = new AesGcmJWEEncryptionProvider(jweEncryptionName);
+
+        JWEHeader jweHeader = new JWEHeader(jweAlgorithmName, jweEncryptionName, null);
+        JWE jwe = new JWE().header(jweHeader).content(payload.getBytes(StandardCharsets.UTF_8));
+
+        jwe.getKeyStorage().setEncryptionKey(publicKey);
+
+        try {
+            return jwe.encodeJwe(jweAlgorithmProvider, jweEncryptionProvider);
+        } catch (JWEException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/test/resources/realms/test-realm-haip.json
+++ b/src/test/resources/realms/test-realm-haip.json
@@ -1,0 +1,88 @@
+{
+  "id": "test-haip",
+  "realm": "test-haip",
+  "enabled": true,
+  "sslRequired": "none",
+  "eventsEnabled": true,
+  "enabledEventTypes": ["LOGIN", "LOGIN_ERROR"],
+  "users": [
+    {
+      "id": "test-user-haip-id",
+      "username": "test-user-haip",
+      "enabled": true,
+      "email": "test-user@localhost",
+      "firstName": "Tom",
+      "lastName": "Brady",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password"
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "test-app",
+      "enabled": true,
+      "secret": "password",
+      "redirectUris": [
+        "http://localhost:4200/*"
+      ],
+      "attributes": {
+        "login_theme": "keycloak.v2+oid4vp"
+      }
+    }
+  ],
+  "authenticationFlows": [
+    {
+      "id": "cf67d848-fac2-4086-b833-d9d970cf79ee",
+      "alias": "oid4vp auth",
+      "description": "Authenticate via OpenID4VP presentations of self-issued identity credentials",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "sd-jwt-authenticator",
+          "authenticatorConfig": "sd-jwt-auth-config-haip",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "22c197eb-2b40-41a4-9676-43bc5775ca50",
+      "alias": "sd-jwt-auth-config-haip",
+      "config": {
+        "vct": "https://credentials.example.com/identity_credential",
+        "requireExpClaim": "true",
+        "enforceRevocationStatus": "true",
+        "responseMode": "direct_post.jwt",
+        "customUrlScheme": "haip-vp://",
+        "accessCertificate": "MIIB2DCCAX6gAwIBAgIVAJ/cbtVmxliKj42QvoeUp/EwD8DlMAoGCCqGSM49BAMCMA8xDTALBgNVBAMMBHRlc3QwHhcNMjYwNDE1MTE1NDMyWhcNMjYwNDE1MTI1NjEyWjAPMQ0wCwYDVQQDDAR0ZXN0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb8TdscwrNw92bp6i3LPP7fSnjbKumELHDVeWWIhjxcdX3FhgHlY7uqyPRD0ZkiYNOKYkq63efplc26yeqjiAIKOBtjCBszAdBgNVHQ4EFgQUJQ95IGyH/2HVO2sGiNOSPbR+r3QwPAYDVR0jBDUwM4AUJQ95IGyH/2HVO2sGiNOSPbR+r3ShE6QRMA8xDTALBgNVBAMMBHRlc3SCBgGdkP++2TALBgNVHQ8EBAMCAYYwHQYDVR0lBBYwFAYIKwYBBQUHAwQGCCsGAQUFBwMBMBIGA1UdEwEB/wQIMAYBAf8CAQAwFAYDVR0RBA0wC4IJbG9jYWxob3N0MAoGCCqGSM49BAMCA0gAMEUCIQCk6RJ61sjDELlrZeAVVB5SZD9qslZV0MVk/qFuXFJpQAIgM70RqTwcjNi1NS78eSd7Aoouqla+rIOLcErkleuwiYE=",
+        "registrationCertificate": "registration.certificate.jwt"
+      }
+    }
+  ],
+  "components": {
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "name": "custom-rsa",
+        "providerId": "rsa",
+        "config": {
+          "algorithm": [
+            "RS256"
+          ],
+          "privateKey": [
+            "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCDs5vCDYxAJ/2o\nskI+hd2Y8uBoBzwPHQlk/l+OG5FCxiekao5g1Se3cIvDoauOiL27oLAG8vJD11l1\nsQjScLxgMQAuFEddZojmLGqXPQsV3Z8025HhBftv4IDDBCO32ue40SFQJldDPQsB\nwFzhChFLjU839t5dH5Q70dU18B7ROiKENf5Ircu558u1mIz+U1ec4aZL+dG3zpqN\nDrVgAvwrt/m1Ov2H7EgWABsiBwVJRt8mMFJTkPgsWIJKfNc36L6P1FASqQ3H1yPE\nIN9bPB1wWCREkI4B0pxFYUdEKMIq4JuXcpY8nLhkS7zIZ//gWJR61B0kwVxrpbjf\nmB8UfBb3AgMBAAECggEAevpf2xfjepTdG4U4rkE55vQD75+xyTsH5rJQb9X2EjAO\nHE0Tnf/sEjKZj5eLJpEw+d7V/+cjqY2RD4C8CCUVAY0/6cctzF1OQAABmC98BnLn\nkufklAaN/q3YDkHzSF60ObOuM7VZjoOVn5EMKWbJN49ABbYTdUljlWgeezs4y4zy\nLpFNC2lD9kRcmGOZkF8c5NdfxCSQfwKCJF7tpoJYZpaTYusRcuDxy68X3k51pDEO\nGcxKjkhn4+Vh4yxn85dDl/KbaMGOMzPxtGhIs3CgXtUmn4MPtRAuwufHaX6SKcNL\nIfYf+ZVCPApbkPyGH9swfr3Ckh07zqHsfaYm+cQfAQKBgQC/du1wXFN0A4FhRhqT\ndPCq2oSS+KdDjTjLx7RyQ+FmZAwU1kpG0IHvKv2rxBI+C/eMyymTq/pmPKgBdyiR\nlxKWLU5hAP03e/BSOSL/FvkxJw6jcprNLlGbKd689LHB5KNc+TnIOJ223Q3xDfEJ\nWryje1BxGY+gcVNkk6IBGTZV1wKBgQCwF9xko8FFSpILNEXTtATDZjrajVFuecD1\nJQcww64QbglS0WSWzFrzNiMzSgz9x0NdWqGokqjM0aGnSulEcLLasj9OWZ6fTuve\nPe1n8J+s65NGAB6eZ9fvAYvVjc3dN5MuofcAhHN8aS+suYKyVTYiuIos/VtXbdb+\nPXWe8avj4QKBgFJVO+lzalebIknIMalzQgLWkOf6kULVObU3nXr9gbHcF+3l8G7f\nPuCwJgF1ATs5PiyHOMvNypGoR77JlOJ2ioGV3fyMxlbTrxZMh6YWJPZkC0FyCOtu\nnZ0RtjyfJMlyHmXermBRKFD4YgRksGALas8KOh9IlKCz2t6HNcUvKFRlAoGBAKqj\nhKNVeA0AVQNcdSnP8Sm0X+W3OajXfR9Q8WXUyVEMgCZr2JC0mJHD7VpfMLWfKW1G\nTQ8Ah2hq374wPlle6EI6plPzTl3L6Y7j7bFiICk94unbZdBUipAFrI6Vql7q4so2\nkxdCQnLVryguYDMVla8RqnwsSx4uxz55KgiK4emhAoGBAIx5c1FP+6+q1vJM+SgE\nOZZXUy8X78WnKEw9imM4Tkk4r6jM10PyHopuZr0+yXZ4A3Gw/bIplMVpGScqBr/I\nvk8aFXw8Fat+CWlNOs4JlyRVGlfzPQjst3KiiSBNyrOrEOf8/kDmKCuP7rvdp7pz\nuID6EdUn4in0E2RYnLVD7HcR\n-----END PRIVATE KEY-----\n"
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR addresses two main points:
- Configuration for certificates to advertise and other minor details (auth request URL scheme, response mode to enforce)
- Response encryption/decryption with ephemeral keys

These are necessary to achieve conformance with [PID Presentation](https://bmi.usercontent.opencode.de/eudi-wallet/wallet-development-documentation-public/latest/architecture-concept/flows/22-pid-presentation/).

Related to #49 