### PR TITLE
chore: add OID4VCI request patch and suppress metadata encryption parameters

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedOID4VCIssuerEndpoint.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedOID4VCIssuerEndpoint.java
@@ -1,0 +1,62 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.patch.issuance;
+
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
+import org.keycloak.protocol.oid4vc.model.CredentialRequest;
+import org.keycloak.util.JsonSerialization;
+
+/**
+ * Temporary patch: Translates {@code credential_configuration_id} to {@code credential_identifier}
+ * in the incoming Wallet Credential Request.
+ * <p>
+ * Some wallet applications incorrectly send {@code credential_configuration_id} instead of
+ * {@code credential_identifier} (which is required if {@code credential_identifiers} are present
+ * in the token, see OID4VCI spec section 8.2).
+ * </p>
+ * <p>
+ * Prerequisite: {@code credential_identifier} and {@code credential_configuration_id}
+ * must have the same value (Keycloak default when no separate credential_identifier
+ * is configured). Only the incoming request is modified – tokens, OfferState,
+ * and all security checks remain fully intact.
+ * </p>
+ */
+public class PatchedOID4VCIssuerEndpoint extends OID4VCIssuerEndpoint {
+
+    private static final Logger logger = Logger.getLogger(PatchedOID4VCIssuerEndpoint.class);
+
+    public PatchedOID4VCIssuerEndpoint(KeycloakSession session) {
+        super(session);
+    }
+
+    @Override
+    public Response requestCredential(String requestPayload) {
+        return super.requestCredential(patchWalletRequest(requestPayload));
+    }
+
+    protected static String patchWalletRequest(String requestPayload) {
+        if (requestPayload == null || requestPayload.isBlank()) {
+            return requestPayload;
+        }
+        try {
+            CredentialRequest req = JsonSerialization.readValue(requestPayload, CredentialRequest.class);
+
+            if (req.getCredentialIdentifier() != null || req.getCredentialConfigurationId() == null) {
+                return requestPayload; // Nothing to do
+            }
+
+            String configId = req.getCredentialConfigurationId();
+            logger.debugf(
+                    "[Patch] Wallet sent credential_configuration_id='%s', copying to credential_identifier", configId);
+
+            req.setCredentialIdentifier(configId);
+            req.setCredentialConfigurationId(null);
+            return JsonSerialization.writeValueAsString(req);
+
+        } catch (Exception e) {
+            logger.warn("[Patch] Failed to patch wallet credential request, forwarding as-is", e);
+            return requestPayload;
+        }
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedOID4VCLoginProtocolFactory.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedOID4VCLoginProtocolFactory.java
@@ -1,0 +1,22 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.patch.issuance;
+
+import org.keycloak.events.EventBuilder;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oid4vc.OID4VCLoginProtocolFactory;
+
+/**
+ * Overrides the default {@link OID4VCLoginProtocolFactory} with a higher priority
+ * to provide the {@link PatchedOID4VCIssuerEndpoint}.
+ */
+public class PatchedOID4VCLoginProtocolFactory extends OID4VCLoginProtocolFactory {
+
+    @Override
+    public Object createProtocolEndpoint(KeycloakSession session, EventBuilder event) {
+        return new PatchedOID4VCIssuerEndpoint(session);
+    }
+
+    @Override
+    public int order() {
+        return super.order() + 10; // Higher than default -> this factory wins
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedOID4VCLoginProtocolFactory.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedOID4VCLoginProtocolFactory.java
@@ -17,6 +17,6 @@ public class PatchedOID4VCLoginProtocolFactory extends OID4VCLoginProtocolFactor
 
     @Override
     public int order() {
-        return super.order() + 10; // Higher than default -> this factory wins
+        return super.order() + 9; // Higher than default -> this factory wins
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/metadata/OID4VCIssuerMetadataProvider.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/metadata/OID4VCIssuerMetadataProvider.java
@@ -35,6 +35,10 @@ public class OID4VCIssuerMetadataProvider extends OID4VCIssuerWellKnownProvider 
         // Add root display metadata
         metadata.setDisplay(parseDisplay());
 
+        // Always omit encryption parameters from metadata
+        metadata.setCredentialResponseEncryption(null);
+        metadata.setCredentialRequestEncryption(null);
+
         return metadata;
     }
 

--- a/src/main/resources/META-INF/services/org.keycloak.protocol.LoginProtocolFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.protocol.LoginProtocolFactory
@@ -1,0 +1,1 @@
+io.github.adorsysgis.keycloak.protocol.oid4vc.patch.issuance.PatchedOID4VCLoginProtocolFactory

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedOID4VCIssuerEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedOID4VCIssuerEndpointTest.java
@@ -32,5 +32,13 @@ public class PatchedOID4VCIssuerEndpointTest {
         // Case 4: null/empty
         assertNull(PatchedOID4VCIssuerEndpoint.patchWalletRequest(null));
         assertEquals("", PatchedOID4VCIssuerEndpoint.patchWalletRequest(""));
+
+        // Case 5: invalid JSON (should be forwarded as-is)
+        String invalidJson = "{\"invalid\": ";
+        assertEquals(invalidJson, PatchedOID4VCIssuerEndpoint.patchWalletRequest(invalidJson));
+
+        // Case 6: whitespace-only payload (should be returned unchanged)
+        String whitespace = "   ";
+        assertEquals(whitespace, PatchedOID4VCIssuerEndpoint.patchWalletRequest(whitespace));
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedOID4VCIssuerEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedOID4VCIssuerEndpointTest.java
@@ -1,0 +1,36 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.patch.issuance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.protocol.oid4vc.model.CredentialRequest;
+import org.keycloak.util.JsonSerialization;
+
+public class PatchedOID4VCIssuerEndpointTest {
+
+    @Test
+    public void testPatchWalletRequest() throws Exception {
+        // Case 1: wallet sends credential_configuration_id only
+        String payload = "{\"credential_configuration_id\": \"my-config\"}";
+        String patched = PatchedOID4VCIssuerEndpoint.patchWalletRequest(payload);
+
+        CredentialRequest req = JsonSerialization.readValue(patched, CredentialRequest.class);
+        assertEquals("my-config", req.getCredentialIdentifier());
+        assertNull(req.getCredentialConfigurationId());
+
+        // Case 2: wallet sends both (already correct or following some other logic)
+        payload = "{\"credential_configuration_id\": \"my-config\", \"credential_identifier\": \"my-id\"}";
+        patched = PatchedOID4VCIssuerEndpoint.patchWalletRequest(payload);
+        assertEquals(payload, patched);
+
+        // Case 3: wallet sends credential_identifier only (already correct)
+        payload = "{\"credential_identifier\": \"my-id\"}";
+        patched = PatchedOID4VCIssuerEndpoint.patchWalletRequest(payload);
+        assertEquals(payload, patched);
+
+        // Case 4: null/empty
+        assertNull(PatchedOID4VCIssuerEndpoint.patchWalletRequest(null));
+        assertEquals("", PatchedOID4VCIssuerEndpoint.patchWalletRequest(""));
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/metadata/OID4VCIssuerMetadataProviderTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/metadata/OID4VCIssuerMetadataProviderTest.java
@@ -46,6 +46,9 @@ public class OID4VCIssuerMetadataProviderTest {
             assertEquals("Example Credential Issuer", displayEn.getName());
             assertEquals("https://example.com/logo.png", displayEn.getLogo().getUri());
             assertEquals("Issuer Logo", displayEn.getLogo().getAltText());
+
+            assertNull(metadata.getCredentialResponseEncryption(), "credential_response_encryption should be omitted");
+            assertNull(metadata.getCredentialRequestEncryption(), "credential_request_encryption should be omitted");
         }
     }
 
@@ -57,6 +60,8 @@ public class OID4VCIssuerMetadataProviderTest {
             CredentialIssuer metadata = assertDoesNotThrow(() ->
                     retrieveCredentialIssuerMetadata(httpClient, keycloak.getAuthServerUrl(), getActiveTestRealm()));
             assertNull(metadata.getDisplay());
+            assertNull(metadata.getCredentialResponseEncryption(), "credential_response_encryption should be omitted");
+            assertNull(metadata.getCredentialRequestEncryption(), "credential_request_encryption should be omitted");
         }
     }
 


### PR DESCRIPTION
This PR introduces the following changes:

- Added `PatchedOID4VCIssuerEndpoint` to map `credential_configuration_id` → `credential_identifier`
- Removed `credential_response_encryption` and `credential_request_encryption` from issuer metadata
- Added unit tests for the endpoint mapping logic
- Updated metadata provider tests to reflect removed encryption fields