### PR TITLE
Align client_id prefix handling with strict KB-JWT audience equality

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthRequirements.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthRequirements.java
@@ -131,12 +131,8 @@ public class SdJwtAuthRequirements {
     }
 
     private static ClaimCheck buildAudClaimCheck(String expectedKbJwtAud) {
-        // Some wallets prepend a scheme to the expected audience. We accept any such scheme.
-        String regex = String.format("([^:]+:)?%s", Pattern.quote(expectedKbJwtAud));
-        Pattern expectedPattern = Pattern.compile(regex);
-        return new ClaimCheck(JsonWebToken.AUD, expectedKbJwtAud, (expectedAud, aud) -> expectedPattern
-                .matcher(aud)
-                .matches());
+        // Final 1.0 requires using the full Client Identifier, including prefix, in proof bindings.
+        return new ClaimCheck(JsonWebToken.AUD, expectedKbJwtAud, String::equals);
     }
 
     private List<String> parseMultiStr(String str) {

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -567,6 +567,7 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
     public void shouldFailAuthentication_InvalidKbJwt_InvalidAud() throws Exception {
         var invalidAuds = List.of(
                 "invalid-aud",
+                getVerifierClientId(), // Missing required client_id prefix
                 ":" + getVerifierClientId(), // Missing scheme
                 "double:scheme:" + getVerifierClientId());
 


### PR DESCRIPTION
- Enforce strict equality for key-binding JWT `aud` validation against the expected verifier `client_id`.
- Remove permissive audience matching that allowed additional scheme/prefix variants.
- Keep client identifier handling aligned with full prefixed `client_id` semantics.

## Spec Alignment
- OpenID4VP Final 1.0, Client Identifier Prefix model (Section 5.9).
- OpenID4VP Final 1.0, Always use full Client Identifier (Section 14.8).
- Key-binding audience binding requirements (`aud` bound to verifier identifier, non-DC API flow).

closes https://github.com/ADORSYS-GIS/keycloak-oid4vp-plugin/issues/65