### PR TITLE
Clean up metadata exposed in request object

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
@@ -2,6 +2,7 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator;
 
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPEnvironmentProviderFactory;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientIdScheme;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.QueryLanguage;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.TrustedStatusListJwtFetcher;
@@ -45,6 +46,9 @@ public class SdJwtAuthenticatorFactory implements AuthenticatorFactory, OID4VPEn
 
     public static final String CLIENT_ID_SCHEME_CONFIG = "clientIdScheme";
     public static final String CLIENT_ID_SCHEME_CONFIG_DEFAULT = ClientIdScheme.X509_SAN_DNS.getValue();
+
+    public static final String QUERY_LANGUAGE_CONFIG = "queryLanguage";
+    public static final String QUERY_LANGUAGE_CONFIG_DEFAULT = QueryLanguage.DCQL_QUERY.getValue();
 
     public static final String RESPONSE_MODE_CONFIG = "responseMode";
     public static final String RESPONSE_MODE_CONFIG_DEFAULT = ResponseMode.DIRECT_POST.getValue();
@@ -110,6 +114,16 @@ public class SdJwtAuthenticatorFactory implements AuthenticatorFactory, OID4VPEn
         property.setDefaultValue(CLIENT_ID_SCHEME_CONFIG_DEFAULT);
         property.setOptions(List.of(ClientIdScheme.X509_SAN_DNS.getValue(), ClientIdScheme.X509_HASH.getValue()));
         property.setHelpText("Client Identifier Prefix to conform to as per OpenID4VP spec.");
+        configProperties.add(property);
+
+        property = new ProviderConfigProperty();
+        property.setName(QUERY_LANGUAGE_CONFIG);
+        property.setLabel("Query language");
+        property.setType(ProviderConfigProperty.LIST_TYPE);
+        property.setDefaultValue(QUERY_LANGUAGE_CONFIG_DEFAULT);
+        property.setOptions(
+                List.of(QueryLanguage.DCQL_QUERY.getValue(), QueryLanguage.DIF_PRESENTATION_EXCHANGE.getValue()));
+        property.setHelpText("Query language specification for encoding presentation requests.");
         configProperties.add(property);
 
         property = new ProviderConfigProperty();

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
@@ -4,6 +4,7 @@ import com.apicatalog.jsonld.StringUtils;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactory;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientIdScheme;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.QueryLanguage;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
 import java.io.ByteArrayInputStream;
 import java.security.cert.CertificateFactory;
