### PR TITLE
fix(oid4vp): enforce final request object JOSE/media type rules

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpoint.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpoint.java
@@ -59,6 +59,7 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
     public static final String RESPONSE_URI_PATH = "/response";
     public static final String AUTH_STATUS_PATH = "/status/{transactionId}";
     public static final String AUTH_CODE_PATH = "/code";
+    public static final String AUTH_REQ_JWT_MEDIA_TYPE = "application/oauth-authz-req+jwt";
 
     private final AuthorizationRequestService authorizationRequestService;
     private final AuthorizationResponseService authorizationResponseService;
@@ -120,12 +121,12 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
      */
     @GET
     @Path(REQUEST_JWT_PATH + "/{requestId}")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Produces(AUTH_REQ_JWT_MEDIA_TYPE)
     public Response getSignedRequestObject(@PathParam("requestId") String requestId) {
         logger.debug("Resolving request URI to signed request object...");
         AuthorizationContext authorizationContext = recoverAuthorizationContextByRequestId(requestId);
         String requestObjectJwt = authorizationContext.getRequestObjectJwt();
-        return CorsService.open().add(Response.ok(requestObjectJwt));
+        return CorsService.open().add(Response.ok(requestObjectJwt, AUTH_REQ_JWT_MEDIA_TYPE));
     }
 
     /**

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPBaseKeycloakTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPBaseKeycloakTest.java
@@ -100,6 +100,13 @@ public abstract class OID4VPBaseKeycloakTest extends BaseKeycloakTest {
      * A request is sent to the request_uri dereferencing endpoint to retrieve the request object.     *
      */
     protected String resolveSignedRequestObject(String authRequest) throws IOException {
+        HttpResponse response = resolveSignedRequestObjectResponse(authRequest);
+
+        // Parse and return the expected JWT response
+        return EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+    }
+
+    protected HttpResponse resolveSignedRequestObjectResponse(String authRequest) throws IOException {
         // Extract the request_uri parameter
         String requestUri = URLEncodedUtils.parse(authRequest, StandardCharsets.UTF_8).stream()
                 .filter(p -> p.getName().equals("request_uri"))
@@ -111,9 +118,7 @@ public abstract class OID4VPBaseKeycloakTest extends BaseKeycloakTest {
         HttpGet httpGet = new HttpGet(requestUri);
         HttpResponse response = httpClient.execute(httpGet);
         assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
-
-        // Parse and return the expected JWT response
-        return EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+        return response;
     }
 
     /**

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointHAIPTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointHAIPTest.java
@@ -3,6 +3,7 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactory.ACCESS_CERTIFICATE_CONFIG;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactory.REGISTRATION_CERTIFICATE_CONFIG;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactory.VCT_CONFIG_DEFAULT;
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.AuthorizationRequestService.AUTH_REQ_JWT;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.AuthorizationRequestService.REGISTRATION_CERT_FORMAT;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.VerifierDiscoveryService.SUPPORTED_ENC_ALGS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -64,6 +65,11 @@ public class OID4VPUserAuthEndpointHAIPTest extends OID4VPBaseUserAuthEndpointTe
         String signedReqJwt = resolveSignedRequestObject(authRequest);
         JWSInput jwsInput = new JWSInput(signedReqJwt);
         RequestObject requestObject = jwsInput.readJsonContent(RequestObject.class);
+        HttpResponse requestUriResponse = resolveSignedRequestObjectResponse(authRequest);
+        assertEquals(
+                OID4VPUserAuthEndpoint.AUTH_REQ_JWT_MEDIA_TYPE,
+                requestUriResponse.getEntity().getContentType().getValue());
+        assertEquals(AUTH_REQ_JWT, jwsInput.getHeader().getType());
 
         // Must use configured custom URL scheme
         URI authRequestUri = new URI(authRequest);

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -4,6 +4,7 @@ import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPUserAut
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPUserAuthEndpointBase.pruneAuthSessionId;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactory.VCT_CONFIG_DEFAULT;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtCredentialConstrainer.QueryMap;
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.AuthorizationRequestService.AUTH_REQ_JWT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -12,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtCredentialConstrainerTest;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientIdScheme;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContextStatus;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.ProcessingError;
@@ -76,6 +78,12 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
 
         // Resolve the request_uri parameter from the authorization request
         RequestObject requestObject = resolveRequestObject(authRequest);
+        String signedReqJwt = resolveSignedRequestObject(authRequest);
+        JWSInput jwsInput = new JWSInput(signedReqJwt);
+        HttpResponse requestUriResponse = resolveSignedRequestObjectResponse(authRequest);
+        assertEquals(
+                OID4VPUserAuthEndpoint.AUTH_REQ_JWT_MEDIA_TYPE,
+                requestUriResponse.getEntity().getContentType().getValue());
 
         // Assert: Ensure authentication sessions match
         String expectedSessionId = pruneAuthSessionId(authContext.getTransactionId());
@@ -94,6 +102,8 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
         String schemedClientId = "x509_san_dns:" + getVerifierClientId();
         assertEquals(schemedClientId, requestObject.getIssuer());
         assertEquals(schemedClientId, requestObject.getClientId());
+        assertEquals(ResponseMode.DIRECT_POST, requestObject.getResponseMode());
+        assertEquals(AUTH_REQ_JWT, jwsInput.getHeader().getType());
 
         // Assert: Request object must not advertise symmetric signing algs
         var dcSdJwt = requestObject.getClientMetadata().getVpFormat().getDcSdJwt();


### PR DESCRIPTION
- set Request URI dereference response content type to `application/oauth-authz-req+jwt` as required by Final 1.0
- keep Request Object JOSE `typ` as `oauth-authz-req+jwt` and add explicit test assertions
- ensure `response_mode` is always present in request objects and assert this in tests
- verify request object serialization consistency for wallets (`iss` and `client_id` alignment) with explicit coverage

## Spec alignment
- Final 1.0 §5 Authorization Request:
  - Request Object JOSE `typ` must be `oauth-authz-req+jwt`
  - `client_id` required; `iss` compatibility handling
  - `response_mode` required
- Final 1.0 §5.10.1 Request URI Response:
  - `Content-Type: application/oauth-authz-req+jwt`

closes https://github.com/ADORSYS-GIS/keycloak-oid4vp-plugin/issues/75