### PR TITLE
feat(oid4vp): SD-JWT presentation validator 

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthRequirements.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthRequirements.java
@@ -4,6 +4,8 @@ import static org.keycloak.OID4VCConstants.CLAIM_NAME_ISSUER;
 import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
 import static org.keycloak.sdjwt.ClaimVerifier.ClaimCheck;
 
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -101,6 +103,31 @@ public class SdJwtAuthRequirements {
             requirements.addClaimRequirement(CLAIM_NAME_ISSUER, Pattern.quote("\"%s\"".formatted(keycloakIssuerURI)));
         }
         return requirements.build();
+    }
+
+    public boolean isVerifyIssuerClaim() {
+        return verifyIssuerClaim;
+    }
+
+    public String getIssuerPattern() {
+        return Pattern.quote("\"%s\"".formatted(keycloakIssuerURI));
+    }
+
+    /**
+     * Regex pattern for {@code vct} as required by the DCQL credential query (OpenID4VP §8.6).
+     */
+    public String getVctPatternForCredential(Credential credentialQuery) {
+        String vctPattern = vctPatternFromMeta(credentialQuery.getMeta());
+        return vctPattern != null ? vctPattern : expectedVctsPattern;
+    }
+
+    private String vctPatternFromMeta(Meta meta) {
+        if (meta == null || meta.getVctValues() == null || meta.getVctValues().isEmpty()) {
+            return null;
+        }
+        return meta.getVctValues().stream()
+                .map(vct -> Pattern.quote("\"" + vct + "\""))
+                .collect(Collectors.joining("|", "(", ")"));
     }
 
     public SdJwtCredentialConstrainer.QueryMap getSdJwtQueryMap() {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorConfigResolver.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorConfigResolver.java
@@ -1,0 +1,31 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPUserAuthEndpointBase;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+
+/**
+ * Resolves SD-JWT authenticator configuration from the OpenID4VP authentication flow.
+ */
+public final class SdJwtAuthenticatorConfigResolver {
+
+    private SdJwtAuthenticatorConfigResolver() {}
+
+    public static AuthenticatorConfigModel resolve(KeycloakSession session) {
+        RealmModel realm = session.getContext().getRealm();
+        var flow = realm.getFlowByAlias(OID4VPUserAuthEndpointBase.OID4VP_AUTH_FLOW);
+        if (flow == null) {
+            throw new IllegalStateException(String.format(
+                    "Authentication flow '%s' not found. Such is supposed to be built-in",
+                    OID4VPUserAuthEndpointBase.OID4VP_AUTH_FLOW));
+        }
+        return realm.getAuthenticationExecutionsStream(flow.getId())
+                .filter(execution -> execution.getAuthenticator().equals(SdJwtAuthenticatorFactory.PROVIDER_ID))
+                .findFirst()
+                .map(AuthenticationExecutionModel::getAuthenticatorConfig)
+                .map(realm::getAuthenticatorConfigById)
+                .orElse(new AuthenticatorConfigModel());
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactories.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactories.java
@@ -1,0 +1,26 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.KeycloakSession;
+
+/**
+ * Access to the registered {@link SdJwtAuthenticatorFactory} for a session.
+ */
+public final class SdJwtAuthenticatorFactories {
+
+    private SdJwtAuthenticatorFactories() {}
+
+    public static SdJwtAuthenticatorFactory getFactory(KeycloakSession session) {
+        var providerFactory = session.getKeycloakSessionFactory()
+                .getProviderFactory(Authenticator.class, SdJwtAuthenticatorFactory.PROVIDER_ID);
+        if (providerFactory instanceof SdJwtAuthenticatorFactory sdJwtAuthenticatorFactory) {
+            return sdJwtAuthenticatorFactory;
+        }
+        return new SdJwtAuthenticatorFactory();
+    }
+
+    public static StatusListJwtFetcher createStatusListJwtFetcher(KeycloakSession session) {
+        return getFactory(session).createStatusListJwtFetcher(session);
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
@@ -173,6 +173,13 @@ public class SdJwtAuthenticatorFactory implements AuthenticatorFactory, OID4VPEn
         return PROVIDER_ID;
     }
 
+    /**
+     * Creates the status list fetcher used for revocation checks during presentation validation.
+     */
+    public StatusListJwtFetcher createStatusListJwtFetcher(KeycloakSession session) {
+        return new TrustedStatusListJwtFetcher(session);
+    }
+
     @Override
     public Authenticator create(KeycloakSession session) {
         StatusListJwtFetcher httpFetcher = new TrustedStatusListJwtFetcher(session);

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SelfTrustedSdJwtIssuer.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SelfTrustedSdJwtIssuer.java
@@ -27,7 +27,11 @@ public class SelfTrustedSdJwtIssuer implements TrustedSdJwtIssuer {
     private final KeycloakSession session;
 
     public SelfTrustedSdJwtIssuer(AuthenticationFlowContext context) {
-        this.session = context.getSession();
+        this(context.getSession());
+    }
+
+    public SelfTrustedSdJwtIssuer(KeycloakSession session) {
+        this.session = session;
     }
 
     @Override

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Claim.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Claim.java
@@ -12,7 +12,7 @@ public class Claim {
     private List<String> path;
 
     @JsonProperty("values")
-    private List<String> values;
+    private List<Object> values;
 
     public String getId() {
         return id;
@@ -30,11 +30,11 @@ public class Claim {
         this.path = path;
     }
 
-    public List<String> getValues() {
+    public List<Object> getValues() {
         return values;
     }
 
-    public void setValues(List<String> values) {
+    public void setValues(List<Object> values) {
         this.values = values;
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Credential.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Credential.java
@@ -20,6 +20,12 @@ public class Credential {
     @JsonProperty("claim_sets")
     private List<List<String>> claimSets;
 
+    @JsonProperty("multiple")
+    private Boolean multiple;
+
+    @JsonProperty("require_cryptographic_holder_binding")
+    private Boolean requireCryptographicHolderBinding;
+
     public String getId() {
         return id;
     }
@@ -58,5 +64,29 @@ public class Credential {
 
     public void setClaimSets(List<List<String>> claimSets) {
         this.claimSets = claimSets;
+    }
+
+    public Boolean getMultiple() {
+        return multiple;
+    }
+
+    public void setMultiple(Boolean multiple) {
+        this.multiple = multiple;
+    }
+
+    public Boolean getRequireCryptographicHolderBinding() {
+        return requireCryptographicHolderBinding;
+    }
+
+    public void setRequireCryptographicHolderBinding(Boolean requireCryptographicHolderBinding) {
+        this.requireCryptographicHolderBinding = requireCryptographicHolderBinding;
+    }
+
+    public boolean allowsMultiplePresentations() {
+        return Boolean.TRUE.equals(multiple);
+    }
+
+    public boolean requiresCryptographicHolderBinding() {
+        return requireCryptographicHolderBinding == null || requireCryptographicHolderBinding;
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/ClaimsPathProcessor.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/ClaimsPathProcessor.java
@@ -1,0 +1,127 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Applies DCQL claims path pointers to JSON-based credentials (OpenID4VP §7.1).
+ */
+public final class ClaimsPathProcessor {
+
+    private ClaimsPathProcessor() {}
+
+    /**
+     * @return selected claim values; empty when the path does not resolve
+     */
+    public static List<JsonNode> process(JsonNode root, List<Object> path) throws VpTokenValidationException {
+        if (root == null || path == null || path.isEmpty()) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL, "Claims path pointer must be a non-empty array");
+        }
+
+        List<JsonNode> selected = List.of(root);
+        for (Object component : path) {
+            selected = processComponent(selected, component);
+            if (selected.isEmpty()) {
+                return List.of();
+            }
+        }
+        return selected;
+    }
+
+    private static List<JsonNode> processComponent(List<JsonNode> current, Object component)
+            throws VpTokenValidationException {
+        if (component instanceof String key) {
+            return selectObjectKey(current, key);
+        }
+        if (component == null) {
+            return selectAllArrayElements(current);
+        }
+        if (component instanceof Integer index) {
+            return selectArrayIndex(current, index);
+        }
+        if (component instanceof Number number) {
+            if (number.doubleValue() != Math.floor(number.doubleValue()) || number.longValue() < 0) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.DCQL, "Claims path index must be a non-negative integer");
+            }
+            return selectArrayIndex(current, number.intValue());
+        }
+        throw new VpTokenValidationException(
+                VpTokenValidationException.Phase.DCQL, "Unsupported claims path pointer component: " + component);
+    }
+
+    private static List<JsonNode> selectObjectKey(List<JsonNode> current, String key) {
+        List<JsonNode> next = new ArrayList<>();
+        for (JsonNode node : current) {
+            if (!node.isObject()) {
+                continue;
+            }
+            JsonNode child = node.get(key);
+            if (child != null) {
+                next.add(child);
+            }
+        }
+        return next;
+    }
+
+    private static List<JsonNode> selectAllArrayElements(List<JsonNode> current) throws VpTokenValidationException {
+        List<JsonNode> next = new ArrayList<>();
+        for (JsonNode node : current) {
+            if (!node.isArray()) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.DCQL,
+                        "Claims path pointer expected an array at the current selection");
+            }
+            ArrayNode arrayNode = (ArrayNode) node;
+            arrayNode.forEach(next::add);
+        }
+        return next;
+    }
+
+    private static List<JsonNode> selectArrayIndex(List<JsonNode> current, int index)
+            throws VpTokenValidationException {
+        List<JsonNode> next = new ArrayList<>();
+        for (JsonNode node : current) {
+            if (!node.isArray()) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.DCQL,
+                        "Claims path pointer expected an array at the current selection");
+            }
+            ArrayNode arrayNode = (ArrayNode) node;
+            if (index >= 0 && index < arrayNode.size()) {
+                next.add(arrayNode.get(index));
+            }
+        }
+        return next;
+    }
+
+    /**
+     * Adapts a DCQL {@code path} from {@link io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim}
+     * to the mixed components expected by {@link #process}.
+     *
+     * <p>Today {@code Claim.path} is {@code List<String>} because our DCQL schemas only use object-key
+     * segments. OpenID4VP §7.1 also allows integers (array indices) and {@code null} (all array elements),
+     * e.g. {@code ["address", null, "street_address"]}. {@link #process} already supports those types.
+     *
+     * <p>If {@code Claim.path} is widened to deserialize mixed JSON array elements, update this mapper to
+     * translate numeric indices and {@code null} entries—not only {@link List#copyOf} of strings.
+     */
+    public static List<Object> toPathComponents(List<String> path) {
+        return List.copyOf(path);
+    }
+
+    /**
+     * Merges issuer-signed payload with selectively disclosed claims for path resolution.
+     */
+    public static ObjectNode credentialClaimsRoot(JsonNode issuerSignedPayload, JsonNode disclosedClaims) {
+        ObjectNode root = issuerSignedPayload.deepCopy();
+        if (disclosedClaims != null && disclosedClaims.isObject()) {
+            disclosedClaims.properties().forEach(entry -> root.set(entry.getKey(), entry.getValue()));
+        }
+        return root;
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlClaimValues.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlClaimValues.java
@@ -1,0 +1,56 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+/**
+ * Compares presented claim values against DCQL {@code values} constraints (§6.3, §6.4.1).
+ *
+ * <p>Matching is strict by JSON value type: a string constraint such as {@code "true"} only matches
+ * a textual claim, not a boolean {@code true}; a string {@code "42"} only matches text, not numeric
+ * {@code 42}. Use boolean/number entries in {@code values} when those types are intended.
+ */
+final class DcqlClaimValues {
+
+    private DcqlClaimValues() {}
+
+    static boolean matchesAny(List<JsonNode> resolved, List<Object> expectedValues) {
+        if (expectedValues == null || expectedValues.isEmpty()) {
+            return true;
+        }
+        for (JsonNode actual : resolved) {
+            for (Object expected : expectedValues) {
+                if (equals(actual, expected)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean equals(JsonNode actual, Object expected) {
+        if (actual == null || expected == null) {
+            return false;
+        }
+        if (expected instanceof String expectedString) {
+            return equalsString(actual, expectedString);
+        }
+        if (expected instanceof Boolean expectedBoolean) {
+            return actual.isBoolean() && actual.asBoolean() == expectedBoolean;
+        }
+        if (expected instanceof Integer expectedInteger) {
+            return actual.isIntegralNumber() && actual.asInt() == expectedInteger;
+        }
+        if (expected instanceof Long expectedLong) {
+            return actual.isIntegralNumber() && actual.asLong() == expectedLong;
+        }
+        if (expected instanceof Number expectedNumber) {
+            return actual.isNumber() && actual.asDouble() == expectedNumber.doubleValue();
+        }
+        return expected.toString().equals(actual.isValueNode() ? actual.asText() : actual.toString());
+    }
+
+    private static boolean equalsString(JsonNode actual, String expected) {
+        return actual.isTextual() && expected.equals(actual.asText());
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlQueryRules.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlQueryRules.java
@@ -1,0 +1,113 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.CredentialSet;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Shared DCQL selection rules (OpenID4VP §6.4.2, §8.1).
+ */
+final class DcqlQueryRules {
+
+    private DcqlQueryRules() {}
+
+    static boolean usesCredentialSets(DcqlQuery dcqlQuery) {
+        return dcqlQuery.getCredentialSets() != null
+                && !dcqlQuery.getCredentialSets().isEmpty();
+    }
+
+    static Set<String> credentialQueryIds(DcqlQuery dcqlQuery) {
+        return dcqlQuery.getCredentials().stream()
+                .map(credential -> credential.getId())
+                .collect(Collectors.toSet());
+    }
+
+    static void requireAllCredentialQueriesPresent(
+            Map<String, ?> presentedById, DcqlQuery dcqlQuery, VpTokenValidationException.Phase phase)
+            throws VpTokenValidationException {
+        for (String credentialId : credentialQueryIds(dcqlQuery)) {
+            if (!presentedById.containsKey(credentialId)) {
+                throw new VpTokenValidationException(
+                        phase, "Presented vp_token map does not match DCQL credential query");
+            }
+        }
+    }
+
+    static void validateRequiredCredentialSets(
+            Map<String, ?> presentedById, DcqlQuery dcqlQuery, VpTokenValidationException.Phase phase)
+            throws VpTokenValidationException {
+        if (!usesCredentialSets(dcqlQuery)) {
+            return;
+        }
+
+        for (CredentialSet credentialSet : dcqlQuery.getCredentialSets()) {
+            boolean required = credentialSet.getRequired() == null || credentialSet.getRequired();
+            if (!required) {
+                continue;
+            }
+            if (credentialSet.getOptions() == null || credentialSet.getOptions().isEmpty()) {
+                throw new VpTokenValidationException(phase, "DCQL credential_sets entry is missing options");
+            }
+            if (!satisfiesAnyCredentialSetOption(presentedById, credentialSet.getOptions())) {
+                throw new VpTokenValidationException(
+                        phase, "Returned presentations do not satisfy required DCQL credential_sets constraints");
+            }
+        }
+    }
+
+    /**
+     * When {@code credential_sets} is used, every returned credential id must belong to a satisfied
+     * credential set option (§8.1 — no entries for non-matching optional queries).
+     */
+    static void validatePresentedCredentialsWithinCredentialSets(
+            Map<String, ?> presentedById, DcqlQuery dcqlQuery, VpTokenValidationException.Phase phase)
+            throws VpTokenValidationException {
+        if (!usesCredentialSets(dcqlQuery)) {
+            return;
+        }
+
+        Set<String> permittedIds = permittedCredentialIds(presentedById, dcqlQuery);
+        for (String presentedId : presentedById.keySet()) {
+            if (!permittedIds.contains(presentedId)) {
+                throw new VpTokenValidationException(
+                        phase,
+                        "vp_token contains credential query id outside satisfied DCQL credential_sets: " + presentedId);
+            }
+        }
+    }
+
+    private static Set<String> permittedCredentialIds(Map<String, ?> presentedById, DcqlQuery dcqlQuery) {
+        Set<String> permitted = new HashSet<>();
+        for (CredentialSet credentialSet : dcqlQuery.getCredentialSets()) {
+            List<List<String>> options = credentialSet.getOptions();
+            if (options == null) {
+                continue;
+            }
+            for (List<String> option : options) {
+                if (option == null || option.isEmpty()) {
+                    continue;
+                }
+                if (presentedById.keySet().containsAll(option)) {
+                    permitted.addAll(option);
+                }
+            }
+        }
+        return permitted;
+    }
+
+    private static boolean satisfiesAnyCredentialSetOption(Map<String, ?> presentedById, List<List<String>> options) {
+        for (List<String> option : options) {
+            if (option == null || option.isEmpty()) {
+                continue;
+            }
+            if (presentedById.keySet().containsAll(option)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlSatisfactionValidator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlSatisfactionValidator.java
@@ -1,0 +1,161 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.keycloak.VCFormat;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+
+/**
+ * Verifies that validated presentations satisfy the issued DCQL query (OpenID4VP §6.4, §8.6).
+ *
+ * <p>The wallet may have enforced DCQL already; the verifier MUST NOT rely on that.
+ */
+public class DcqlSatisfactionValidator {
+
+    public void validate(List<PresentedCredential> presentations, DcqlQuery dcqlQuery)
+            throws VpTokenValidationException {
+        Map<String, PresentedCredential> presentedById = new HashMap<>();
+        for (PresentedCredential presented : presentations) {
+            presentedById.put(presented.credentialQueryId(), presented);
+        }
+
+        if (!DcqlQueryRules.usesCredentialSets(dcqlQuery)) {
+            DcqlQueryRules.requireAllCredentialQueriesPresent(
+                    presentedById, dcqlQuery, VpTokenValidationException.Phase.DCQL);
+        } else {
+            DcqlQueryRules.validateRequiredCredentialSets(
+                    presentedById, dcqlQuery, VpTokenValidationException.Phase.DCQL);
+            DcqlQueryRules.validatePresentedCredentialsWithinCredentialSets(
+                    presentedById, dcqlQuery, VpTokenValidationException.Phase.DCQL);
+        }
+
+        for (PresentedCredential presented : presentations) {
+            validateCredentialQuery(presented.presentation(), presented.credentialQuery());
+        }
+    }
+
+    private void validateCredentialQuery(SdJwtVP presentation, Credential credentialQuery)
+            throws VpTokenValidationException {
+        validateFormat(credentialQuery);
+        validateMeta(presentation, credentialQuery.getMeta());
+        validateClaims(presentation, credentialQuery);
+    }
+
+    private void validateFormat(Credential credentialQuery) throws VpTokenValidationException {
+        String expectedFormat = credentialQuery.getFormat();
+        if (expectedFormat == null || expectedFormat.isBlank()) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL, "DCQL credential query is missing format");
+        }
+        if (!VCFormat.SD_JWT_VC.equals(expectedFormat) && !"dc+sd-jwt".equals(expectedFormat)) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL,
+                    "Unsupported credential format in DCQL query: " + expectedFormat);
+        }
+    }
+
+    private void validateMeta(SdJwtVP presentation, Meta meta) throws VpTokenValidationException {
+        if (meta == null || meta.getVctValues() == null || meta.getVctValues().isEmpty()) {
+            return;
+        }
+
+        String presentedVct = readScalarClaim(presentation, CLAIM_NAME_VCT);
+        if (presentedVct == null) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL, "Presentation is missing required vct claim");
+        }
+        if (!meta.getVctValues().contains(presentedVct)) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL,
+                    "Presentation vct does not match any value requested in DCQL meta.vct_values");
+        }
+    }
+
+    private void validateClaims(SdJwtVP presentation, Credential credentialQuery) throws VpTokenValidationException {
+        List<Claim> claims = credentialQuery.getClaims();
+        if (claims == null || claims.isEmpty()) {
+            return;
+        }
+
+        if (credentialQuery.getClaimSets() != null
+                && !credentialQuery.getClaimSets().isEmpty()) {
+            validateClaimSets(presentation, credentialQuery, claims);
+            return;
+        }
+
+        for (Claim claimQuery : claims) {
+            requireClaimPath(presentation, claimQuery);
+        }
+    }
+
+    private void validateClaimSets(SdJwtVP presentation, Credential credentialQuery, List<Claim> claims)
+            throws VpTokenValidationException {
+        Map<String, Claim> claimsById = new HashMap<>();
+        for (Claim claim : claims) {
+            if (claim.getId() == null || claim.getId().isBlank()) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.DCQL, "DCQL claim id is required when claim_sets are present");
+            }
+            claimsById.put(claim.getId(), claim);
+        }
+
+        for (List<String> option : credentialQuery.getClaimSets()) {
+            if (satisfiesClaimSetOption(presentation, claimsById, option)) {
+                return;
+            }
+        }
+
+        throw new VpTokenValidationException(
+                VpTokenValidationException.Phase.DCQL,
+                "Presentation does not satisfy any requested DCQL claim_sets option");
+    }
+
+    private boolean satisfiesClaimSetOption(SdJwtVP presentation, Map<String, Claim> claimsById, List<String> option)
+            throws VpTokenValidationException {
+        for (String claimId : option) {
+            Claim claimQuery = claimsById.get(claimId);
+            if (claimQuery == null) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.DCQL,
+                        "DCQL claim_sets references unknown claim id: " + claimId);
+            }
+            if (!hasClaimPath(presentation, claimQuery)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void requireClaimPath(SdJwtVP presentation, Claim claimQuery) throws VpTokenValidationException {
+        if (!hasClaimPath(presentation, claimQuery)) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL,
+                    "Presentation does not contain claim required by DCQL path: " + claimQuery.getPath());
+        }
+    }
+
+    private boolean hasClaimPath(SdJwtVP presentation, Claim claimQuery) throws VpTokenValidationException {
+        List<JsonNode> resolved = SdJwtClaimReader.resolveClaimPath(presentation, claimQuery.getPath());
+        if (resolved.isEmpty()) {
+            return false;
+        }
+        return DcqlClaimValues.matchesAny(resolved, claimQuery.getValues());
+    }
+
+    private String readScalarClaim(SdJwtVP presentation, String claimName) throws VpTokenValidationException {
+        List<JsonNode> resolved = SdJwtClaimReader.resolveClaimPath(presentation, List.of(claimName));
+        if (resolved.isEmpty()) {
+            return null;
+        }
+        JsonNode value = resolved.getFirst();
+        return value.isValueNode() ? value.asText() : value.toString();
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/HolderBindingAudienceResolver.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/HolderBindingAudienceResolver.java
@@ -1,0 +1,53 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import java.net.URI;
+import org.keycloak.utils.StringUtil;
+
+/**
+ * Resolves the holder-binding audience for replay protection (OpenID4VP §14.1, §14.8, Appendix A.4).
+ *
+ * <p>Uses the full {@code client_id} (including any Client Identifier Prefix). For Digital
+ * Credentials API flows the audience is {@code origin:}<i>origin</i> and may already be reflected
+ * in {@code client_id}.
+ */
+public final class HolderBindingAudienceResolver {
+
+    private HolderBindingAudienceResolver() {}
+
+    public static String resolve(RequestObject requestObject) {
+        String clientId = requestObject.getClientId();
+        if (!StringUtil.isBlank(clientId)) {
+            if (clientId.startsWith("origin:")) {
+                return clientId;
+            }
+            return clientId;
+        }
+
+        String originAudience = originAudienceFromResponseUri(requestObject.getResponseUri());
+        if (originAudience != null) {
+            return originAudience;
+        }
+
+        return clientId;
+    }
+
+    private static String originAudienceFromResponseUri(String responseUri) {
+        if (StringUtil.isBlank(responseUri)) {
+            return null;
+        }
+        try {
+            URI uri = URI.create(responseUri);
+            if (uri.getScheme() == null || uri.getHost() == null) {
+                return null;
+            }
+            int port = uri.getPort();
+            String origin = port > 0
+                    ? String.format("%s://%s:%d", uri.getScheme(), uri.getHost(), port)
+                    : String.format("%s://%s", uri.getScheme(), uri.getHost());
+            return "origin:" + origin;
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/PresentationFormatValidator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/PresentationFormatValidator.java
@@ -1,0 +1,19 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+
+/**
+ * Format-specific verifier checks for one DCQL credential query (OpenID4VP §8.6 step 1–5).
+ */
+public interface PresentationFormatValidator {
+
+    boolean supports(Credential credentialQuery);
+
+    ValidatedPresentation validate(
+            String encodedPresentation, Credential credentialQuery, VpTokenValidationContext context)
+            throws VpTokenValidationException;
+
+    /** Normalized presentation encoding and parsed form. */
+    record ValidatedPresentation(String presentationString, SdJwtVP presentation) {}
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/PresentationFormatValidators.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/PresentationFormatValidators.java
@@ -1,0 +1,25 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import java.util.List;
+
+/**
+ * Resolves the format validator for a DCQL credential query.
+ */
+final class PresentationFormatValidators {
+
+    private final List<PresentationFormatValidator> validators;
+
+    PresentationFormatValidators(List<PresentationFormatValidator> validators) {
+        this.validators = List.copyOf(validators);
+    }
+
+    PresentationFormatValidator requireValidatorFor(Credential credentialQuery) throws VpTokenValidationException {
+        return validators.stream()
+                .filter(validator -> validator.supports(credentialQuery))
+                .findFirst()
+                .orElseThrow(() -> new VpTokenValidationException(
+                        VpTokenValidationException.Phase.FORMAT,
+                        "Unsupported credential format: " + credentialQuery.getFormat()));
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/PresentedCredential.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/PresentedCredential.java
@@ -1,0 +1,10 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+
+/**
+ * A presentation bound to its DCQL credential query after format validation.
+ */
+public record PresentedCredential(
+        String credentialQueryId, Credential credentialQuery, String encodedPresentation, SdJwtVP presentation) {}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtClaimReader.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtClaimReader.java
@@ -1,0 +1,54 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.keycloak.common.VerificationException;
+import org.keycloak.sdjwt.SdJwtUtils;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+
+/**
+ * Reads claim values from an SD-JWT presentation for DCQL satisfaction checks.
+ */
+public final class SdJwtClaimReader {
+
+    private SdJwtClaimReader() {}
+
+    public static ObjectNode disclosedClaimsRoot(SdJwtVP sdJwt) throws VerificationException {
+        Map<String, JsonNode> claims = new LinkedHashMap<>();
+        for (String disclosure : sdJwt.getDisclosuresString()) {
+            ArrayNode arrayNode = SdJwtUtils.decodeDisclosureString(disclosure);
+            if (arrayNode.size() == 3) {
+                claims.put(arrayNode.get(1).asText(), arrayNode.get(2));
+            }
+        }
+        ObjectNode root = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+        claims.forEach(root::set);
+        return root;
+    }
+
+    public static List<JsonNode> resolveClaimPath(JsonNode claimsRoot, List<String> path)
+            throws VpTokenValidationException {
+        if (path == null || path.isEmpty()) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL, "DCQL claim query is missing path");
+        }
+        return ClaimsPathProcessor.process(claimsRoot, ClaimsPathProcessor.toPathComponents(path));
+    }
+
+    public static List<JsonNode> resolveClaimPath(SdJwtVP sdJwt, List<String> path) throws VpTokenValidationException {
+        try {
+            JsonNode issuerPayload = sdJwt.getIssuerSignedJWT().getPayload();
+            ObjectNode root = ClaimsPathProcessor.credentialClaimsRoot(issuerPayload, disclosedClaimsRoot(sdJwt));
+            return resolveClaimPath(root, path);
+        } catch (VerificationException e) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL,
+                    "Failed to read disclosed claims from SD-JWT presentation",
+                    e);
+        }
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtPresentationRequirements.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtPresentationRequirements.java
@@ -1,0 +1,91 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_ISSUER;
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.keycloak.common.VerificationException;
+import org.keycloak.sdjwt.consumer.PresentationRequirements;
+
+/**
+ * Presentation requirements for SD-JWT format validation (OpenID4VP §8.6) using the same
+ * DCQL §7.1 path resolution as {@link DcqlSatisfactionValidator}.
+ */
+public final class SdJwtPresentationRequirements implements PresentationRequirements {
+
+    private static final Pattern ANY_VALUE = Pattern.compile(".*");
+
+    private final List<List<String>> requiredPaths;
+    private final Pattern vctPattern;
+    private final Pattern issPattern;
+
+    private SdJwtPresentationRequirements(List<List<String>> requiredPaths, Pattern vctPattern, Pattern issPattern) {
+        this.requiredPaths = List.copyOf(requiredPaths);
+        this.vctPattern = vctPattern;
+        this.issPattern = issPattern;
+    }
+
+    public static PresentationRequirements forCredential(
+            SdJwtAuthRequirements authRequirements, Credential credentialQuery) {
+        List<List<String>> paths = new ArrayList<>();
+        authRequirements.getRequiredClaims().stream().map(List::of).forEach(paths::add);
+
+        if (credentialQuery.getClaims() != null) {
+            for (Claim claim : credentialQuery.getClaims()) {
+                if (claim.getPath() != null && !claim.getPath().isEmpty()) {
+                    paths.add(List.copyOf(claim.getPath()));
+                }
+            }
+        }
+
+        Pattern vctPattern = Pattern.compile(authRequirements.getVctPatternForCredential(credentialQuery));
+        Pattern issPattern =
+                authRequirements.isVerifyIssuerClaim() ? Pattern.compile(authRequirements.getIssuerPattern()) : null;
+
+        return new SdJwtPresentationRequirements(paths, vctPattern, issPattern);
+    }
+
+    @Override
+    public void checkIfSatisfiedBy(JsonNode claimsRoot) throws VerificationException {
+        for (List<String> path : requiredPaths) {
+            requireClaimMatches(claimsRoot, path, ANY_VALUE);
+        }
+        requireClaimMatches(claimsRoot, List.of(CLAIM_NAME_VCT), vctPattern);
+        if (issPattern != null) {
+            requireClaimMatches(claimsRoot, List.of(CLAIM_NAME_ISSUER), issPattern);
+        }
+    }
+
+    private static void requireClaimMatches(JsonNode claimsRoot, List<String> path, Pattern pattern)
+            throws VerificationException {
+        List<JsonNode> resolved;
+        try {
+            resolved = SdJwtClaimReader.resolveClaimPath(claimsRoot, path);
+        } catch (VpTokenValidationException e) {
+            throw new VerificationException(e.getMessage(), e);
+        }
+
+        if (resolved.isEmpty()) {
+            throw new VerificationException("A required field was not presented: `%s`".formatted(formatPath(path)));
+        }
+
+        for (JsonNode value : resolved) {
+            String presented = value.toString();
+            if (!pattern.matcher(presented).matches()) {
+                throw new VerificationException(String.format(
+                        "Pattern matching failed for required field: `%s`. Expected pattern: /%s/, but got: %s",
+                        formatPath(path), pattern.pattern(), presented));
+            }
+        }
+    }
+
+    private static String formatPath(List<String> path) {
+        return String.join(".", path);
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtPresentationValidator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtPresentationValidator.java
@@ -1,0 +1,105 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.ReferencedTokenValidationException;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SelfTrustedSdJwtIssuer;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
+import java.util.List;
+import org.keycloak.VCFormat;
+import org.keycloak.common.VerificationException;
+import org.keycloak.sdjwt.consumer.SdJwtPresentationConsumer;
+import org.keycloak.sdjwt.vp.KeyBindingJwtVerificationOpts;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+
+/**
+ * Format-specific validation for {@code dc+sd-jwt} presentations (OpenID4VP §8.6, Appendix B).
+ */
+public class SdJwtPresentationValidator implements PresentationFormatValidator {
+
+    private final SdJwtPresentationConsumer consumer;
+    private final ReferencedTokenValidator tokenStatusValidator;
+
+    public SdJwtPresentationValidator(StatusListJwtFetcher statusListJwtFetcher) {
+        this.consumer = new SdJwtPresentationConsumer();
+        this.tokenStatusValidator = new ReferencedTokenValidator(statusListJwtFetcher);
+    }
+
+    @Override
+    public boolean supports(Credential credentialQuery) {
+        String format = credentialQuery.getFormat();
+        return VCFormat.SD_JWT_VC.equals(format) || "dc+sd-jwt".equals(format);
+    }
+
+    @Override
+    public ValidatedPresentation validate(
+            String encodedPresentation, Credential credentialQuery, VpTokenValidationContext context)
+            throws VpTokenValidationException {
+        if (!supports(credentialQuery)) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.FORMAT,
+                    "Unsupported credential format: " + credentialQuery.getFormat());
+        }
+
+        final SdJwtVP presentation;
+        final String normalizedPresentation;
+        try {
+            normalizedPresentation = VpTokenPresentationDecoder.decodeIfBase64Url(encodedPresentation);
+            presentation = SdJwtVP.of(normalizedPresentation);
+        } catch (IllegalArgumentException e) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.STRUCTURE,
+                    "Could not parse SD-JWT VP token contained in `vp_token`",
+                    e);
+        }
+
+        SdJwtAuthRequirements authRequirements = context.authRequirements();
+        try {
+            KeyBindingJwtVerificationOpts kbJwtOpts =
+                    buildKeyBindingOptions(credentialQuery, authRequirements, context.nonce(), context.audience());
+
+            consumer.verifySdJwtPresentation(
+                    presentation,
+                    SdJwtPresentationRequirements.forCredential(authRequirements, credentialQuery),
+                    List.of(new SelfTrustedSdJwtIssuer(context.session())),
+                    authRequirements.getIssuerSignedJwtVerificationOpts(),
+                    kbJwtOpts);
+        } catch (VerificationException e) {
+            throw new VpTokenValidationException(VpTokenValidationException.Phase.FORMAT, e.getMessage(), e);
+        }
+
+        if (authRequirements.shouldEnforceRevocationStatus()) {
+            try {
+                tokenStatusValidator.validate(presentation.getIssuerSignedJWT().getPayload());
+            } catch (ReferencedTokenValidationException e) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.FORMAT, "Token status verification failed", e);
+            }
+        }
+
+        return new ValidatedPresentation(normalizedPresentation, presentation);
+    }
+
+    private static KeyBindingJwtVerificationOpts buildKeyBindingOptions(
+            Credential credentialQuery, SdJwtAuthRequirements authRequirements, String nonce, String audience)
+            throws VpTokenValidationException {
+        if (!credentialQuery.requiresCryptographicHolderBinding()) {
+            return KeyBindingJwtVerificationOpts.builder()
+                    .withKeyBindingRequired(false)
+                    .build();
+        }
+        if (nonce == null || nonce.isBlank()) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.FORMAT,
+                    "Authorization request nonce is required for cryptographic holder binding");
+        }
+        if (audience == null || audience.isBlank()) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.FORMAT,
+                    "Authorization request client_id is required for cryptographic holder binding");
+        }
+        return authRequirements.getKeyBindingJwtVerificationOpts(nonce, audience);
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenPresentationDecoder.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenPresentationDecoder.java
@@ -1,0 +1,67 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.keycloak.utils.StringUtil;
+
+/**
+ * Normalizes presentation encodings returned in a {@code vp_token}.
+ *
+ * <p>Wallets are expected to return the SD-JWT verifiable presentation in its on-the-wire compact form:
+ * an issuer-signed JWT, optional disclosures, and an optional key-binding JWT separated by {@code ~}
+ * (see SD-JWT / SD-JWT VC specs). That string already contains {@code .} segment separators and must
+ * not be base64url-decoded as a whole.
+ *
+ * <p>Some wallet implementations instead return the same compact presentation wrapped as a single
+ * base64url-encoded UTF-8 string (no {@code .} or {@code ~} in the wrapper). This decoder detects
+ * the compact SD-JWT/JWT shape first and only attempts base64url decoding when the value is not
+ * already a presentation.
+ */
+final class VpTokenPresentationDecoder {
+
+    private VpTokenPresentationDecoder() {}
+
+    /**
+     * Returns a compact SD-JWT presentation string, accepting either raw or base64url-wrapped input.
+     */
+    static String decodeIfBase64Url(String input) {
+        if (StringUtil.isBlank(input)) {
+            return input;
+        }
+
+        String trimmed = input.trim();
+        if (looksLikeSdJwtPresentation(trimmed)) {
+            return trimmed;
+        }
+
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(trimmed);
+            String decodedPresentation = new String(decoded, StandardCharsets.UTF_8);
+            if (looksLikeSdJwtPresentation(decodedPresentation)) {
+                return decodedPresentation;
+            }
+        } catch (IllegalArgumentException ignored) {
+            // Not a base64url wrapper; return the original value for downstream parse errors.
+        }
+
+        return trimmed;
+    }
+
+    /**
+     * Detects compact SD-JWT VP strings ({@code <JWT>~[<disclosures>~]<KB-JWT>}) and plain JWTs.
+     */
+    static boolean looksLikeSdJwtPresentation(String value) {
+        if (StringUtil.isBlank(value)) {
+            return false;
+        }
+        if (value.contains("~")) {
+            return looksLikeCompactJwt(value.substring(0, value.indexOf('~')));
+        }
+        return looksLikeCompactJwt(value);
+    }
+
+    private static boolean looksLikeCompactJwt(String value) {
+        String[] parts = value.split("\\.");
+        return parts.length >= 3 && !parts[0].isEmpty() && !parts[1].isEmpty() && !parts[2].isEmpty();
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationContext.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationContext.java
@@ -1,0 +1,15 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import org.keycloak.models.KeycloakSession;
+
+/**
+ * Inputs required to validate a returned {@code vp_token} for one authorization request.
+ */
+public record VpTokenValidationContext(
+        KeycloakSession session,
+        RequestObject requestObject,
+        SdJwtAuthRequirements authRequirements,
+        String nonce,
+        String audience) {}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationException.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationException.java
@@ -1,0 +1,29 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+/**
+ * Raised when a returned {@code vp_token} or contained presentation fails verifier-side validation.
+ */
+public class VpTokenValidationException extends Exception {
+
+    public enum Phase {
+        STRUCTURE,
+        FORMAT,
+        DCQL
+    }
+
+    private final Phase phase;
+
+    public VpTokenValidationException(Phase phase, String message) {
+        super(message);
+        this.phase = phase;
+    }
+
+    public VpTokenValidationException(Phase phase, String message, Throwable cause) {
+        super(message, cause);
+        this.phase = phase;
+    }
+
+    public Phase getPhase() {
+        return phase;
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/ClaimsPathProcessorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/ClaimsPathProcessorTest.java
@@ -1,0 +1,36 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ClaimsPathProcessorTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void selectsNestedClaim() throws Exception {
+        ObjectNode root = MAPPER.createObjectNode();
+        ObjectNode address = root.putObject("address");
+        address.put("street_address", "42 Market Street");
+
+        var selected = ClaimsPathProcessor.process(root, List.of("address", "street_address"));
+
+        assertEquals(1, selected.size());
+        assertEquals("42 Market Street", selected.getFirst().asText());
+    }
+
+    @Test
+    void returnsEmptyWhenPathMissing() throws Exception {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("name", "Arthur Dent");
+
+        var selected = ClaimsPathProcessor.process(root, List.of("address", "street_address"));
+
+        assertTrue(selected.isEmpty());
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlClaimValuesTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlClaimValuesTest.java
@@ -1,0 +1,42 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DcqlClaimValuesTest {
+
+    @Test
+    void matchesStringValue() {
+        List<JsonNode> resolved = List.of(JsonNodeFactory.instance.textNode("alice"));
+
+        assertTrue(DcqlClaimValues.matchesAny(resolved, List.of("alice")));
+        assertFalse(DcqlClaimValues.matchesAny(resolved, List.of("bob")));
+    }
+
+    @Test
+    void matchesBooleanValue() {
+        List<JsonNode> resolved = List.of(JsonNodeFactory.instance.booleanNode(true));
+
+        assertTrue(DcqlClaimValues.matchesAny(resolved, List.of(true)));
+        assertFalse(DcqlClaimValues.matchesAny(resolved, List.of(false)));
+    }
+
+    @Test
+    void matchesIntegerValue() {
+        List<JsonNode> resolved = List.of(JsonNodeFactory.instance.numberNode(42));
+
+        assertTrue(DcqlClaimValues.matchesAny(resolved, List.of(42)));
+        assertFalse(DcqlClaimValues.matchesAny(resolved, List.of(7)));
+    }
+
+    @Test
+    void doesNotCoerceStringConstraintToOtherJsonTypes() {
+        assertFalse(DcqlClaimValues.matchesAny(List.of(JsonNodeFactory.instance.booleanNode(true)), List.of("true")));
+        assertFalse(DcqlClaimValues.matchesAny(List.of(JsonNodeFactory.instance.numberNode(42)), List.of("42")));
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlSatisfactionValidatorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlSatisfactionValidatorTest.java
@@ -1,0 +1,90 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.keycloak.VCFormat;
+import org.keycloak.sdjwt.IssuerSignedJWT;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+
+class DcqlSatisfactionValidatorTest {
+
+    private final DcqlSatisfactionValidator validator = new DcqlSatisfactionValidator();
+
+    @Test
+    void rejectsClaimWhenValuesDoNotMatch() {
+        Credential credentialQuery = credentialWithClaim("username", List.of("alice"));
+        SdJwtVP presentation = mockPresentationWithClaim("username", "bob");
+
+        PresentedCredential presented = new PresentedCredential("cred-1", credentialQuery, "vp", presentation);
+
+        assertThrows(
+                VpTokenValidationException.class,
+                () -> validator.validate(List.of(presented), queryWithCredentials(credentialQuery)));
+    }
+
+    @Test
+    void acceptsClaimWhenValuesMatch() {
+        Credential credentialQuery = credentialWithClaim("username", List.of("alice"));
+        SdJwtVP presentation = mockPresentationWithClaim("username", "alice");
+
+        PresentedCredential presented = new PresentedCredential("cred-1", credentialQuery, "vp", presentation);
+
+        assertDoesNotThrow(() -> validator.validate(List.of(presented), queryWithCredentials(credentialQuery)));
+    }
+
+    @Test
+    void acceptsClaimWhenBooleanValuesMatch() {
+        Credential credentialQuery = credentialWithClaim("adult", List.of(true));
+        SdJwtVP presentation = mockPresentationWithClaim("adult", true);
+
+        PresentedCredential presented = new PresentedCredential("cred-1", credentialQuery, "vp", presentation);
+
+        assertDoesNotThrow(() -> validator.validate(List.of(presented), queryWithCredentials(credentialQuery)));
+    }
+
+    private static DcqlQuery queryWithCredentials(Credential credential) {
+        DcqlQuery query = new DcqlQuery();
+        query.setCredentials(List.of(credential));
+        return query;
+    }
+
+    private static Credential credentialWithClaim(String claimName, List<Object> values) {
+        Claim claim = new Claim();
+        claim.setPath(List.of(claimName));
+        claim.setValues(values);
+
+        Credential credential = new Credential();
+        credential.setId("cred-1");
+        credential.setFormat(VCFormat.SD_JWT_VC);
+        credential.setMeta(new Meta());
+        credential.getMeta().setVctValues(List.of("https://example.com/vct"));
+        credential.setClaims(List.of(claim));
+        return credential;
+    }
+
+    private static SdJwtVP mockPresentationWithClaim(String claimName, Object claimValue) {
+        SdJwtVP presentation = mock(SdJwtVP.class);
+        IssuerSignedJWT issuerSignedJwt = mock(IssuerSignedJWT.class);
+        var payload = JsonNodeFactory.instance.objectNode();
+        payload.put("vct", "https://example.com/vct");
+        if (claimValue instanceof Boolean booleanValue) {
+            payload.put(claimName, booleanValue);
+        } else {
+            payload.put(claimName, String.valueOf(claimValue));
+        }
+        when(presentation.getIssuerSignedJWT()).thenReturn(issuerSignedJwt);
+        when(issuerSignedJwt.getPayload()).thenReturn(payload);
+        when(presentation.getDisclosuresString()).thenReturn(List.of());
+        return presentation;
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/HolderBindingAudienceResolverTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/HolderBindingAudienceResolverTest.java
@@ -1,0 +1,30 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import org.junit.jupiter.api.Test;
+
+class HolderBindingAudienceResolverTest {
+
+    @Test
+    void usesFullClientIdentifierIncludingPrefix() {
+        RequestObject request = new RequestObject().setClientId("redirect_uri:https://verifier.example.org/cb");
+
+        assertEquals("redirect_uri:https://verifier.example.org/cb", HolderBindingAudienceResolver.resolve(request));
+    }
+
+    @Test
+    void preservesOriginPrefixedClientIdentifier() {
+        RequestObject request = new RequestObject().setClientId("origin:https://verifier.example.org");
+
+        assertEquals("origin:https://verifier.example.org", HolderBindingAudienceResolver.resolve(request));
+    }
+
+    @Test
+    void derivesOriginAudienceFromResponseUriWhenClientIdMissing() {
+        RequestObject request = new RequestObject().setResponseUri("https://verifier.example.org/openid4vp/response");
+
+        assertEquals("origin:https://verifier.example.org", HolderBindingAudienceResolver.resolve(request));
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtPresentationRequirementsTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtPresentationRequirementsTest.java
@@ -1,0 +1,62 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.VCFormat;
+import org.keycloak.common.VerificationException;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.sdjwt.consumer.PresentationRequirements;
+
+class SdJwtPresentationRequirementsTest {
+
+    @Test
+    void requiresNestedDcqlPathNotOnlyLeafName() throws Exception {
+        Claim claim = new Claim();
+        claim.setPath(List.of("address", "street_address"));
+
+        Credential credential = new Credential();
+        credential.setId("cred-1");
+        credential.setFormat(VCFormat.SD_JWT_VC);
+        credential.setMeta(new Meta());
+        credential.getMeta().setVctValues(List.of("https://example.com/vct"));
+        credential.setClaims(List.of(claim));
+
+        SdJwtAuthRequirements authRequirements = mock(SdJwtAuthRequirements.class);
+        when(authRequirements.getRequiredClaims()).thenReturn(List.of(JsonWebToken.SUBJECT, OAuth2Constants.USERNAME));
+        when(authRequirements.getVctPatternForCredential(credential))
+                .thenReturn(Pattern.quote("\"https://example.com/vct\""));
+        when(authRequirements.isVerifyIssuerClaim()).thenReturn(false);
+
+        PresentationRequirements requirements =
+                SdJwtPresentationRequirements.forCredential(authRequirements, credential);
+
+        var flatClaims = JsonNodeFactory.instance.objectNode();
+        flatClaims.put("street_address", "42 Market Street");
+        flatClaims.put("vct", "https://example.com/vct");
+        flatClaims.put("sub", "user-1");
+        flatClaims.put("username", "alice");
+
+        assertThrows(VerificationException.class, () -> requirements.checkIfSatisfiedBy(flatClaims));
+
+        var nestedClaims = JsonNodeFactory.instance.objectNode();
+        var address = nestedClaims.putObject("address");
+        address.put("street_address", "42 Market Street");
+        nestedClaims.put("vct", "https://example.com/vct");
+        nestedClaims.put("sub", "user-1");
+        nestedClaims.put("username", "alice");
+
+        assertDoesNotThrow(() -> requirements.checkIfSatisfiedBy(nestedClaims));
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenPresentationDecoderTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenPresentationDecoderTest.java
@@ -1,0 +1,37 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+class VpTokenPresentationDecoderTest {
+
+    private static final String RAW_SD_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature~disclosure";
+
+    @Test
+    void returnsRawSdJwtWithoutDecoding() {
+        assertEquals(RAW_SD_JWT, VpTokenPresentationDecoder.decodeIfBase64Url(RAW_SD_JWT));
+    }
+
+    @Test
+    void decodesBase64UrlWrappedPresentation() {
+        String wrapped = Base64.getUrlEncoder().encodeToString(RAW_SD_JWT.getBytes(StandardCharsets.UTF_8));
+        assertEquals(RAW_SD_JWT, VpTokenPresentationDecoder.decodeIfBase64Url(wrapped));
+    }
+
+    @Test
+    void detectsCompactJwtShape() {
+        assertTrue(VpTokenPresentationDecoder.looksLikeSdJwtPresentation(RAW_SD_JWT));
+        assertFalse(VpTokenPresentationDecoder.looksLikeSdJwtPresentation("not-a-jwt"));
+    }
+
+    @Test
+    void leavesNonJwtInputUntouchedWhenNotWrapped() {
+        String invalid = "not-a-jwt-or-wrapper";
+        assertEquals(invalid, VpTokenPresentationDecoder.decodeIfBase64Url(invalid));
+    }
+}


### PR DESCRIPTION
This second PR adds SD-JWT format validation for returned `vp_token` presentations using upstream Keycloak’s `SdJwtPresentationConsumer`, holder-binding replay checks (nonce/audience), and optional Token Status List revocation (OpenID4VP §8.6 format steps, §14.1, §14.8).

This PR does not wire the login path yet: no changes to `AuthorizationResponseService` or `SdJwtAuthenticator`. Those land in PR 3. Depends on PR 1 (76-dcql-model-and-satisfaction).

## What's included

- SD-JWT format validation (validation package)
  - `SdJwtPresentationValidator` — decodes VP strings and calls `SdJwtPresentationConsumer.verifySdJwtPresentation(...)` with issuer trust, presentation requirements, and KB-JWT opts
  - `SdJwtPresentationRequirements` — builds PresentationRequirements per DCQL credential query (paths, vct, iss)
  - `HolderBindingAudienceResolver` — resolves holder-binding aud from client_id (Client Identifier Prefix /origin:)
  - `VpTokenPresentationDecoder` — Base64URL decoding for vp_token entries
  - `PresentationFormatValidator` / `PresentationFormatValidators` — pluggable format validators for dc+sd-jwt / vc+sd-jwt
  - `VpTokenValidationContext` — session, request object, SdJwtAuthRequirements, nonce, audience

- Shared SD-JWT verification inputs (authenticator package)
  - `SdJwtAuthRequirements` — getVctPatternForCredential(), getIssuerPattern(), isVerifyIssuerClaim() for format-phase checks
  - `SdJwtAuthenticatorConfigResolver` — loads SD-JWT authenticator config from the OpenID4VP flow
  - `SdJwtAuthenticatorFactories` — resolves registered factory and status-list fetcher for a session
  - `SdJwtAuthenticatorFactory` — createStatusListJwtFetcher() for revocation during format validation
  - `SelfTrustedSdJwtIssuer` — KeycloakSession constructor for use outside AuthenticationFlowContext

## Tests

- `HolderBindingAudienceResolverTest`
- `SdJwtPresentationRequirementsTest`
- `VpTokenPresentationDecoderTest`