@@ -26,6 +27,7 @@ public class VerifierConfig {
     private final SdJwtAuthRequirements authRequirements;
 
     private final ClientIdScheme clientIdScheme;
+    private final QueryLanguage queryLanguage;
     private final ResponseMode responseMode;
     private final String authReqUrlScheme;
     private final X509Certificate accessCertificate;
@@ -43,6 +45,10 @@ public class VerifierConfig {
         this.clientIdScheme = validateClientIdScheme(config.getOrDefault(
                 SdJwtAuthenticatorFactory.CLIENT_ID_SCHEME_CONFIG,
                 SdJwtAuthenticatorFactory.CLIENT_ID_SCHEME_CONFIG_DEFAULT));
+
+        this.queryLanguage = validateQueryLanguage(config.getOrDefault(
+                SdJwtAuthenticatorFactory.QUERY_LANGUAGE_CONFIG,
+                SdJwtAuthenticatorFactory.QUERY_LANGUAGE_CONFIG_DEFAULT));
 
         this.responseMode = validateResponseMode(config.getOrDefault(
                 SdJwtAuthenticatorFactory.RESPONSE_MODE_CONFIG,
@@ -68,6 +74,16 @@ public class VerifierConfig {
             String defaultClientIdScheme = SdJwtAuthenticatorFactory.CLIENT_ID_SCHEME_CONFIG_DEFAULT;
             logger.warnf("Invalid client ID scheme: %s. Defaulting to %s", clientIdScheme, defaultClientIdScheme);
             return ClientIdScheme.fromValue(defaultClientIdScheme);
+        }
+    }
+
+    private static QueryLanguage validateQueryLanguage(String queryLanguage) {
+        try {
+            return QueryLanguage.fromValue(queryLanguage);
+        } catch (IllegalArgumentException e) {
+            String defaultQueryLanguage = SdJwtAuthenticatorFactory.QUERY_LANGUAGE_CONFIG_DEFAULT;
+            logger.warnf("Invalid query language: %s. Defaulting to %s", queryLanguage, defaultQueryLanguage);
+            return QueryLanguage.fromValue(defaultQueryLanguage);
         }
     }
 
@@ -117,6 +133,10 @@ public class VerifierConfig {
 
     public ClientIdScheme getClientIdScheme() {
         return clientIdScheme;
+    }
+
+    public QueryLanguage getQueryLanguage() {
+        return queryLanguage;
     }
 
     public ResponseMode getResponseMode() {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ClientMetadata.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ClientMetadata.java
@@ -3,6 +3,7 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.ClaimFormat;
+import java.util.List;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 
 /**
@@ -15,23 +16,14 @@ import org.keycloak.jose.jwk.JSONWebKeySet;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ClientMetadata {
 
-    @JsonProperty("client_id")
-    private String clientId;
-
     @JsonProperty("vp_formats")
     private VpFormat vpFormat;
 
     @JsonProperty("jwks")
     private JSONWebKeySet jwks;
 
-    public String getClientId() {
-        return clientId;
-    }
-
-    public ClientMetadata setClientId(String clientId) {
-        this.clientId = clientId;
-        return this;
-    }
+    @JsonProperty("encrypted_response_enc_values_supported")
+    private List<String> encryptedResponseEncValuesSupported;
 
     public VpFormat getVpFormat() {
         return vpFormat;
@@ -48,6 +40,15 @@ public class ClientMetadata {
 
     public ClientMetadata setJwks(JSONWebKeySet jwks) {
         this.jwks = jwks;
+        return this;
+    }
+
+    public List<String> getEncryptedResponseEncValuesSupported() {
+        return encryptedResponseEncValuesSupported;
+    }
+
+    public ClientMetadata setEncryptedResponseEncValuesSupported(List<String> encryptedResponseEncValuesSupported) {
+        this.encryptedResponseEncValuesSupported = encryptedResponseEncValuesSupported;
         return this;
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/QueryLanguage.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/QueryLanguage.java
@@ -1,0 +1,30 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum QueryLanguage {
+    DCQL_QUERY("dcql_query"),
+    DIF_PRESENTATION_EXCHANGE("dif_presentation_exchange"),
+    ;
+
+    private final String value;
+
+    QueryLanguage(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public static QueryLanguage fromValue(String value) {
+        for (QueryLanguage lang : QueryLanguage.values()) {
+            if (lang.value.equalsIgnoreCase(value)) {
+                return lang;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown query language: " + value);
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -10,6 +10,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtA
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtCredentialConstrainer;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.VerifierConfig;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientMetadata;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.QueryLanguage;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseType;
@@ -105,24 +106,23 @@ public class AuthorizationRequestService {
         // Resolve and validate the certificate that will be advertised under x5c.
         X509Certificate certificate = resolveAccessCertificate(config, signingKey);
 
-        // Discover client metadata
-        ClientMetadata clientMetadata =
-                discoveryService.getClientMetadata(config.getClientIdScheme(), certificate, encryptionKey);
+        // Resolve client ID and discover client metadata
+        String clientId = discoveryService.getClientId(config.getClientIdScheme(), certificate);
+        ClientMetadata clientMetadata = discoveryService.getClientMetadata(encryptionKey);
 
         // Load query map for SD-JWT authentication
         SdJwtAuthRequirements authReqs = config.getAuthRequirements();
         var queryMap = authReqs.getSdJwtQueryMap();
 
         // Build request object
-        RequestObject requestObject = buildRequestObject(clientMetadata, config, queryMap, requestId);
+        RequestObject requestObject = buildRequestObject(clientId, clientMetadata, config, queryMap, requestId);
 
         // Sign request object
         String requestObjectJwt = signRequestObject(requestObject, signingKey, certificate);
 
         // Build authorization request link
         String urlScheme = config.getAuthReqUrlScheme();
-        String authorizationRequestLink =
-                buildAuthorizationRequestLink(urlScheme, clientMetadata.getClientId(), requestId);
+        String authorizationRequestLink = buildAuthorizationRequestLink(urlScheme, clientId, requestId);
 
         // Gather authorization context
         AuthorizationContext authorizationContext = new AuthorizationContext()
@@ -202,11 +202,11 @@ public class AuthorizationRequestService {
      * Returns a starter for building request objects.
      */
     private RequestObject buildRequestObject(
+            String clientId,
             ClientMetadata clientMetadata,
             VerifierConfig config,
             SdJwtCredentialConstrainer.QueryMap queryMap,
             String requestId) {
-        String clientId = clientMetadata.getClientId();
         String responseUri = KeycloakUriBuilder.fromUri(openID4VPRootUrl)
                 .path(OID4VPUserAuthEndpoint.RESPONSE_URI_PATH)
                 .path(requestId)
@@ -226,7 +226,8 @@ public class AuthorizationRequestService {
                 .map(List::of)
                 .orElse(null);
 
-        return new RequestObject()
+        // Aggregate properties
+        RequestObject requestObject = new RequestObject()
                 .setIssuer(clientId)
                 .setResponseMode(config.getResponseMode())
                 .setResponseUri(responseUri)
@@ -237,10 +238,17 @@ public class AuthorizationRequestService {
                 .setState(requestId)
                 .setAudience(SYMBOLIC_AUD)
                 .setClientMetadata(clientMetadata)
-                .setVerifierInfo(verifierInfo)
-                .setDcqlQuery(constrainer.generateDcqlQuery(queryMap))
-                // Kept for backward compatibility with Draft 20 wallets
-                .setPresentationDefinition(constrainer.generatePresentationDefinition(queryMap));
+                .setVerifierInfo(verifierInfo);
+
+        // Append presentation request
+        if (config.getQueryLanguage().equals(QueryLanguage.DIF_PRESENTATION_EXCHANGE)) {
+            // Kept for backward compatibility with Draft 20 wallets
+            requestObject.setPresentationDefinition(constrainer.generatePresentationDefinition(queryMap));
+        } else {
+            requestObject.setDcqlQuery(constrainer.generateDcqlQuery(queryMap));
+        }
+
+        return requestObject;
     }
 
     private String buildAuthorizationRequestLink(String urlScheme, String clientId, String requestId) {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/VerifierDiscoveryService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/VerifierDiscoveryService.java
@@ -11,15 +11,15 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import org.jboss.logging.Logger;
 import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.CryptoUtils;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
-import org.keycloak.crypto.SignatureProvider;
+import org.keycloak.jose.jwe.JWEConstants;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
-import org.keycloak.provider.ProviderFactory;
 import org.keycloak.services.Urls;
 import org.keycloak.urls.UrlType;
 
@@ -34,6 +34,9 @@ public class VerifierDiscoveryService {
 
     private static final Logger logger = Logger.getLogger(VerifierDiscoveryService.class);
 
+    public static final List<String> SUPPORTED_ENC_ALGS =
+            List.of(JWEConstants.A128GCM, JWEConstants.A192GCM, JWEConstants.A256GCM);
+
     private final KeycloakSession session;
 
     public VerifierDiscoveryService(KeycloakSession session) {
@@ -43,14 +46,9 @@ public class VerifierDiscoveryService {
     /**
      * Discovers and return client metadata as Keycloak acts as an OpenID4VP client.
      */
-    public ClientMetadata getClientMetadata(
-            ClientIdScheme clientIdScheme, X509Certificate clientCertificate, EphemeralKey ephemeralKey) {
+    public ClientMetadata getClientMetadata(EphemeralKey ephemeralKey) {
         logger.debug("Discovering Keycloak's metadata as an OpenID4VP client");
         ClientMetadata metadata = new ClientMetadata();
-
-        // Compute client ID as per client ID scheme rules
-        String clientId = getClientId(clientIdScheme, clientCertificate);
-        metadata.setClientId(clientId);
 
         // Only SD-JWT presentations are supported for now.
         ClientMetadata.VpFormat vpFormat = new ClientMetadata.VpFormat();
@@ -61,7 +59,7 @@ public class VerifierDiscoveryService {
         if (ephemeralKey != null) {
             JSONWebKeySet jwks = new JSONWebKeySet();
             jwks.setKeys(new JWK[] {ephemeralKey.publicKey()});
-            metadata.setJwks(jwks);
+            metadata.setJwks(jwks).setEncryptedResponseEncValuesSupported(SUPPORTED_ENC_ALGS);
         }
 
         // Return aggregated metadata
@@ -111,7 +109,7 @@ public class VerifierDiscoveryService {
         return session.getContext().getUri().getBaseUri().getHost();
     }
 
-    private String getClientId(ClientIdScheme clientIdScheme, X509Certificate clientCertificate) {
+    public String getClientId(ClientIdScheme clientIdScheme, X509Certificate clientCertificate) {
         // Compute client ID as per client ID scheme rules
         String clientId =
                 switch (clientIdScheme) {
@@ -138,9 +136,6 @@ public class VerifierDiscoveryService {
     }
 
     private List<String> getSupportedSignatureAlgorithms() {
-        return session.getKeycloakSessionFactory()
-                .getProviderFactoriesStream(SignatureProvider.class)
-                .map(ProviderFactory::getId)
-                .toList();
+        return CryptoUtils.getSupportedAsymmetricSignatureAlgorithms(session);
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPBaseUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPBaseUserAuthEndpointTest.java
@@ -220,7 +220,7 @@ public abstract class OID4VPBaseUserAuthEndpointTest extends OID4VPBaseKeycloakT
         if (!opts.shouldForceUnencryptedResponse()
                 && requestObject.getClientMetadata().getJwks() != null) {
             oid4vpResponse = prepareEncryptedOpenID4VPResponse(sdJwtVpToken, requestObject);
-        } else if (opts.shouldPrepareLegacyResponse()) {
+        } else if (requestObject.getPresentationDefinition() != null) {
             oid4vpResponse = prepareLegacyOpenID4VPResponse(sdJwtVpToken, requestObject, opts);
         } else {
             oid4vpResponse = prepareOpenID4VPResponse(sdJwtVpToken, requestObject);
@@ -333,7 +333,6 @@ public abstract class OID4VPBaseUserAuthEndpointTest extends OID4VPBaseKeycloakT
         private AuthorizationContext authContext;
         private boolean shouldBase64EncodeVpToken;
         private boolean shouldRetrieveAccessToken = true;
-        private boolean shouldPrepareLegacyResponse = true;
         private boolean shouldEnforceRedirectUri = false;
         private boolean shouldForceUnencryptedResponse = false;
         private String overridePresentationDefinitionId;
@@ -378,15 +377,6 @@ public abstract class OID4VPBaseUserAuthEndpointTest extends OID4VPBaseKeycloakT
 
         public TestOpts setShouldRetrieveAccessToken(boolean retrieveAccessToken) {
             this.shouldRetrieveAccessToken = retrieveAccessToken;
-            return this;
-        }
-
-        public boolean shouldPrepareLegacyResponse() {
-            return shouldPrepareLegacyResponse;
-        }
-
-        public TestOpts setShouldPrepareLegacyResponse(boolean shouldPrepareLegacyResponse) {
-            this.shouldPrepareLegacyResponse = shouldPrepareLegacyResponse;
             return this;
         }
 

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointHAIPTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointHAIPTest.java
@@ -4,6 +4,7 @@ import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactory.REGISTRATION_CERTIFICATE_CONFIG;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactory.VCT_CONFIG_DEFAULT;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.AuthorizationRequestService.REGISTRATION_CERT_FORMAT;
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.VerifierDiscoveryService.SUPPORTED_ENC_ALGS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -11,7 +12,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtCredentialConstrainer;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtCredentialConstrainerTest;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientIdScheme;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientMetadata;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.VerifierInfo;
@@ -25,6 +29,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.jboss.resteasy.specimpl.ResteasyUriInfo;
 import org.junit.jupiter.api.Test;
+import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.common.util.PemUtils;
 import org.keycloak.crypto.KeyType;
@@ -32,6 +37,7 @@ import org.keycloak.crypto.KeyUse;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 
 /**
@@ -80,6 +86,11 @@ public class OID4VPUserAuthEndpointHAIPTest extends OID4VPBaseUserAuthEndpointTe
         // Request object must use configured response mode
         assertEquals(ResponseMode.DIRECT_POST_JWT, requestObject.getResponseMode());
 
+        // Assert: Ensure the request object contains a DCQL query
+        var queryMap = new SdJwtCredentialConstrainer.QueryMap(
+                List.of(VCT_CONFIG_DEFAULT), List.of(JsonWebToken.SUBJECT, OAuth2Constants.USERNAME));
+        SdJwtCredentialConstrainerTest.assertDcqlQuery(requestObject.getDcqlQuery(), queryMap);
+
         // Signed request object must embed access certificate in X5C header
         assertTrue(accessCertificate.startsWith("MIIDITCCAgmgAwIBAgIUcQyt0bvRf7/e4/Gtfw0OHRIBJfU"));
         assertEquals(List.of(accessCertificate), jwsInput.getHeader().getX5c());
@@ -93,13 +104,17 @@ public class OID4VPUserAuthEndpointHAIPTest extends OID4VPBaseUserAuthEndpointTe
                 verifierInfo.getFirst().getData());
 
         // Request object must advertise an ephemeral key for response encryption
-        JSONWebKeySet jwks = requestObject.getClientMetadata().getJwks();
+        ClientMetadata clientMetadata = requestObject.getClientMetadata();
+        JSONWebKeySet jwks = clientMetadata.getJwks();
         assertEquals(1, jwks.getKeys().length);
         JWK jwk = jwks.getKeys()[0];
         assertNotNull(jwk.getKeyId(), "A key ID is mandatory");
         assertEquals(KeyType.EC, jwk.getKeyType());
         assertEquals(KeyUse.ENC.getSpecName(), jwk.getPublicKeyUse());
         assertNull(jwk.getOtherClaims().get(ECTestUtils.JWK_SECRET_D_FIELD));
+
+        // Request object must explicitly advertise support encryption algs
+        assertEquals(SUPPORTED_ENC_ALGS, clientMetadata.getEncryptedResponseEncValuesSupported());
     }
 
     @Test

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -82,10 +82,9 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
         String actualSessionId = pruneAuthSessionId(requestObject.getState());
         assertEquals(expectedSessionId, actualSessionId);
 
-        // Assert: Ensure the request object contains a DCQL query and a legacy presentation definition
+        // Assert: Ensure the request object contains a legacy presentation definition
         var queryMap = new QueryMap(
                 List.of(VCT_CONFIG_DEFAULT, VCT_CONFIG_ALT), List.of(JsonWebToken.SUBJECT, OAuth2Constants.USERNAME));
-        SdJwtCredentialConstrainerTest.assertDcqlQuery(requestObject.getDcqlQuery(), queryMap);
         SdJwtCredentialConstrainerTest.assertPrexQuery(requestObject.getPresentationDefinition(), queryMap);
 
         // Request object must use expected default client ID scheme
@@ -95,7 +94,12 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
         String schemedClientId = "x509_san_dns:" + getVerifierClientId();
         assertEquals(schemedClientId, requestObject.getIssuer());
         assertEquals(schemedClientId, requestObject.getClientId());
-        assertEquals(schemedClientId, requestObject.getClientMetadata().getClientId());
+
+        // Assert: Request object must not advertise symmetric signing algs
+        var dcSdJwt = requestObject.getClientMetadata().getVpFormat().getDcSdJwt();
+        for (var algs : List.of(dcSdJwt.getSdJwtAlgValues(), dcSdJwt.getKbJwtAlgValues())) {
+            assertFalse(algs.stream().anyMatch(alg -> alg.startsWith("HS")));
+        }
     }
 
     @Test
@@ -223,16 +227,6 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
 
         // Proceed to authentication (Use 'dc-sd+jwt' in presentation submission descriptor)
         TestOpts opts = TestOpts.getDefault().setOverrideDescriptorFormat(Descriptor.Format.DC_SD_JWT);
-        testSuccessfulAuthentication(sdJwt, opts);
-    }
-
-    @Test
-    public void shouldAuthenticateSuccessfully_VpTokenMapToDCQL() throws Exception {
-        // Request a valid SD-JWT credential from Keycloak to use for authentication
-        String sdJwt = sdJwtVPTestUtils.requestSdJwtCredential(VCT_CONFIG_DEFAULT, TEST_USER);
-
-        // Proceed to authentication
-        TestOpts opts = TestOpts.getDefault().setShouldPrepareLegacyResponse(false);
         testSuccessfulAuthentication(sdJwt, opts);
     }
 

--- a/src/test/resources/realms/test-realm.json
+++ b/src/test/resources/realms/test-realm.json
@@ -81,7 +81,8 @@
       "config": {
         "vct": "https://credentials.example.com/identity_credential,https://example.com/vct-alt",
         "requireExpClaim": "true",
-        "enforceRevocationStatus": "true"
+        "enforceRevocationStatus": "true",
+        "queryLanguage": "dif_presentation_exchange"
       }
     }
   ],


### PR DESCRIPTION
Regarding metadata exposed in request object, this PR:
- Explicitly advertises supported encryption algorithms (`encrypted_response_enc_values_supported`). Confirmed by EphemeralKeyUtilsTest.
- Only advertises asymetric algorithms in vpFormat.
- Add configuration for exposing `presentation_definition` XOR newer `dcql_query`. Not both.
- Removes deprecated clientId field in clientMetadata.