### PR TITLE
Further clean up metadata exposed in request object

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/crypto/EphemeralKeyUtils.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/crypto/EphemeralKeyUtils.java
@@ -15,6 +15,7 @@ import org.keycloak.common.crypto.CryptoConstants;
 import org.keycloak.crypto.KeyType;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.jose.jwe.JWE;
+import org.keycloak.jose.jwe.JWEConstants;
 import org.keycloak.jose.jwe.JWEException;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKBuilder;
@@ -41,6 +42,7 @@ public class EphemeralKeyUtils {
 
             KeyPair kp = kpg.generateKeyPair();
             JWK pubJwk = JWKBuilder.create().ec(kp.getPublic(), KeyUse.ENC);
+            pubJwk.setAlgorithm(JWEConstants.ECDH_ES);
 
             return new EphemeralKey((ECPrivateKey) kp.getPrivate(), pubJwk);
         } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
@@ -8,6 +8,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusList
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.TrustedStatusListJwtFetcher;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import org.keycloak.Config;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.AuthenticatorFactory;
@@ -122,7 +123,7 @@ public class SdJwtAuthenticatorFactory implements AuthenticatorFactory, OID4VPEn
         property.setType(ProviderConfigProperty.LIST_TYPE);
         property.setDefaultValue(QUERY_LANGUAGE_CONFIG_DEFAULT);
         property.setOptions(
-                List.of(QueryLanguage.DCQL_QUERY.getValue(), QueryLanguage.DIF_PRESENTATION_EXCHANGE.getValue()));
+                Stream.of(QueryLanguage.values()).map(QueryLanguage::getValue).toList());
         property.setHelpText("Query language specification for encoding presentation requests.");
         configProperties.add(property);
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtCredentialConstrainer.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtCredentialConstrainer.java
@@ -3,6 +3,7 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPUserAuthEndpointFactory;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.CredentialSet;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.Constraints;
@@ -47,8 +48,12 @@ public class SdJwtCredentialConstrainer {
         credential.setMeta(meta);
         credential.setClaims(claims);
 
+        CredentialSet credentialSet = new CredentialSet();
+        credentialSet.setOptions(List.of(List.of(credential.getId())));
+
         DcqlQuery query = new DcqlQuery();
         query.setCredentials(List.of(credential));
+        query.setCredentialSets(List.of(credentialSet));
         return query;
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ClientMetadata.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/ClientMetadata.java
@@ -16,7 +16,7 @@ import org.keycloak.jose.jwk.JSONWebKeySet;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ClientMetadata {
 
-    @JsonProperty("vp_formats")
+    @JsonProperty("vp_formats_supported")
     private VpFormat vpFormat;
 
     @JsonProperty("jwks")

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/QueryLanguage.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/QueryLanguage.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum QueryLanguage {
     DCQL_QUERY("dcql_query"),
     DIF_PRESENTATION_EXCHANGE("dif_presentation_exchange"),
-    ;
+    ALL("all");
 
     private final String value;
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -241,10 +241,12 @@ public class AuthorizationRequestService {
                 .setVerifierInfo(verifierInfo);
 
         // Append presentation request
-        if (config.getQueryLanguage().equals(QueryLanguage.DIF_PRESENTATION_EXCHANGE)) {
+        QueryLanguage ql = config.getQueryLanguage();
+        if (ql.equals(QueryLanguage.ALL) || ql.equals(QueryLanguage.DIF_PRESENTATION_EXCHANGE)) {
             // Kept for backward compatibility with Draft 20 wallets
             requestObject.setPresentationDefinition(constrainer.generatePresentationDefinition(queryMap));
-        } else {
+        }
+        if (ql.equals(QueryLanguage.ALL) || ql.equals(QueryLanguage.DCQL_QUERY)) {
             requestObject.setDcqlQuery(constrainer.generateDcqlQuery(queryMap));
         }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -27,6 +27,7 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.naming.ldap.LdapName;
@@ -270,7 +271,7 @@ public class AuthorizationRequestService {
     private String signRequestObject(RequestObject requestObject, KeyWrapper signingKey, X509Certificate certificate) {
         logger.debug("Signing request object");
         Long expiration = Instant.now().plusSeconds(authSessionLifespanSecs).getEpochSecond();
-        requestObject.issuedNow().exp(expiration);
+        requestObject.issuedNow().exp(expiration).id(UUID.randomUUID().toString());
 
         // Derive signer context
         String algorithm = signingKey.getAlgorithmOrDefault();

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/VerifierDiscoveryService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/VerifierDiscoveryService.java
@@ -33,7 +33,7 @@ public class VerifierDiscoveryService {
 
     private static final Logger logger = Logger.getLogger(VerifierDiscoveryService.class);
 
-    public static final List<String> SUPPORTED_ENC_ALGS = List.of(JWEConstants.A128GCM);
+    public static final List<String> SUPPORTED_ENC_ALGS = List.of(JWEConstants.A256GCM);
 
     private final KeycloakSession session;
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/VerifierDiscoveryService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/VerifierDiscoveryService.java
@@ -11,7 +11,6 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import org.jboss.logging.Logger;
 import org.keycloak.crypto.Algorithm;
-import org.keycloak.crypto.CryptoUtils;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.jose.jwe.JWEConstants;
@@ -34,8 +33,7 @@ public class VerifierDiscoveryService {
 
     private static final Logger logger = Logger.getLogger(VerifierDiscoveryService.class);
 
-    public static final List<String> SUPPORTED_ENC_ALGS =
-            List.of(JWEConstants.A128GCM, JWEConstants.A192GCM, JWEConstants.A256GCM);
+    public static final List<String> SUPPORTED_ENC_ALGS = List.of(JWEConstants.A128GCM);
 
     private final KeycloakSession session;
 
@@ -136,6 +134,7 @@ public class VerifierDiscoveryService {
     }
 
     private List<String> getSupportedSignatureAlgorithms() {
-        return CryptoUtils.getSupportedAsymmetricSignatureAlgorithms(session);
+        // TODO: CryptoUtils.getSupportedAsymmetricSignatureAlgorithms(session);
+        return List.of(Algorithm.ES256);
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointHAIPTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointHAIPTest.java
@@ -34,6 +34,7 @@ import org.keycloak.OAuthErrorException;
 import org.keycloak.common.util.PemUtils;
 import org.keycloak.crypto.KeyType;
 import org.keycloak.crypto.KeyUse;
+import org.keycloak.jose.jwe.JWEConstants;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jws.JWSInput;
@@ -111,6 +112,7 @@ public class OID4VPUserAuthEndpointHAIPTest extends OID4VPBaseUserAuthEndpointTe
         assertNotNull(jwk.getKeyId(), "A key ID is mandatory");
         assertEquals(KeyType.EC, jwk.getKeyType());
         assertEquals(KeyUse.ENC.getSpecName(), jwk.getPublicKeyUse());
+        assertEquals(JWEConstants.ECDH_ES, jwk.getAlgorithm());
         assertNull(jwk.getOtherClaims().get(ECTestUtils.JWK_SECRET_D_FIELD));
 
         // Request object must explicitly advertise support encryption algs

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtCredentialConstrainerTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtCredentialConstrainerTest.java
@@ -46,6 +46,12 @@ public class SdJwtCredentialConstrainerTest {
                 .map(claim -> claim.getPath().getFirst())
                 .toList();
         assertEquals(map.requiredClaims(), paths);
+
+        // Assert credential sets
+        assertEquals(1, query.getCredentialSets().size());
+        var credentialSet = query.getCredentialSets().getFirst();
+        assertEquals(1, credentialSet.getOptions().size());
+        assertEquals(List.of(credential.getId()), credentialSet.getOptions().getFirst());
     }
 
     public static void assertPrexQuery(PresentationDefinition def, QueryMap map) {


### PR DESCRIPTION
- Add `credential_sets` to DCQL
- Add `ECDH_ES` to encryption keys
- Rename `vp_formats` to `vp_formats_supported`
- Restore ability to expose both DCQL and DIF presentation exchange requests
- Reduce the list of advertised signing and encryption algorithms (could be causing incompatibility issues)