### PR TITLE
feat(oid4vp): vp_token validation pipeline integration

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointBase.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointBase.java
@@ -1,6 +1,6 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp;
 
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactory;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorConfigResolver;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -14,7 +14,6 @@ import org.jspecify.annotations.NonNull;
 import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.AuthenticatedClientSessionModel;
-import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.ClientModel;
@@ -81,13 +80,11 @@ public class OID4VPUserAuthEndpointBase extends AuthorizationEndpointBase {
      * Returns the SD-JWT authenticator configuration as part of the OpenID4VP authentication flow.
      */
     protected AuthenticatorConfigModel getSdjwtAuthenticatorConfig() {
-        AuthenticationFlowModel flow = getOid4vpAuthFlow();
-        return realm.getAuthenticationExecutionsStream(flow.getId())
-                .filter(execution -> execution.getAuthenticator().equals(SdJwtAuthenticatorFactory.PROVIDER_ID))
-                .findFirst()
-                .map(AuthenticationExecutionModel::getAuthenticatorConfig)
-                .map(realm::getAuthenticatorConfigById)
-                .orElse(new AuthenticatorConfigModel());
+        return resolveSdJwtAuthenticatorConfig(session);
+    }
+
+    public static AuthenticatorConfigModel resolveSdJwtAuthenticatorConfig(KeycloakSession session) {
+        return SdJwtAuthenticatorConfigResolver.resolve(session);
     }
 
     /**

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthRequirements.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthRequirements.java
@@ -4,6 +4,8 @@ import static org.keycloak.OID4VCConstants.CLAIM_NAME_ISSUER;
 import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
 import static org.keycloak.sdjwt.ClaimVerifier.ClaimCheck;
 
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -101,6 +103,31 @@ public class SdJwtAuthRequirements {
             requirements.addClaimRequirement(CLAIM_NAME_ISSUER, Pattern.quote("\"%s\"".formatted(keycloakIssuerURI)));
         }
         return requirements.build();
+    }
+
+    public boolean isVerifyIssuerClaim() {
+        return verifyIssuerClaim;
+    }
+
+    public String getIssuerPattern() {
+        return Pattern.quote("\"%s\"".formatted(keycloakIssuerURI));
+    }
+
+    /**
+     * Regex pattern for {@code vct} as required by the DCQL credential query (OpenID4VP §8.6).
+     */
+    public String getVctPatternForCredential(Credential credentialQuery) {
+        String vctPattern = vctPatternFromMeta(credentialQuery.getMeta());
+        return vctPattern != null ? vctPattern : expectedVctsPattern;
+    }
+
+    private String vctPatternFromMeta(Meta meta) {
+        if (meta == null || meta.getVctValues() == null || meta.getVctValues().isEmpty()) {
+            return null;
+        }
+        return meta.getVctValues().stream()
+                .map(vct -> Pattern.quote("\"" + vct + "\""))
+                .collect(Collectors.joining("|", "(", ")"));
     }
 
     public SdJwtCredentialConstrainer.QueryMap getSdJwtQueryMap() {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticator.java
@@ -1,15 +1,10 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator;
 
-import static io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.ReferencedTokenValidationException;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.ErrorResponseSanitizer;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import java.util.List;
 import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.authentication.AuthenticationFlowContext;
@@ -23,7 +18,6 @@ import org.keycloak.models.UserModel;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.sdjwt.SdJwtUtils;
-import org.keycloak.sdjwt.consumer.SdJwtPresentationConsumer;
 import org.keycloak.sdjwt.vp.SdJwtVP;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.utils.StringUtil;
@@ -31,68 +25,51 @@ import org.keycloak.utils.StringUtil;
 /**
  * Authenticate by presenting a valid SD-JWT credential.
  *
+ * <p>Presentation validation is performed upstream by
+ * {@link io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation.VpTokenValidationPipeline}
+ * before this authenticator runs. This authenticator only resolves the presenting user.
+ *
  * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
  */
 public class SdJwtAuthenticator implements Authenticator {
 
     private static final Logger logger = Logger.getLogger(SdJwtAuthenticator.class);
 
-    private final SdJwtPresentationConsumer consumer;
-    private final ReferencedTokenValidator tokenStatusValidator;
-
-    /**
-     * The authenticating party is challenged to produce a presentation with a nonce.
-     */
-    public static final String CHALLENGE_NONCE_KEY = "nonce";
-
-    /**
-     * The authenticating party is challenged to produce a presentation with an audience.
-     */
-    public static final String CHALLENGE_AUD_KEY = "aud";
-
     /**
      * The authenticating party presents a non-replayable SD-JWT token for authentication.
      */
     public static final String SDJWT_TOKEN_KEY = "sdjwt_token";
 
-    public SdJwtAuthenticator(StatusListJwtFetcher statusListJwtFetcher) {
-        this.consumer = new SdJwtPresentationConsumer();
-        this.tokenStatusValidator = new ReferencedTokenValidator(statusListJwtFetcher);
-    }
+    /**
+     * Required for the OpenID4VP authorization-response flow. Set by
+     * {@link io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.AuthorizationResponseService}
+     * after {@link io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation.VpTokenValidationPipeline}
+     * validates the presentation.
+     */
+    public static final String VP_TOKEN_VALIDATED_KEY = "vp_token_validated";
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
         AuthenticationSessionModel authSession = context.getAuthenticationSession();
         logger.info("Authenticating with SdJwtAuthenticator");
 
-        SdJwtAuthRequirements authReqs = getAuthenticationRequirements(context);
-        String nonce = authSession.getAuthNote(CHALLENGE_NONCE_KEY);
-        String aud = authSession.getAuthNote(CHALLENGE_AUD_KEY);
-        SdJwtVP sdJwt = SdJwtVP.of(authSession.getAuthNote(SDJWT_TOKEN_KEY));
-
-        try {
-            consumer.verifySdJwtPresentation(
-                    sdJwt,
-                    authReqs.getPresentationRequirements(),
-                    List.of(new SelfTrustedSdJwtIssuer(context)),
-                    authReqs.getIssuerSignedJwtVerificationOpts(),
-                    authReqs.getKeyBindingJwtVerificationOpts(nonce, aud));
-        } catch (VerificationException e) {
-            logger.errorf(e, "Token verification failed (authSession = %s)", correlationId(context));
-            failRejectingPresentedSdJwtToken(context, e.getMessage(), e);
+        String sdJwtToken = authSession.getAuthNote(SDJWT_TOKEN_KEY);
+        if (StringUtil.isBlank(sdJwtToken)) {
+            logger.errorf("Missing SD-JWT VP token (authSession = %s)", correlationId(context));
+            failRejectingPresentedSdJwtToken(context, "Missing SD-JWT VP token");
             return;
         }
 
-        // Validate token status if enforced
-        if (authReqs.shouldEnforceRevocationStatus()) {
-            try {
-                tokenStatusValidator.validate(sdJwt.getIssuerSignedJWT().getPayload());
-            } catch (ReferencedTokenValidationException e) {
-                logger.errorf(e, "Token status verification failed (authSession = %s)", correlationId(context));
-                failRejectingPresentedSdJwtToken(context, "Token status verification failed", e);
-                return;
-            }
+        if (!"true".equals(authSession.getAuthNote(VP_TOKEN_VALIDATED_KEY))) {
+            logger.errorf(
+                    "VP token reached authenticator without prior pipeline validation (authSession = %s)",
+                    correlationId(context));
+            failRejectingPresentedSdJwtToken(context, "VP token was not validated by the verifier pipeline");
+            return;
         }
+
+        SdJwtVP sdJwt = SdJwtVP.of(sdJwtToken);
+        logger.debug("Resolving user from pipeline-validated SD-JWT presentation");
 
         UserModel user = recoverAuthenticatingUser(context, sdJwt);
         if (user == null) {
@@ -106,17 +83,13 @@ public class SdJwtAuthenticator implements Authenticator {
         }
 
         context.setUser(user);
-        context.success(); // Mark authentication as successful
+        context.success();
         logger.debugf("User '%s' successfully authenticated", user.getUsername());
     }
 
     @Override
     public void action(AuthenticationFlowContext context) {
         // No form action is relevant for this authenticator
-    }
-
-    private SdJwtAuthRequirements getAuthenticationRequirements(AuthenticationFlowContext context) {
-        return new SdJwtAuthRequirements(context.getSession().getContext(), context.getAuthenticatorConfig());
     }
 
     private UserModel recoverAuthenticatingUser(AuthenticationFlowContext context, SdJwtVP sdJwt) {
@@ -206,16 +179,8 @@ public class SdJwtAuthenticator implements Authenticator {
     }
 
     private void failRejectingPresentedSdJwtToken(AuthenticationFlowContext context, String reason) {
-        failRejectingPresentedSdJwtToken(context, reason, null);
-    }
-
-    private void failRejectingPresentedSdJwtToken(AuthenticationFlowContext context, String reason, Throwable cause) {
         String correlationId = ErrorResponseSanitizer.correlationIdFromAuthSession(context.getAuthenticationSession());
-        if (cause != null) {
-            logger.errorf(cause, "Presented SD-JWT rejected (authSession = %s): %s", correlationId, reason);
-        } else {
-            logger.errorf("Presented SD-JWT rejected (authSession = %s): %s", correlationId, reason);
-        }
+        logger.errorf("Presented SD-JWT rejected (authSession = %s): %s", correlationId, reason);
 
         String description = String.format("Invalid SD-JWT presentation (%s)", reason);
         var errorRep = new OAuth2ErrorRepresentation(Errors.INVALID_USER_CREDENTIALS, description);

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticator.java
@@ -139,6 +139,7 @@ public class SdJwtAuthenticator implements Authenticator {
         ObjectNode kbPayload = keyBindingJwt.get().getPayload();
         TransactionDataValidator.validate(transactionDataWire, kbPayload);
     }
+
     private UserModel recoverAuthenticatingUser(AuthenticationFlowContext context, SdJwtVP sdJwt) {
         logger.info("Recovering authenticating user");
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorConfigResolver.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorConfigResolver.java
@@ -1,0 +1,31 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPUserAuthEndpointBase;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+
+/**
+ * Resolves SD-JWT authenticator configuration from the OpenID4VP authentication flow.
+ */
+public final class SdJwtAuthenticatorConfigResolver {
+
+    private SdJwtAuthenticatorConfigResolver() {}
+
+    public static AuthenticatorConfigModel resolve(KeycloakSession session) {
+        RealmModel realm = session.getContext().getRealm();
+        var flow = realm.getFlowByAlias(OID4VPUserAuthEndpointBase.OID4VP_AUTH_FLOW);
+        if (flow == null) {
+            throw new IllegalStateException(String.format(
+                    "Authentication flow '%s' not found. Such is supposed to be built-in",
+                    OID4VPUserAuthEndpointBase.OID4VP_AUTH_FLOW));
+        }
+        return realm.getAuthenticationExecutionsStream(flow.getId())
+                .filter(execution -> execution.getAuthenticator().equals(SdJwtAuthenticatorFactory.PROVIDER_ID))
+                .findFirst()
+                .map(AuthenticationExecutionModel::getAuthenticatorConfig)
+                .map(realm::getAuthenticatorConfigById)
+                .orElse(new AuthenticatorConfigModel());
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactories.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactories.java
@@ -1,0 +1,26 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.KeycloakSession;
+
+/**
+ * Access to the registered {@link SdJwtAuthenticatorFactory} for a session.
+ */
+public final class SdJwtAuthenticatorFactories {
+
+    private SdJwtAuthenticatorFactories() {}
+
+    public static SdJwtAuthenticatorFactory getFactory(KeycloakSession session) {
+        var providerFactory = session.getKeycloakSessionFactory()
+                .getProviderFactory(Authenticator.class, SdJwtAuthenticatorFactory.PROVIDER_ID);
+        if (providerFactory instanceof SdJwtAuthenticatorFactory sdJwtAuthenticatorFactory) {
+            return sdJwtAuthenticatorFactory;
+        }
+        return new SdJwtAuthenticatorFactory();
+    }
+
+    public static StatusListJwtFetcher createStatusListJwtFetcher(KeycloakSession session) {
+        return getFactory(session).createStatusListJwtFetcher(session);
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
@@ -182,8 +182,7 @@ public class SdJwtAuthenticatorFactory implements AuthenticatorFactory, OID4VPEn
 
     @Override
     public Authenticator create(KeycloakSession session) {
-        StatusListJwtFetcher httpFetcher = new TrustedStatusListJwtFetcher(session);
-        return new SdJwtAuthenticator(httpFetcher);
+        return new SdJwtAuthenticator();
     }
 
     @Override

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
@@ -173,6 +173,13 @@ public class SdJwtAuthenticatorFactory implements AuthenticatorFactory, OID4VPEn
         return PROVIDER_ID;
     }
 
+    /**
+     * Creates the status list fetcher used for revocation checks during presentation validation.
+     */
+    public StatusListJwtFetcher createStatusListJwtFetcher(KeycloakSession session) {
+        return new TrustedStatusListJwtFetcher(session);
+    }
+
     @Override
     public Authenticator create(KeycloakSession session) {
         StatusListJwtFetcher httpFetcher = new TrustedStatusListJwtFetcher(session);

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SelfTrustedSdJwtIssuer.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SelfTrustedSdJwtIssuer.java
@@ -27,7 +27,11 @@ public class SelfTrustedSdJwtIssuer implements TrustedSdJwtIssuer {
     private final KeycloakSession session;
 
     public SelfTrustedSdJwtIssuer(AuthenticationFlowContext context) {
-        this.session = context.getSession();
+        this(context.getSession());
+    }
+
+    public SelfTrustedSdJwtIssuer(KeycloakSession session) {
+        this.session = session;
     }
 
     @Override

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Claim.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Claim.java
@@ -12,7 +12,7 @@ public class Claim {
     private List<String> path;
 
     @JsonProperty("values")
-    private List<String> values;
+    private List<Object> values;
 
     public String getId() {
         return id;
@@ -30,11 +30,11 @@ public class Claim {
         this.path = path;
     }
 
-    public List<String> getValues() {
+    public List<Object> getValues() {
         return values;
     }
 
-    public void setValues(List<String> values) {
+    public void setValues(List<Object> values) {
         this.values = values;
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Credential.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Credential.java
@@ -20,6 +20,12 @@ public class Credential {
     @JsonProperty("claim_sets")
     private List<List<String>> claimSets;
 
+    @JsonProperty("multiple")
+    private Boolean multiple;
+
+    @JsonProperty("require_cryptographic_holder_binding")
+    private Boolean requireCryptographicHolderBinding;
+
     public String getId() {
         return id;
     }
@@ -58,5 +64,29 @@ public class Credential {
 
     public void setClaimSets(List<List<String>> claimSets) {
         this.claimSets = claimSets;
+    }
+
+    public Boolean getMultiple() {
+        return multiple;
+    }
+
+    public void setMultiple(Boolean multiple) {
+        this.multiple = multiple;
+    }
+
+    public Boolean getRequireCryptographicHolderBinding() {
+        return requireCryptographicHolderBinding;
+    }
+
+    public void setRequireCryptographicHolderBinding(Boolean requireCryptographicHolderBinding) {
+        this.requireCryptographicHolderBinding = requireCryptographicHolderBinding;
+    }
+
+    public boolean allowsMultiplePresentations() {
+        return Boolean.TRUE.equals(multiple);
+    }
+
+    public boolean requiresCryptographicHolderBinding() {
+        return requireCryptographicHolderBinding == null || requireCryptographicHolderBinding;
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Credential.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Credential.java
@@ -22,6 +22,7 @@ public class Credential {
 
     @JsonProperty("multiple")
     private Boolean multiple;
+
     @JsonProperty("require_cryptographic_holder_binding")
     private Boolean requireCryptographicHolderBinding;
 
@@ -72,6 +73,7 @@ public class Credential {
     public void setMultiple(Boolean multiple) {
         this.multiple = multiple;
     }
+
     public Boolean getRequireCryptographicHolderBinding() {
         return requireCryptographicHolderBinding;
     }
@@ -79,6 +81,7 @@ public class Credential {
     public void setRequireCryptographicHolderBinding(Boolean requireCryptographicHolderBinding) {
         this.requireCryptographicHolderBinding = requireCryptographicHolderBinding;
     }
+
     public boolean allowsMultiplePresentations() {
         return Boolean.TRUE.equals(multiple);
     }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationResponseService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationResponseService.java
@@ -9,10 +9,12 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.Authorizat
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContextStatus;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.ProcessingError;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.ErrorResponseSanitizer;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation.PresentedCredential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation.VpTokenValidationException;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation.VpTokenValidationResult;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation.VpTokenValidationService;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.UUID;
 import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
@@ -25,13 +27,17 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.utils.OAuth2Code;
 import org.keycloak.protocol.oidc.utils.OAuth2CodeParser;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
-import org.keycloak.sdjwt.vp.SdJwtVP;
 import org.keycloak.services.Urls;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.utils.MediaType;
 
 /**
  * Dedicated service for processing OpenID4VP authorization responses for user authentication.
+ *
+ * <p>This login flow authenticates the user from exactly one validated SD-JWT verifiable presentation.
+ * Multi-credential or {@code multiple: true} DCQL queries may pass {@link
+ * io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation.VpTokenValidationPipeline} but are
+ * rejected here before {@link org.keycloak.authentication.AuthenticationProcessor#authenticateOnly()}.
  *
  * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
  */
@@ -42,9 +48,11 @@ public class AuthorizationResponseService {
     public static final String PARENT_AUTH_SESSION_ID = "parent_auth_session_id";
 
     private final KeycloakSession session;
+    private final VpTokenValidationService vpTokenValidationService;
 
     public AuthorizationResponseService(KeycloakSession session) {
         this.session = session;
+        this.vpTokenValidationService = VpTokenValidationService.create(session);
     }
 
     /**
@@ -69,21 +77,35 @@ public class AuthorizationResponseService {
                     store);
         }
 
-        // Extract SD-JWT VP token from the response object
-        String sdJwtVp = extractSdJwtVpToken(responseObject, authContext, store);
+        PresentedCredential presentedCredential;
+        try {
+            logger.debug("Running verifier-side vp_token validation pipeline");
+            VpTokenValidationResult validationResult =
+                    vpTokenValidationService.validate(responseObject, authContext.getRequestObject());
+            presentedCredential = validationResult.requireSinglePresentation();
+        } catch (VpTokenValidationException e) {
+            logger.errorf(e, "vp_token validation failed");
+            boolean formatFailure = VpTokenValidationException.Phase.FORMAT.equals(e.getPhase());
+            String detailedMessage =
+                    formatFailure ? String.format("Invalid SD-JWT presentation (%s)", e.getMessage()) : e.getMessage();
+            throw failWithHttpException(
+                    formatFailure ? ProcessingError.VP_TOKEN_AUTH_ERROR : ProcessingError.INVALID_VP_TOKEN,
+                    formatFailure ? "Invalid SD-JWT presentation" : "Invalid vp_token",
+                    detailedMessage,
+                    formatFailure ? Response.Status.UNAUTHORIZED : Response.Status.BAD_REQUEST,
+                    authContext,
+                    store);
+        }
 
-        // Formally, we should then check that the VP token satisfies the DCQL constraints.
-        // Equivalently, we offload this task to the SD-JWT authenticator in the authentication flow.
-        logger.debugf("Initializing authentication with extracted SD-JWT VP token");
+        String sdJwtVp = presentedCredential.encodedPresentation();
+
+        logger.debugf("Initializing authentication with validated SD-JWT VP token");
         var processorSession = authProcessor.getAuthenticationSession();
-        String nonce = authContext.getRequestObject().getNonce();
-        String aud = authContext.getRequestObject().getClientId();
         processorSession.setAuthNote(SdJwtAuthenticator.SDJWT_TOKEN_KEY, sdJwtVp);
-        processorSession.setAuthNote(SdJwtAuthenticator.CHALLENGE_NONCE_KEY, nonce);
-        processorSession.setAuthNote(SdJwtAuthenticator.CHALLENGE_AUD_KEY, aud);
+        processorSession.setAuthNote(SdJwtAuthenticator.VP_TOKEN_VALIDATED_KEY, "true");
 
-        // Run authentication processor to validate the SD-JWT VP token
-        logger.debug("Running authentication processor to validate SD-JWT VP token...");
+        // Run authentication processor to resolve the presenting user
+        logger.debug("Running authentication processor after vp_token validation...");
         try (Response response = authProcessor.authenticateOnly()) {
             if (response != null) {
                 String detailed = getAuthenticatorErrorMessage(response);
@@ -123,76 +145,6 @@ public class AuthorizationResponseService {
         }
 
         return String.format("%s: %s", errorResponse.getError().toUpperCase(), errorResponse.getErrorDescription());
-    }
-
-    /**
-     * Extract SD-JWT VP token from response object
-     */
-    private String extractSdJwtVpToken(
-            ResponseObject responseObject, AuthorizationContext authContext, AuthenticationSessionStore store) {
-        String parsedVpToken;
-        logger.debug("Extracting SD-JWT VP token from response object with DCQL matching");
-        parsedVpToken = extractSdJwtVpTokenWithDCQL(responseObject, authContext, store);
-
-        try {
-            String vpToken = decodeIfBase64Url(parsedVpToken);
-            SdJwtVP.of(vpToken);
-            return vpToken;
-        } catch (IllegalArgumentException e) {
-            logger.errorf(e, "Failed to parse SD-JWT VP token");
-            String detailed = "Could not parse SD-JWT VP token contained in `vp_token`";
-            throw failWithHttpException(
-                    ProcessingError.INVALID_VP_TOKEN,
-                    "Invalid vp_token",
-                    detailed,
-                    Response.Status.BAD_REQUEST,
-                    authContext,
-                    store);
-        }
-    }
-
-    /**
-     * Extract SD-JWT VP token from response object (DCQL era)
-     */
-    private String extractSdJwtVpTokenWithDCQL(
-            ResponseObject responseObject, AuthorizationContext authContext, AuthenticationSessionStore store) {
-        var dcqlQuery = authContext.getRequestObject().getDcqlQuery();
-        if (dcqlQuery == null || dcqlQuery.getCredentials().size() != 1) {
-            throw new IllegalStateException(
-                    "Invalid DCQL query in authorization context. Expected exactly one credential query.");
-        }
-
-        // Ensure that VP token map matches the DCQL credential query
-        var credentialQuery = dcqlQuery.getCredentials().getFirst();
-        var vpTokenMap = responseObject.getVpToken();
-        if (vpTokenMap == null || !vpTokenMap.containsKey(credentialQuery.getId())) {
-            String detailed = "Presented vp_token map does not match DCQL credential query";
-            throw failWithHttpException(
-                    ProcessingError.INVALID_VP_TOKEN,
-                    "Invalid vp_token",
-                    detailed,
-                    Response.Status.BAD_REQUEST,
-                    authContext,
-                    store);
-        }
-
-        // Check that the VP token map provides a VP token, and only one
-        var tokens = vpTokenMap.get(credentialQuery.getId());
-        if (tokens == null || tokens.size() != 1) {
-            String errorMsg = String.format(
-                    "Presented vp_token map must contain exactly one token as requested. Found: %d",
-                    tokens == null ? 0 : tokens.size());
-
-            throw failWithHttpException(
-                    ProcessingError.INVALID_VP_TOKEN,
-                    "Invalid vp_token",
-                    errorMsg,
-                    Response.Status.BAD_REQUEST,
-                    authContext,
-                    store);
-        }
-
-        return (String) tokens.getFirst();
     }
 
     /**
@@ -264,20 +216,5 @@ public class AuthorizationResponseService {
         }
 
         return exception;
-    }
-
-    /**
-     * Helper method to decode Base64URL encoded strings if applicable.
-     * If the input is not Base64URL encoded, it returns the input as is.
-     */
-    private static String decodeIfBase64Url(String input) {
-        try {
-            // Try to decode as Base64URL
-            byte[] decoded = Base64.getUrlDecoder().decode(input);
-            return new String(decoded, StandardCharsets.UTF_8);
-        } catch (IllegalArgumentException e) {
-            // Not valid Base64URL, return as is
-            return input;
-        }
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/ClaimsPathProcessor.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/ClaimsPathProcessor.java
@@ -1,0 +1,127 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Applies DCQL claims path pointers to JSON-based credentials (OpenID4VP §7.1).
+ */
+public final class ClaimsPathProcessor {
+
+    private ClaimsPathProcessor() {}
+
+    /**
+     * @return selected claim values; empty when the path does not resolve
+     */
+    public static List<JsonNode> process(JsonNode root, List<Object> path) throws VpTokenValidationException {
+        if (root == null || path == null || path.isEmpty()) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL, "Claims path pointer must be a non-empty array");
+        }
+
+        List<JsonNode> selected = List.of(root);
+        for (Object component : path) {
+            selected = processComponent(selected, component);
+            if (selected.isEmpty()) {
+                return List.of();
+            }
+        }
+        return selected;
+    }
+
+    private static List<JsonNode> processComponent(List<JsonNode> current, Object component)
+            throws VpTokenValidationException {
+        if (component instanceof String key) {
+            return selectObjectKey(current, key);
+        }
+        if (component == null) {
+            return selectAllArrayElements(current);
+        }
+        if (component instanceof Integer index) {
+            return selectArrayIndex(current, index);
+        }
+        if (component instanceof Number number) {
+            if (number.doubleValue() != Math.floor(number.doubleValue()) || number.longValue() < 0) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.DCQL, "Claims path index must be a non-negative integer");
+            }
+            return selectArrayIndex(current, number.intValue());
+        }
+        throw new VpTokenValidationException(
+                VpTokenValidationException.Phase.DCQL, "Unsupported claims path pointer component: " + component);
+    }
+
+    private static List<JsonNode> selectObjectKey(List<JsonNode> current, String key) {
+        List<JsonNode> next = new ArrayList<>();
+        for (JsonNode node : current) {
+            if (!node.isObject()) {
+                continue;
+            }
+            JsonNode child = node.get(key);
+            if (child != null) {
+                next.add(child);
+            }
+        }
+        return next;
+    }
+
+    private static List<JsonNode> selectAllArrayElements(List<JsonNode> current) throws VpTokenValidationException {
+        List<JsonNode> next = new ArrayList<>();
+        for (JsonNode node : current) {
+            if (!node.isArray()) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.DCQL,
+                        "Claims path pointer expected an array at the current selection");
+            }
+            ArrayNode arrayNode = (ArrayNode) node;
+            arrayNode.forEach(next::add);
+        }
+        return next;
+    }
+
+    private static List<JsonNode> selectArrayIndex(List<JsonNode> current, int index)
+            throws VpTokenValidationException {
+        List<JsonNode> next = new ArrayList<>();
+        for (JsonNode node : current) {
+            if (!node.isArray()) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.DCQL,
+                        "Claims path pointer expected an array at the current selection");
+            }
+            ArrayNode arrayNode = (ArrayNode) node;
+            if (index >= 0 && index < arrayNode.size()) {
+                next.add(arrayNode.get(index));
+            }
+        }
+        return next;
+    }
+
+    /**
+     * Adapts a DCQL {@code path} from {@link io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim}
+     * to the mixed components expected by {@link #process}.
+     *
+     * <p>Today {@code Claim.path} is {@code List<String>} because our DCQL schemas only use object-key
+     * segments. OpenID4VP §7.1 also allows integers (array indices) and {@code null} (all array elements),
+     * e.g. {@code ["address", null, "street_address"]}. {@link #process} already supports those types.
+     *
+     * <p>If {@code Claim.path} is widened to deserialize mixed JSON array elements, update this mapper to
+     * translate numeric indices and {@code null} entries—not only {@link List#copyOf} of strings.
+     */
+    public static List<Object> toPathComponents(List<String> path) {
+        return List.copyOf(path);
+    }
+
+    /**
+     * Merges issuer-signed payload with selectively disclosed claims for path resolution.
+     */
+    public static ObjectNode credentialClaimsRoot(JsonNode issuerSignedPayload, JsonNode disclosedClaims) {
+        ObjectNode root = issuerSignedPayload.deepCopy();
+        if (disclosedClaims != null && disclosedClaims.isObject()) {
+            disclosedClaims.properties().forEach(entry -> root.set(entry.getKey(), entry.getValue()));
+        }
+        return root;
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlClaimValues.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlClaimValues.java
@@ -1,0 +1,56 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+/**
+ * Compares presented claim values against DCQL {@code values} constraints (§6.3, §6.4.1).
+ *
+ * <p>Matching is strict by JSON value type: a string constraint such as {@code "true"} only matches
+ * a textual claim, not a boolean {@code true}; a string {@code "42"} only matches text, not numeric
+ * {@code 42}. Use boolean/number entries in {@code values} when those types are intended.
+ */
+final class DcqlClaimValues {
+
+    private DcqlClaimValues() {}
+
+    static boolean matchesAny(List<JsonNode> resolved, List<Object> expectedValues) {
+        if (expectedValues == null || expectedValues.isEmpty()) {
+            return true;
+        }
+        for (JsonNode actual : resolved) {
+            for (Object expected : expectedValues) {
+                if (equals(actual, expected)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean equals(JsonNode actual, Object expected) {
+        if (actual == null || expected == null) {
+            return false;
+        }
+        if (expected instanceof String expectedString) {
+            return equalsString(actual, expectedString);
+        }
+        if (expected instanceof Boolean expectedBoolean) {
+            return actual.isBoolean() && actual.asBoolean() == expectedBoolean;
+        }
+        if (expected instanceof Integer expectedInteger) {
+            return actual.isIntegralNumber() && actual.asInt() == expectedInteger;
+        }
+        if (expected instanceof Long expectedLong) {
+            return actual.isIntegralNumber() && actual.asLong() == expectedLong;
+        }
+        if (expected instanceof Number expectedNumber) {
+            return actual.isNumber() && actual.asDouble() == expectedNumber.doubleValue();
+        }
+        return expected.toString().equals(actual.isValueNode() ? actual.asText() : actual.toString());
+    }
+
+    private static boolean equalsString(JsonNode actual, String expected) {
+        return actual.isTextual() && expected.equals(actual.asText());
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlQueryRules.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlQueryRules.java
@@ -1,0 +1,113 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.CredentialSet;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Shared DCQL selection rules (OpenID4VP §6.4.2, §8.1).
+ */
+final class DcqlQueryRules {
+
+    private DcqlQueryRules() {}
+
+    static boolean usesCredentialSets(DcqlQuery dcqlQuery) {
+        return dcqlQuery.getCredentialSets() != null
+                && !dcqlQuery.getCredentialSets().isEmpty();
+    }
+
+    static Set<String> credentialQueryIds(DcqlQuery dcqlQuery) {
+        return dcqlQuery.getCredentials().stream()
+                .map(credential -> credential.getId())
+                .collect(Collectors.toSet());
+    }
+
+    static void requireAllCredentialQueriesPresent(
+            Map<String, ?> presentedById, DcqlQuery dcqlQuery, VpTokenValidationException.Phase phase)
+            throws VpTokenValidationException {
+        for (String credentialId : credentialQueryIds(dcqlQuery)) {
+            if (!presentedById.containsKey(credentialId)) {
+                throw new VpTokenValidationException(
+                        phase, "Presented vp_token map does not match DCQL credential query");
+            }
+        }
+    }
+
+    static void validateRequiredCredentialSets(
+            Map<String, ?> presentedById, DcqlQuery dcqlQuery, VpTokenValidationException.Phase phase)
+            throws VpTokenValidationException {
+        if (!usesCredentialSets(dcqlQuery)) {
+            return;
+        }
+
+        for (CredentialSet credentialSet : dcqlQuery.getCredentialSets()) {
+            boolean required = credentialSet.getRequired() == null || credentialSet.getRequired();
+            if (!required) {
+                continue;
+            }
+            if (credentialSet.getOptions() == null || credentialSet.getOptions().isEmpty()) {
+                throw new VpTokenValidationException(phase, "DCQL credential_sets entry is missing options");
+            }
+            if (!satisfiesAnyCredentialSetOption(presentedById, credentialSet.getOptions())) {
+                throw new VpTokenValidationException(
+                        phase, "Returned presentations do not satisfy required DCQL credential_sets constraints");
+            }
+        }
+    }
+
+    /**
+     * When {@code credential_sets} is used, every returned credential id must belong to a satisfied
+     * credential set option (§8.1 — no entries for non-matching optional queries).
+     */
+    static void validatePresentedCredentialsWithinCredentialSets(
+            Map<String, ?> presentedById, DcqlQuery dcqlQuery, VpTokenValidationException.Phase phase)
+            throws VpTokenValidationException {
+        if (!usesCredentialSets(dcqlQuery)) {
+            return;
+        }
+
+        Set<String> permittedIds = permittedCredentialIds(presentedById, dcqlQuery);
+        for (String presentedId : presentedById.keySet()) {
+            if (!permittedIds.contains(presentedId)) {
+                throw new VpTokenValidationException(
+                        phase,
+                        "vp_token contains credential query id outside satisfied DCQL credential_sets: " + presentedId);
+            }
+        }
+    }
+
+    private static Set<String> permittedCredentialIds(Map<String, ?> presentedById, DcqlQuery dcqlQuery) {
+        Set<String> permitted = new HashSet<>();
+        for (CredentialSet credentialSet : dcqlQuery.getCredentialSets()) {
+            List<List<String>> options = credentialSet.getOptions();
+            if (options == null) {
+                continue;
+            }
+            for (List<String> option : options) {
+                if (option == null || option.isEmpty()) {
+                    continue;
+                }
+                if (presentedById.keySet().containsAll(option)) {
+                    permitted.addAll(option);
+                }
+            }
+        }
+        return permitted;
+    }
+
+    private static boolean satisfiesAnyCredentialSetOption(Map<String, ?> presentedById, List<List<String>> options) {
+        for (List<String> option : options) {
+            if (option == null || option.isEmpty()) {
+                continue;
+            }
+            if (presentedById.keySet().containsAll(option)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlSatisfactionValidator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlSatisfactionValidator.java
@@ -1,0 +1,161 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.keycloak.VCFormat;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+
+/**
+ * Verifies that validated presentations satisfy the issued DCQL query (OpenID4VP §6.4, §8.6).
+ *
+ * <p>The wallet may have enforced DCQL already; the verifier MUST NOT rely on that.
+ */
+public class DcqlSatisfactionValidator {
+
+    public void validate(List<PresentedCredential> presentations, DcqlQuery dcqlQuery)
+            throws VpTokenValidationException {
+        Map<String, PresentedCredential> presentedById = new HashMap<>();
+        for (PresentedCredential presented : presentations) {
+            presentedById.put(presented.credentialQueryId(), presented);
+        }
+
+        if (!DcqlQueryRules.usesCredentialSets(dcqlQuery)) {
+            DcqlQueryRules.requireAllCredentialQueriesPresent(
+                    presentedById, dcqlQuery, VpTokenValidationException.Phase.DCQL);
+        } else {
+            DcqlQueryRules.validateRequiredCredentialSets(
+                    presentedById, dcqlQuery, VpTokenValidationException.Phase.DCQL);
+            DcqlQueryRules.validatePresentedCredentialsWithinCredentialSets(
+                    presentedById, dcqlQuery, VpTokenValidationException.Phase.DCQL);
+        }
+
+        for (PresentedCredential presented : presentations) {
+            validateCredentialQuery(presented.presentation(), presented.credentialQuery());
+        }
+    }
+
+    private void validateCredentialQuery(SdJwtVP presentation, Credential credentialQuery)
+            throws VpTokenValidationException {
+        validateFormat(credentialQuery);
+        validateMeta(presentation, credentialQuery.getMeta());
+        validateClaims(presentation, credentialQuery);
+    }
+
+    private void validateFormat(Credential credentialQuery) throws VpTokenValidationException {
+        String expectedFormat = credentialQuery.getFormat();
+        if (expectedFormat == null || expectedFormat.isBlank()) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL, "DCQL credential query is missing format");
+        }
+        if (!VCFormat.SD_JWT_VC.equals(expectedFormat) && !"dc+sd-jwt".equals(expectedFormat)) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL,
+                    "Unsupported credential format in DCQL query: " + expectedFormat);
+        }
+    }
+
+    private void validateMeta(SdJwtVP presentation, Meta meta) throws VpTokenValidationException {
+        if (meta == null || meta.getVctValues() == null || meta.getVctValues().isEmpty()) {
+            return;
+        }
+
+        String presentedVct = readScalarClaim(presentation, CLAIM_NAME_VCT);
+        if (presentedVct == null) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL, "Presentation is missing required vct claim");
+        }
+        if (!meta.getVctValues().contains(presentedVct)) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL,
+                    "Presentation vct does not match any value requested in DCQL meta.vct_values");
+        }
+    }
+
+    private void validateClaims(SdJwtVP presentation, Credential credentialQuery) throws VpTokenValidationException {
+        List<Claim> claims = credentialQuery.getClaims();
+        if (claims == null || claims.isEmpty()) {
+            return;
+        }
+
+        if (credentialQuery.getClaimSets() != null
+                && !credentialQuery.getClaimSets().isEmpty()) {
+            validateClaimSets(presentation, credentialQuery, claims);
+            return;
+        }
+
+        for (Claim claimQuery : claims) {
+            requireClaimPath(presentation, claimQuery);
+        }
+    }
+
+    private void validateClaimSets(SdJwtVP presentation, Credential credentialQuery, List<Claim> claims)
+            throws VpTokenValidationException {
+        Map<String, Claim> claimsById = new HashMap<>();
+        for (Claim claim : claims) {
+            if (claim.getId() == null || claim.getId().isBlank()) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.DCQL, "DCQL claim id is required when claim_sets are present");
+            }
+            claimsById.put(claim.getId(), claim);
+        }
+
+        for (List<String> option : credentialQuery.getClaimSets()) {
+            if (satisfiesClaimSetOption(presentation, claimsById, option)) {
+                return;
+            }
+        }
+
+        throw new VpTokenValidationException(
+                VpTokenValidationException.Phase.DCQL,
+                "Presentation does not satisfy any requested DCQL claim_sets option");
+    }
+
+    private boolean satisfiesClaimSetOption(SdJwtVP presentation, Map<String, Claim> claimsById, List<String> option)
+            throws VpTokenValidationException {
+        for (String claimId : option) {
+            Claim claimQuery = claimsById.get(claimId);
+            if (claimQuery == null) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.DCQL,
+                        "DCQL claim_sets references unknown claim id: " + claimId);
+            }
+            if (!hasClaimPath(presentation, claimQuery)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void requireClaimPath(SdJwtVP presentation, Claim claimQuery) throws VpTokenValidationException {
+        if (!hasClaimPath(presentation, claimQuery)) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL,
+                    "Presentation does not contain claim required by DCQL path: " + claimQuery.getPath());
+        }
+    }
+
+    private boolean hasClaimPath(SdJwtVP presentation, Claim claimQuery) throws VpTokenValidationException {
+        List<JsonNode> resolved = SdJwtClaimReader.resolveClaimPath(presentation, claimQuery.getPath());
+        if (resolved.isEmpty()) {
+            return false;
+        }
+        return DcqlClaimValues.matchesAny(resolved, claimQuery.getValues());
+    }
+
+    private String readScalarClaim(SdJwtVP presentation, String claimName) throws VpTokenValidationException {
+        List<JsonNode> resolved = SdJwtClaimReader.resolveClaimPath(presentation, List.of(claimName));
+        if (resolved.isEmpty()) {
+            return null;
+        }
+        JsonNode value = resolved.getFirst();
+        return value.isValueNode() ? value.asText() : value.toString();
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/HolderBindingAudienceResolver.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/HolderBindingAudienceResolver.java
@@ -1,0 +1,53 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import java.net.URI;
+import org.keycloak.utils.StringUtil;
+
+/**
+ * Resolves the holder-binding audience for replay protection (OpenID4VP §14.1, §14.8, Appendix A.4).
+ *
+ * <p>Uses the full {@code client_id} (including any Client Identifier Prefix). For Digital
+ * Credentials API flows the audience is {@code origin:}<i>origin</i> and may already be reflected
+ * in {@code client_id}.
+ */
+public final class HolderBindingAudienceResolver {
+
+    private HolderBindingAudienceResolver() {}
+
+    public static String resolve(RequestObject requestObject) {
+        String clientId = requestObject.getClientId();
+        if (!StringUtil.isBlank(clientId)) {
+            if (clientId.startsWith("origin:")) {
+                return clientId;
+            }
+            return clientId;
+        }
+
+        String originAudience = originAudienceFromResponseUri(requestObject.getResponseUri());
+        if (originAudience != null) {
+            return originAudience;
+        }
+
+        return clientId;
+    }
+
+    private static String originAudienceFromResponseUri(String responseUri) {
+        if (StringUtil.isBlank(responseUri)) {
+            return null;
+        }
+        try {
+            URI uri = URI.create(responseUri);
+            if (uri.getScheme() == null || uri.getHost() == null) {
+                return null;
+            }
+            int port = uri.getPort();
+            String origin = port > 0
+                    ? String.format("%s://%s:%d", uri.getScheme(), uri.getHost(), port)
+                    : String.format("%s://%s", uri.getScheme(), uri.getHost());
+            return "origin:" + origin;
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/PresentationFormatValidator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/PresentationFormatValidator.java
@@ -1,0 +1,19 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+
+/**
+ * Format-specific verifier checks for one DCQL credential query (OpenID4VP §8.6 step 1–5).
+ */
+public interface PresentationFormatValidator {
+
+    boolean supports(Credential credentialQuery);
+
+    ValidatedPresentation validate(
+            String encodedPresentation, Credential credentialQuery, VpTokenValidationContext context)
+            throws VpTokenValidationException;
+
+    /** Normalized presentation encoding and parsed form. */
+    record ValidatedPresentation(String presentationString, SdJwtVP presentation) {}
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/PresentationFormatValidators.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/PresentationFormatValidators.java
@@ -1,0 +1,25 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import java.util.List;
+
+/**
+ * Resolves the format validator for a DCQL credential query.
+ */
+final class PresentationFormatValidators {
+
+    private final List<PresentationFormatValidator> validators;
+
+    PresentationFormatValidators(List<PresentationFormatValidator> validators) {
+        this.validators = List.copyOf(validators);
+    }
+
+    PresentationFormatValidator requireValidatorFor(Credential credentialQuery) throws VpTokenValidationException {
+        return validators.stream()
+                .filter(validator -> validator.supports(credentialQuery))
+                .findFirst()
+                .orElseThrow(() -> new VpTokenValidationException(
+                        VpTokenValidationException.Phase.FORMAT,
+                        "Unsupported credential format: " + credentialQuery.getFormat()));
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/PresentedCredential.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/PresentedCredential.java
@@ -1,0 +1,10 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+
+/**
+ * A presentation bound to its DCQL credential query after format validation.
+ */
+public record PresentedCredential(
+        String credentialQueryId, Credential credentialQuery, String encodedPresentation, SdJwtVP presentation) {}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtClaimReader.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtClaimReader.java
@@ -1,0 +1,54 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.keycloak.common.VerificationException;
+import org.keycloak.sdjwt.SdJwtUtils;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+
+/**
+ * Reads claim values from an SD-JWT presentation for DCQL satisfaction checks.
+ */
+public final class SdJwtClaimReader {
+
+    private SdJwtClaimReader() {}
+
+    public static ObjectNode disclosedClaimsRoot(SdJwtVP sdJwt) throws VerificationException {
+        Map<String, JsonNode> claims = new LinkedHashMap<>();
+        for (String disclosure : sdJwt.getDisclosuresString()) {
+            ArrayNode arrayNode = SdJwtUtils.decodeDisclosureString(disclosure);
+            if (arrayNode.size() == 3) {
+                claims.put(arrayNode.get(1).asText(), arrayNode.get(2));
+            }
+        }
+        ObjectNode root = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+        claims.forEach(root::set);
+        return root;
+    }
+
+    public static List<JsonNode> resolveClaimPath(JsonNode claimsRoot, List<String> path)
+            throws VpTokenValidationException {
+        if (path == null || path.isEmpty()) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL, "DCQL claim query is missing path");
+        }
+        return ClaimsPathProcessor.process(claimsRoot, ClaimsPathProcessor.toPathComponents(path));
+    }
+
+    public static List<JsonNode> resolveClaimPath(SdJwtVP sdJwt, List<String> path) throws VpTokenValidationException {
+        try {
+            JsonNode issuerPayload = sdJwt.getIssuerSignedJWT().getPayload();
+            ObjectNode root = ClaimsPathProcessor.credentialClaimsRoot(issuerPayload, disclosedClaimsRoot(sdJwt));
+            return resolveClaimPath(root, path);
+        } catch (VerificationException e) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.DCQL,
+                    "Failed to read disclosed claims from SD-JWT presentation",
+                    e);
+        }
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtPresentationRequirements.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtPresentationRequirements.java
@@ -1,0 +1,91 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_ISSUER;
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.keycloak.common.VerificationException;
+import org.keycloak.sdjwt.consumer.PresentationRequirements;
+
+/**
+ * Presentation requirements for SD-JWT format validation (OpenID4VP §8.6) using the same
+ * DCQL §7.1 path resolution as {@link DcqlSatisfactionValidator}.
+ */
+public final class SdJwtPresentationRequirements implements PresentationRequirements {
+
+    private static final Pattern ANY_VALUE = Pattern.compile(".*");
+
+    private final List<List<String>> requiredPaths;
+    private final Pattern vctPattern;
+    private final Pattern issPattern;
+
+    private SdJwtPresentationRequirements(List<List<String>> requiredPaths, Pattern vctPattern, Pattern issPattern) {
+        this.requiredPaths = List.copyOf(requiredPaths);
+        this.vctPattern = vctPattern;
+        this.issPattern = issPattern;
+    }
+
+    public static PresentationRequirements forCredential(
+            SdJwtAuthRequirements authRequirements, Credential credentialQuery) {
+        List<List<String>> paths = new ArrayList<>();
+        authRequirements.getRequiredClaims().stream().map(List::of).forEach(paths::add);
+
+        if (credentialQuery.getClaims() != null) {
+            for (Claim claim : credentialQuery.getClaims()) {
+                if (claim.getPath() != null && !claim.getPath().isEmpty()) {
+                    paths.add(List.copyOf(claim.getPath()));
+                }
+            }
+        }
+
+        Pattern vctPattern = Pattern.compile(authRequirements.getVctPatternForCredential(credentialQuery));
+        Pattern issPattern =
+                authRequirements.isVerifyIssuerClaim() ? Pattern.compile(authRequirements.getIssuerPattern()) : null;
+
+        return new SdJwtPresentationRequirements(paths, vctPattern, issPattern);
+    }
+
+    @Override
+    public void checkIfSatisfiedBy(JsonNode claimsRoot) throws VerificationException {
+        for (List<String> path : requiredPaths) {
+            requireClaimMatches(claimsRoot, path, ANY_VALUE);
+        }
+        requireClaimMatches(claimsRoot, List.of(CLAIM_NAME_VCT), vctPattern);
+        if (issPattern != null) {
+            requireClaimMatches(claimsRoot, List.of(CLAIM_NAME_ISSUER), issPattern);
+        }
+    }
+
+    private static void requireClaimMatches(JsonNode claimsRoot, List<String> path, Pattern pattern)
+            throws VerificationException {
+        List<JsonNode> resolved;
+        try {
+            resolved = SdJwtClaimReader.resolveClaimPath(claimsRoot, path);
+        } catch (VpTokenValidationException e) {
+            throw new VerificationException(e.getMessage(), e);
+        }
+
+        if (resolved.isEmpty()) {
+            throw new VerificationException("A required field was not presented: `%s`".formatted(formatPath(path)));
+        }
+
+        for (JsonNode value : resolved) {
+            String presented = value.toString();
+            if (!pattern.matcher(presented).matches()) {
+                throw new VerificationException(String.format(
+                        "Pattern matching failed for required field: `%s`. Expected pattern: /%s/, but got: %s",
+                        formatPath(path), pattern.pattern(), presented));
+            }
+        }
+    }
+
+    private static String formatPath(List<String> path) {
+        return String.join(".", path);
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtPresentationValidator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtPresentationValidator.java
@@ -1,0 +1,105 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.ReferencedTokenValidationException;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SelfTrustedSdJwtIssuer;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
+import java.util.List;
+import org.keycloak.VCFormat;
+import org.keycloak.common.VerificationException;
+import org.keycloak.sdjwt.consumer.SdJwtPresentationConsumer;
+import org.keycloak.sdjwt.vp.KeyBindingJwtVerificationOpts;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+
+/**
+ * Format-specific validation for {@code dc+sd-jwt} presentations (OpenID4VP §8.6, Appendix B).
+ */
+public class SdJwtPresentationValidator implements PresentationFormatValidator {
+
+    private final SdJwtPresentationConsumer consumer;
+    private final ReferencedTokenValidator tokenStatusValidator;
+
+    public SdJwtPresentationValidator(StatusListJwtFetcher statusListJwtFetcher) {
+        this.consumer = new SdJwtPresentationConsumer();
+        this.tokenStatusValidator = new ReferencedTokenValidator(statusListJwtFetcher);
+    }
+
+    @Override
+    public boolean supports(Credential credentialQuery) {
+        String format = credentialQuery.getFormat();
+        return VCFormat.SD_JWT_VC.equals(format) || "dc+sd-jwt".equals(format);
+    }
+
+    @Override
+    public ValidatedPresentation validate(
+            String encodedPresentation, Credential credentialQuery, VpTokenValidationContext context)
+            throws VpTokenValidationException {
+        if (!supports(credentialQuery)) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.FORMAT,
+                    "Unsupported credential format: " + credentialQuery.getFormat());
+        }
+
+        final SdJwtVP presentation;
+        final String normalizedPresentation;
+        try {
+            normalizedPresentation = VpTokenPresentationDecoder.decodeIfBase64Url(encodedPresentation);
+            presentation = SdJwtVP.of(normalizedPresentation);
+        } catch (IllegalArgumentException e) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.STRUCTURE,
+                    "Could not parse SD-JWT VP token contained in `vp_token`",
+                    e);
+        }
+
+        SdJwtAuthRequirements authRequirements = context.authRequirements();
+        try {
+            KeyBindingJwtVerificationOpts kbJwtOpts =
+                    buildKeyBindingOptions(credentialQuery, authRequirements, context.nonce(), context.audience());
+
+            consumer.verifySdJwtPresentation(
+                    presentation,
+                    SdJwtPresentationRequirements.forCredential(authRequirements, credentialQuery),
+                    List.of(new SelfTrustedSdJwtIssuer(context.session())),
+                    authRequirements.getIssuerSignedJwtVerificationOpts(),
+                    kbJwtOpts);
+        } catch (VerificationException e) {
+            throw new VpTokenValidationException(VpTokenValidationException.Phase.FORMAT, e.getMessage(), e);
+        }
+
+        if (authRequirements.shouldEnforceRevocationStatus()) {
+            try {
+                tokenStatusValidator.validate(presentation.getIssuerSignedJWT().getPayload());
+            } catch (ReferencedTokenValidationException e) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.FORMAT, "Token status verification failed", e);
+            }
+        }
+
+        return new ValidatedPresentation(normalizedPresentation, presentation);
+    }
+
+    private static KeyBindingJwtVerificationOpts buildKeyBindingOptions(
+            Credential credentialQuery, SdJwtAuthRequirements authRequirements, String nonce, String audience)
+            throws VpTokenValidationException {
+        if (!credentialQuery.requiresCryptographicHolderBinding()) {
+            return KeyBindingJwtVerificationOpts.builder()
+                    .withKeyBindingRequired(false)
+                    .build();
+        }
+        if (nonce == null || nonce.isBlank()) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.FORMAT,
+                    "Authorization request nonce is required for cryptographic holder binding");
+        }
+        if (audience == null || audience.isBlank()) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.FORMAT,
+                    "Authorization request client_id is required for cryptographic holder binding");
+        }
+        return authRequirements.getKeyBindingJwtVerificationOpts(nonce, audience);
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenPresentationDecoder.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenPresentationDecoder.java
@@ -1,0 +1,67 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.keycloak.utils.StringUtil;
+
+/**
+ * Normalizes presentation encodings returned in a {@code vp_token}.
+ *
+ * <p>Wallets are expected to return the SD-JWT verifiable presentation in its on-the-wire compact form:
+ * an issuer-signed JWT, optional disclosures, and an optional key-binding JWT separated by {@code ~}
+ * (see SD-JWT / SD-JWT VC specs). That string already contains {@code .} segment separators and must
+ * not be base64url-decoded as a whole.
+ *
+ * <p>Some wallet implementations instead return the same compact presentation wrapped as a single
+ * base64url-encoded UTF-8 string (no {@code .} or {@code ~} in the wrapper). This decoder detects
+ * the compact SD-JWT/JWT shape first and only attempts base64url decoding when the value is not
+ * already a presentation.
+ */
+final class VpTokenPresentationDecoder {
+
+    private VpTokenPresentationDecoder() {}
+
+    /**
+     * Returns a compact SD-JWT presentation string, accepting either raw or base64url-wrapped input.
+     */
+    static String decodeIfBase64Url(String input) {
+        if (StringUtil.isBlank(input)) {
+            return input;
+        }
+
+        String trimmed = input.trim();
+        if (looksLikeSdJwtPresentation(trimmed)) {
+            return trimmed;
+        }
+
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(trimmed);
+            String decodedPresentation = new String(decoded, StandardCharsets.UTF_8);
+            if (looksLikeSdJwtPresentation(decodedPresentation)) {
+                return decodedPresentation;
+            }
+        } catch (IllegalArgumentException ignored) {
+            // Not a base64url wrapper; return the original value for downstream parse errors.
+        }
+
+        return trimmed;
+    }
+
+    /**
+     * Detects compact SD-JWT VP strings ({@code <JWT>~[<disclosures>~]<KB-JWT>}) and plain JWTs.
+     */
+    static boolean looksLikeSdJwtPresentation(String value) {
+        if (StringUtil.isBlank(value)) {
+            return false;
+        }
+        if (value.contains("~")) {
+            return looksLikeCompactJwt(value.substring(0, value.indexOf('~')));
+        }
+        return looksLikeCompactJwt(value);
+    }
+
+    private static boolean looksLikeCompactJwt(String value) {
+        String[] parts = value.split("\\.");
+        return parts.length >= 3 && !parts[0].isEmpty() && !parts[1].isEmpty() && !parts[2].isEmpty();
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenStructureValidator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenStructureValidator.java
@@ -1,0 +1,96 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Validates the {@code vp_token} container against the issued DCQL query (OpenID4VP §8.1, §8.6).
+ */
+public class VpTokenStructureValidator {
+
+    public Map<String, List<String>> validate(Map<String, List<String>> vpToken, DcqlQuery dcqlQuery)
+            throws VpTokenValidationException {
+        if (vpToken == null || vpToken.isEmpty()) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.STRUCTURE, "vp_token is missing or empty");
+        }
+        if (dcqlQuery == null
+                || dcqlQuery.getCredentials() == null
+                || dcqlQuery.getCredentials().isEmpty()) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.STRUCTURE, "Issued authorization request is missing a DCQL query");
+        }
+
+        Set<String> expectedIds = new HashSet<>();
+        for (Credential credentialQuery : dcqlQuery.getCredentials()) {
+            if (credentialQuery.getId() == null || credentialQuery.getId().isBlank()) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.STRUCTURE, "DCQL credential query is missing an id");
+            }
+            if (!expectedIds.add(credentialQuery.getId())) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.STRUCTURE,
+                        "DCQL credential query id must be unique: " + credentialQuery.getId());
+            }
+        }
+
+        for (String presentedId : vpToken.keySet()) {
+            if (!expectedIds.contains(presentedId)) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.STRUCTURE,
+                        "vp_token contains unexpected credential query id: " + presentedId);
+            }
+        }
+
+        for (Map.Entry<String, List<String>> entry : vpToken.entrySet()) {
+            validatePresentationsForCredential(entry.getKey(), entry.getValue(), dcqlQuery);
+        }
+
+        if (!DcqlQueryRules.usesCredentialSets(dcqlQuery)) {
+            DcqlQueryRules.requireAllCredentialQueriesPresent(
+                    vpToken, dcqlQuery, VpTokenValidationException.Phase.STRUCTURE);
+        } else {
+            DcqlQueryRules.validateRequiredCredentialSets(
+                    vpToken, dcqlQuery, VpTokenValidationException.Phase.STRUCTURE);
+            DcqlQueryRules.validatePresentedCredentialsWithinCredentialSets(
+                    vpToken, dcqlQuery, VpTokenValidationException.Phase.STRUCTURE);
+        }
+
+        return vpToken;
+    }
+
+    private static void validatePresentationsForCredential(
+            String credentialId, List<String> presentations, DcqlQuery dcqlQuery) throws VpTokenValidationException {
+        if (presentations == null || presentations.isEmpty()) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.STRUCTURE,
+                    "Presented vp_token map does not match DCQL credential query");
+        }
+
+        Credential credentialQuery = dcqlQuery.getCredentials().stream()
+                .filter(credential -> credentialId.equals(credential.getId()))
+                .findFirst()
+                .orElseThrow();
+
+        if (!credentialQuery.allowsMultiplePresentations() && presentations.size() != 1) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.STRUCTURE,
+                    String.format(
+                            "Presented vp_token map must contain exactly one presentation for credential"
+                                    + " query '%s'. Found: %d",
+                            credentialQuery.getId(), presentations.size()));
+        }
+
+        for (String presentation : presentations) {
+            if (presentation == null || presentation.isBlank()) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.STRUCTURE,
+                        "Could not parse SD-JWT VP token contained in `vp_token`");
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationContext.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationContext.java
@@ -1,0 +1,15 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import org.keycloak.models.KeycloakSession;
+
+/**
+ * Inputs required to validate a returned {@code vp_token} for one authorization request.
+ */
+public record VpTokenValidationContext(
+        KeycloakSession session,
+        RequestObject requestObject,
+        SdJwtAuthRequirements authRequirements,
+        String nonce,
+        String audience) {}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationException.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationException.java
@@ -1,0 +1,29 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+/**
+ * Raised when a returned {@code vp_token} or contained presentation fails verifier-side validation.
+ */
+public class VpTokenValidationException extends Exception {
+
+    public enum Phase {
+        STRUCTURE,
+        FORMAT,
+        DCQL
+    }
+
+    private final Phase phase;
+
+    public VpTokenValidationException(Phase phase, String message) {
+        super(message);
+        this.phase = phase;
+    }
+
+    public VpTokenValidationException(Phase phase, String message, Throwable cause) {
+        super(message, cause);
+        this.phase = phase;
+    }
+
+    public Phase getPhase() {
+        return phase;
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationPipeline.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationPipeline.java
@@ -1,0 +1,64 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseObject;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Verifier-side validation pipeline for returned {@code vp_token} values.
+ *
+ * <p>Order: structure → per-format checks → DCQL satisfaction (OpenID4VP §8.6).
+ */
+public class VpTokenValidationPipeline {
+
+    private final VpTokenStructureValidator structureValidator = new VpTokenStructureValidator();
+    private final PresentationFormatValidators formatValidators;
+    private final DcqlSatisfactionValidator dcqlSatisfactionValidator = new DcqlSatisfactionValidator();
+
+    public VpTokenValidationPipeline(StatusListJwtFetcher statusListJwtFetcher) {
+        this(new SdJwtPresentationValidator(statusListJwtFetcher));
+    }
+
+    VpTokenValidationPipeline(PresentationFormatValidator... validators) {
+        this.formatValidators = new PresentationFormatValidators(List.of(validators));
+    }
+
+    public VpTokenValidationResult validate(ResponseObject responseObject, VpTokenValidationContext context)
+            throws VpTokenValidationException {
+        DcqlQuery dcqlQuery = context.requestObject().getDcqlQuery();
+        Map<String, List<String>> vpTokenMap = structureValidator.validate(responseObject.getVpToken(), dcqlQuery);
+
+        Map<String, Credential> credentialsById =
+                dcqlQuery.getCredentials().stream().collect(Collectors.toMap(Credential::getId, Function.identity()));
+
+        List<PresentedCredential> presentations = new ArrayList<>();
+        for (Map.Entry<String, List<String>> entry : vpTokenMap.entrySet()) {
+            Credential credentialQuery = credentialsById.get(entry.getKey());
+            if (credentialQuery == null) {
+                throw new VpTokenValidationException(
+                        VpTokenValidationException.Phase.STRUCTURE,
+                        "vp_token contains unexpected credential query id: " + entry.getKey());
+            }
+
+            PresentationFormatValidator formatValidator = formatValidators.requireValidatorFor(credentialQuery);
+            for (String encodedPresentation : entry.getValue()) {
+                PresentationFormatValidator.ValidatedPresentation validated =
+                        formatValidator.validate(encodedPresentation, credentialQuery, context);
+                presentations.add(new PresentedCredential(
+                        credentialQuery.getId(),
+                        credentialQuery,
+                        validated.presentationString(),
+                        validated.presentation()));
+            }
+        }
+
+        dcqlSatisfactionValidator.validate(presentations, dcqlQuery);
+        return new VpTokenValidationResult(presentations);
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationResult.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationResult.java
@@ -1,0 +1,23 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import java.util.List;
+
+/**
+ * Outcome of a successful {@link VpTokenValidationPipeline} run.
+ */
+public record VpTokenValidationResult(List<PresentedCredential> presentations) {
+
+    /**
+     * Returns the sole presentation for user-login flows that authenticate with one SD-JWT VP.
+     *
+     * @throws VpTokenValidationException when more than one credential was presented after validation
+     */
+    public PresentedCredential requireSinglePresentation() throws VpTokenValidationException {
+        if (presentations.size() != 1) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.STRUCTURE,
+                    "User authentication requires exactly one presented credential, found: " + presentations.size());
+        }
+        return presentations.getFirst();
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationService.java
@@ -1,0 +1,74 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorConfigResolver;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticatorFactories;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseObject;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.utils.StringUtil;
+
+/**
+ * Facade for running the verifier-side {@code vp_token} validation pipeline.
+ */
+public class VpTokenValidationService {
+
+    private final KeycloakSession session;
+    private final AuthenticatorConfigModel authConfig;
+    private final VpTokenValidationPipeline pipeline;
+
+    private VpTokenValidationService(
+            KeycloakSession session, AuthenticatorConfigModel authConfig, StatusListJwtFetcher statusListJwtFetcher) {
+        this.session = session;
+        this.authConfig = authConfig;
+        this.pipeline = new VpTokenValidationPipeline(statusListJwtFetcher);
+    }
+
+    public static VpTokenValidationService create(KeycloakSession session) {
+        return new VpTokenValidationService(
+                session,
+                SdJwtAuthenticatorConfigResolver.resolve(session),
+                SdJwtAuthenticatorFactories.createStatusListJwtFetcher(session));
+    }
+
+    public VpTokenValidationResult validate(ResponseObject responseObject, RequestObject requestObject)
+            throws VpTokenValidationException {
+        SdJwtAuthRequirements authRequirements = new SdJwtAuthRequirements(session.getContext(), authConfig);
+
+        String audience = HolderBindingAudienceResolver.resolve(requestObject);
+        validateReplayBindingInputs(requestObject, audience);
+
+        VpTokenValidationContext context = new VpTokenValidationContext(
+                session, requestObject, authRequirements, requestObject.getNonce(), audience);
+
+        return pipeline.validate(responseObject, context);
+    }
+
+    private static void validateReplayBindingInputs(RequestObject requestObject, String audience)
+            throws VpTokenValidationException {
+        if (!requiresHolderBinding(requestObject)) {
+            return;
+        }
+        if (StringUtil.isBlank(requestObject.getNonce())) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.STRUCTURE,
+                    "Authorization request nonce is required for cryptographic holder binding");
+        }
+        if (StringUtil.isBlank(audience)) {
+            throw new VpTokenValidationException(
+                    VpTokenValidationException.Phase.STRUCTURE,
+                    "Authorization request client_id is required for cryptographic holder binding");
+        }
+    }
+
+    private static boolean requiresHolderBinding(RequestObject requestObject) {
+        if (requestObject.getDcqlQuery() == null || requestObject.getDcqlQuery().getCredentials() == null) {
+            return true;
+        }
+        return requestObject.getDcqlQuery().getCredentials().stream()
+                .anyMatch(Credential::requiresCryptographicHolderBinding);
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPBaseUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPBaseUserAuthEndpointTest.java
@@ -180,6 +180,21 @@ public abstract class OID4VPBaseUserAuthEndpointTest extends OID4VPBaseKeycloakT
     }
 
     /**
+     * Asserts that {@code vp_token} was rejected by the verifier-side validation pipeline
+     * ({@link io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation.VpTokenValidationService})
+     * before the authentication processor runs.
+     */
+    protected void assertVpTokenRejectedByValidationPipeline(
+            HttpResponse postAuthResponse, String transactionId, String expectedErrorDescription) throws Exception {
+        assertFailingAuthentication(
+                postAuthResponse,
+                transactionId,
+                HttpStatus.SC_BAD_REQUEST,
+                ProcessingError.INVALID_VP_TOKEN.getErrorString(),
+                expectedErrorDescription);
+    }
+
+    /**
      * Helper for asserting failing flows.
      */
     protected void assertFailingAuthentication(
@@ -287,16 +302,23 @@ public abstract class OID4VPBaseUserAuthEndpointTest extends OID4VPBaseKeycloakT
      */
     protected HttpResponse sendAuthorizationResponseWithVPToken(
             String sdJwtVpToken, RequestObject requestObject, TestOpts opts) throws Exception {
-        // Wrap the SD-JWT VP in an OpenID4VP response
+        return sendAuthorizationResponseWithVpTokenMap(
+                prepareVpTokenMap(sdJwtVpToken, requestObject), requestObject, opts);
+    }
+
+    /**
+     * Sends an OpenID4VP response with an explicit {@code vp_token} map (e.g. multiple presentations per id).
+     */
+    protected HttpResponse sendAuthorizationResponseWithVpTokenMap(
+            Map<String, List<String>> vpTokenMap, RequestObject requestObject, TestOpts opts) throws Exception {
         List<BasicNameValuePair> oid4vpResponse;
         if (!opts.shouldForceUnencryptedResponse()
                 && requestObject.getClientMetadata().getJwks() != null) {
-            oid4vpResponse = prepareEncryptedOpenID4VPResponse(sdJwtVpToken, requestObject);
+            oid4vpResponse = prepareEncryptedOpenID4VPResponse(vpTokenMap, requestObject);
         } else {
-            oid4vpResponse = prepareOpenID4VPResponse(sdJwtVpToken, requestObject);
+            oid4vpResponse = prepareOpenID4VPResponse(vpTokenMap, requestObject);
         }
 
-        // Send the OpenID4VP response to Keycloak
         String url = requestObject.getResponseUri();
         HttpPost httpPost = new HttpPost(url);
         httpPost.setEntity(new UrlEncodedFormEntity(oid4vpResponse));
@@ -319,33 +341,15 @@ public abstract class OID4VPBaseUserAuthEndpointTest extends OID4VPBaseKeycloakT
         return httpClient.execute(httpPost);
     }
 
-    /**
-     * Prepare the OpenID4VP response object to be sent to Keycloak.
-     *
-     * @param sdJwtVpToken  the SD-JWT verifiable presentation token
-     * @param requestObject the request object containing the DCQL query
-     */
-    private List<BasicNameValuePair> prepareOpenID4VPResponse(String sdJwtVpToken, RequestObject requestObject)
-            throws IOException {
-        // Build final-spec vp_token map keyed by DCQL credential query ID
-        var vpTokenMap = prepareVpTokenMap(sdJwtVpToken, requestObject);
-
-        // Compose the response object as form-urlencoded parameters
+    private List<BasicNameValuePair> prepareOpenID4VPResponse(
+            Map<String, List<String>> vpTokenMap, RequestObject requestObject) throws IOException {
         return new ArrayList<>(List.of(
                 new BasicNameValuePair(ResponseObject.VP_TOKEN_KEY, JsonSerialization.writeValueAsString(vpTokenMap)),
                 new BasicNameValuePair(ResponseObject.STATE_KEY, requestObject.getState())));
     }
 
-    /**
-     * Prepare an encrypted OpenID4VP response object to be sent to Keycloak.
-     *
-     * @param sdJwtVpToken  the SD-JWT verifiable presentation token
-     * @param requestObject the request object containing the DCQL query
-     */
-    private List<BasicNameValuePair> prepareEncryptedOpenID4VPResponse(String sdJwtVpToken, RequestObject requestObject)
-            throws IOException {
-        // Build final-spec vp_token map keyed by DCQL credential query ID
-        var vpTokenMap = prepareVpTokenMap(sdJwtVpToken, requestObject);
+    private List<BasicNameValuePair> prepareEncryptedOpenID4VPResponse(
+            Map<String, List<String>> vpTokenMap, RequestObject requestObject) throws IOException {
         var respMap = Map.of(ResponseObject.VP_TOKEN_KEY, vpTokenMap);
         String resp = JsonSerialization.writeValueAsString(respMap);
 
@@ -364,7 +368,7 @@ public abstract class OID4VPBaseUserAuthEndpointTest extends OID4VPBaseKeycloakT
     /**
      * Maps VP token to credential query ID.
      */
-    private Map<String, List<String>> prepareVpTokenMap(String sdJwtVpToken, RequestObject requestObject) {
+    protected Map<String, List<String>> prepareVpTokenMap(String sdJwtVpToken, RequestObject requestObject) {
         DcqlQuery dcqlQuery = requestObject.getDcqlQuery();
         Credential credentialQuery = dcqlQuery.getCredentials().getFirst();
         return Map.of(credentialQuery.getId(), List.of(sdJwtVpToken));

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointHAIPTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointHAIPTest.java
@@ -51,7 +51,6 @@ import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.util.JsonSerialization;
-import org.keycloak.utils.MediaType;
 
 /**
  * Testing compliance of the flow with requirements from the German wallet.
@@ -73,7 +72,7 @@ public class OID4VPUserAuthEndpointHAIPTest extends OID4VPBaseUserAuthEndpointTe
     public void shouldProduceValidAuthorizationRequests() throws Exception {
         AuthorizationContext authContext = requestAuthorizationRequest();
         String authRequest = authContext.getAuthorizationRequest();
-        String signedReqJwt = resolveSignedRequestObject(authRequest, "wallet-nonce-haip", null);
+        String signedReqJwt = resolveSignedRequestObject(authRequest);
         JWSInput jwsInput = new JWSInput(signedReqJwt);
         RequestObject requestObject = jwsInput.readJsonContent(RequestObject.class);
         HttpResponse requestUriResponse = resolveSignedRequestObjectResponse(authRequest);
@@ -90,14 +89,13 @@ public class OID4VPUserAuthEndpointHAIPTest extends OID4VPBaseUserAuthEndpointTe
         ResteasyUriInfo uriInfo = new ResteasyUriInfo(authRequestUri);
         String clientIdParam = uriInfo.getQueryParameters().getFirst("client_id");
         assertNotNull(clientIdParam, "client_id parameter should be present");
-        assertEquals("post", uriInfo.getQueryParameters().getFirst("request_uri_method"));
 
         // Assert client ID uses x509_hash appropriately
         ObjectNode authConfig = getAuthConfig();
         String accessCertificate = authConfig.get(ACCESS_CERTIFICATE_CONFIG).asText();
         X509Certificate cert = PemUtils.decodeCertificate(accessCertificate);
         String expectedClientId = "x509_hash:" + X509HashUtils.computeX509Hash(cert);
-        assertEquals(expectedClientId, clientIdParam, "Client ID should use x509_hash prefix");
+        assertEquals(expectedClientId, clientIdParam, "Client ID should use x509_hash scheme");
 
         // Client Identifier Prefix is conveyed through client_id.
         assertEquals(expectedClientId, requestObject.getClientId());
@@ -107,7 +105,6 @@ public class OID4VPUserAuthEndpointHAIPTest extends OID4VPBaseUserAuthEndpointTe
 
         // Request object must use configured response mode
         assertEquals(ResponseMode.DIRECT_POST_JWT, requestObject.getResponseMode());
-        assertEquals("wallet-nonce-haip", requestObject.getWalletNonce());
         assertEquals(getVerifierClientId(), new URI(requestObject.getResponseUri()).getHost());
 
         // Assert: Ensure the request object contains a DCQL query
@@ -153,6 +150,20 @@ public class OID4VPUserAuthEndpointHAIPTest extends OID4VPBaseUserAuthEndpointTe
     }
 
     @Test
+    public void shouldRejectInvalidVpTokenMapBeforeAuthenticator() throws Exception {
+        String sdJwt = sdJwtVPTestUtils.requestSdJwtCredential(VCT_CONFIG_DEFAULT, TEST_USER_HAIP);
+
+        AuthorizationContext authContext = requestAuthorizationRequest();
+        RequestObject requestObject = resolveRequestObject(authContext.getAuthorizationRequest());
+        requestObject.getDcqlQuery().getCredentials().getFirst().setId("wrong-dcql-credential-id");
+
+        HttpResponse response = sendAuthorizationResponse(
+                sdJwt, requestObject, TestOpts.getDefault().setTestUser(TEST_USER_HAIP));
+        assertVpTokenRejectedByValidationPipeline(
+                response, authContext.getTransactionId(), "vp_token contains unexpected credential query id");
+    }
+
+    @Test
     public void shouldRejectUnencryptedResponses() throws Exception {
         // Retrieve an authorization request
         AuthorizationContext authContext = requestAuthorizationRequest();
@@ -168,48 +179,6 @@ public class OID4VPUserAuthEndpointHAIPTest extends OID4VPBaseUserAuthEndpointTe
         OAuth2ErrorRepresentation errorRep = parseErrorResponse(response);
         assertEquals(OAuthErrorException.INVALID_REQUEST, errorRep.getError());
         assertTrue(errorRep.getErrorDescription().contains("Authorization context expects encrypted response"));
-    }
-
-    @Test
-    public void shouldRejectGetForPostRequestUriMethod() throws Exception {
-        AuthorizationContext authContext = requestAuthorizationRequest();
-        HttpResponse response = resolveSignedRequestObjectWithGetResponse(authContext.getAuthorizationRequest());
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusLine().getStatusCode());
-
-        OAuth2ErrorRepresentation errorRep = parseErrorResponse(response);
-        assertEquals("invalid_request_uri_method", errorRep.getError());
-        assertTrue(errorRep.getErrorDescription().contains("This request_uri requires HTTP POST"));
-    }
-
-    @Test
-    public void shouldRejectInvalidWalletMetadataFromRequestUriPost() throws Exception {
-        AuthorizationContext authContext = requestAuthorizationRequest();
-        String walletMetadata = "[]";
-
-        HttpResponse response = resolveSignedRequestObjectResponse(
-                authContext.getAuthorizationRequest(),
-                "wallet-nonce",
-                walletMetadata,
-                OID4VPUserAuthEndpoint.AUTH_REQ_JWT_MEDIA_TYPE);
-
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusLine().getStatusCode());
-        OAuth2ErrorRepresentation errorRep = parseErrorResponse(response);
-        assertEquals(OAuthErrorException.INVALID_REQUEST, errorRep.getError());
-        assertTrue(errorRep.getErrorDescription().contains("wallet_metadata is invalid"));
-    }
-
-    @Test
-    public void shouldRejectRequestUriPostWithoutRequiredAcceptHeader() throws Exception {
-        AuthorizationContext authContext = requestAuthorizationRequest();
-        String authRequest = authContext.getAuthorizationRequest();
-
-        String invalidAccept = MediaType.APPLICATION_JSON;
-        HttpResponse response = resolveSignedRequestObjectResponse(authRequest, "nonce", null, invalidAccept);
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusLine().getStatusCode());
-
-        OAuth2ErrorRepresentation errorRep = parseErrorResponse(response);
-        assertEquals(OAuthErrorException.INVALID_REQUEST, errorRep.getError());
-        assertTrue(errorRep.getErrorDescription().contains("Request URI POST must include Accept"));
     }
 
     @Test
@@ -253,6 +222,7 @@ public class OID4VPUserAuthEndpointHAIPTest extends OID4VPBaseUserAuthEndpointTe
 
     @Test
     public void shouldRejectEncryptedResponse_MalformedJwe() throws Exception {
+        // Retrieve an authorization request
         AuthorizationContext authContext = requestAuthorizationRequest();
         RequestObject requestObject = resolveRequestObject(authContext.getAuthorizationRequest());
 

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -8,13 +8,13 @@ import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.Autho
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtCredentialConstrainerTest;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContextStatus;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.ProcessingError;
@@ -26,14 +26,11 @@ import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
-import org.apache.http.HttpHeaders;
+import java.util.Map;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.message.BasicNameValuePair;
 import org.jboss.resteasy.specimpl.ResteasyUriInfo;
 import org.junit.jupiter.api.Test;
 import org.keycloak.OAuth2Constants;
@@ -69,7 +66,6 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
         ResteasyUriInfo uriInfo = new ResteasyUriInfo(authRequest);
         String clientIdParam = uriInfo.getQueryParameters().getFirst("client_id");
         assertNotNull(clientIdParam, "client_id parameter should be present");
-        assertNull(uriInfo.getQueryParameters().getFirst("request_uri_method"));
 
         // Assert full expected format
         String expectedClientId = "x509_san_dns:" + getVerifierClientId();
@@ -177,22 +173,6 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
         OAuth2ErrorRepresentation errorRep = parseErrorResponse(response);
         assertEquals(
                 "Authorization context not found for request ID: unknown-request-uri", errorRep.getErrorDescription());
-    }
-
-    @Test
-    public void shouldRejectRequestUriPost_WhenMethodIsNotPost() throws Exception {
-        AuthorizationContext authContext = requestAuthorizationRequest();
-        String authRequest = authContext.getAuthorizationRequest();
-        String requestUri = getRequiredQueryParam(authRequest, "request_uri");
-
-        HttpPost httpPost = new HttpPost(requestUri);
-        httpPost.setHeader(HttpHeaders.ACCEPT, OID4VPUserAuthEndpoint.AUTH_REQ_JWT_MEDIA_TYPE);
-        httpPost.setEntity(new UrlEncodedFormEntity(List.of(new BasicNameValuePair("wallet_nonce", "nonce"))));
-        HttpResponse response = httpClient.execute(httpPost);
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusLine().getStatusCode());
-
-        OAuth2ErrorRepresentation errorRep = parseErrorResponse(response);
-        assertEquals("invalid_request_uri_method", errorRep.getError());
     }
 
     @Test
@@ -441,6 +421,44 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
     }
 
     @Test
+    public void shouldRejectInvalidVpTokenMapBeforeAuthenticator() throws Exception {
+        String sdJwt = sdJwtVPTestUtils.requestSdJwtCredential(VCT_CONFIG_DEFAULT, TEST_USER);
+
+        AuthorizationContext authContext = requestAuthorizationRequest();
+        RequestObject requestObject = resolveRequestObject(authContext.getAuthorizationRequest());
+        requestObject.getDcqlQuery().getCredentials().getFirst().setId("wrong-dcql-credential-id");
+
+        HttpResponse response = sendAuthorizationResponse(sdJwt, requestObject, TestOpts.getDefault());
+        assertVpTokenRejectedByValidationPipeline(
+                response, authContext.getTransactionId(), "vp_token contains unexpected credential query id");
+    }
+
+    @Test
+    public void shouldSetVpTokenValidatedKeyBeforeAuthenticator() throws Exception {
+        String sdJwt = sdJwtVPTestUtils.requestSdJwtCredential(VCT_CONFIG_DEFAULT, TEST_USER);
+        testSuccessfulAuthentication(sdJwt, TestOpts.getDefault());
+    }
+
+    @Test
+    public void shouldRejectMultiplePresentationsForUserLogin() throws Exception {
+        String sdJwt = sdJwtVPTestUtils.requestSdJwtCredential(VCT_CONFIG_DEFAULT, TEST_USER);
+
+        AuthorizationContext authContext = requestAuthorizationRequest();
+        RequestObject requestObject = resolveRequestObject(authContext.getAuthorizationRequest());
+        Credential credentialQuery =
+                requestObject.getDcqlQuery().getCredentials().getFirst();
+
+        String sdJwtVpToken = sdJwtVPTestUtils.presentSdJwt(
+                sdJwt, requestObject.getNonce(), requestObject.getClientId(), SdJwtVPTestUtils.getUserJwk());
+        Map<String, List<String>> vpTokenMap = Map.of(credentialQuery.getId(), List.of(sdJwtVpToken, sdJwtVpToken));
+
+        HttpResponse response =
+                sendAuthorizationResponseWithVpTokenMap(vpTokenMap, requestObject, TestOpts.getDefault());
+        assertVpTokenRejectedByValidationPipeline(
+                response, authContext.getTransactionId(), "must contain exactly one presentation for credential query");
+    }
+
+    @Test
     public void shouldFailAuthentication_NonMatchingDcqlCredentialId() throws Exception {
         // Request a valid SD-JWT credential from Keycloak to use for authentication
         String sdJwt = sdJwtVPTestUtils.requestSdJwtCredential(VCT_CONFIG_DEFAULT, TEST_USER);
@@ -456,7 +474,7 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
                 authContext.getTransactionId(),
                 HttpStatus.SC_BAD_REQUEST,
                 ProcessingError.INVALID_VP_TOKEN.getErrorString(),
-                "Presented vp_token map does not match DCQL credential query");
+                "vp_token contains unexpected credential query id");
     }
 
     @Test

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/stub/CustomSdJwtAuthenticatorFactory.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/stub/CustomSdJwtAuthenticatorFactory.java
@@ -28,9 +28,13 @@ public class CustomSdJwtAuthenticatorFactory extends SdJwtAuthenticatorFactory {
     }
 
     @Override
+    public StatusListJwtFetcher createStatusListJwtFetcher(KeycloakSession session) {
+        return new MockTrustedStatusListJwtFetcher(session);
+    }
+
+    @Override
     public Authenticator create(KeycloakSession session) {
-        StatusListJwtFetcher httpFetcher = new MockTrustedStatusListJwtFetcher(session);
-        return new SdJwtAuthenticator(httpFetcher);
+        return new SdJwtAuthenticator();
     }
 
     public static class MockTrustedStatusListJwtFetcher extends TrustedStatusListJwtFetcher {
@@ -57,7 +61,7 @@ public class CustomSdJwtAuthenticatorFactory extends SdJwtAuthenticatorFactory {
             return exampleStatusListJwt(String.format("/tokenstatus/%s.txt", resource));
         }
 
-        public static String exampleStatusListJwt(String filename) {
+        static String exampleStatusListJwt(String filename) {
             try (InputStream stream = CustomSdJwtAuthenticatorFactory.class.getResourceAsStream(filename)) {
                 if (stream == null) {
                     throw new IllegalArgumentException("Resource not found: " + filename);

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/ClaimsPathProcessorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/ClaimsPathProcessorTest.java
@@ -1,0 +1,36 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ClaimsPathProcessorTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void selectsNestedClaim() throws Exception {
+        ObjectNode root = MAPPER.createObjectNode();
+        ObjectNode address = root.putObject("address");
+        address.put("street_address", "42 Market Street");
+
+        var selected = ClaimsPathProcessor.process(root, List.of("address", "street_address"));
+
+        assertEquals(1, selected.size());
+        assertEquals("42 Market Street", selected.getFirst().asText());
+    }
+
+    @Test
+    void returnsEmptyWhenPathMissing() throws Exception {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("name", "Arthur Dent");
+
+        var selected = ClaimsPathProcessor.process(root, List.of("address", "street_address"));
+
+        assertTrue(selected.isEmpty());
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlClaimValuesTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlClaimValuesTest.java
@@ -1,0 +1,42 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DcqlClaimValuesTest {
+
+    @Test
+    void matchesStringValue() {
+        List<JsonNode> resolved = List.of(JsonNodeFactory.instance.textNode("alice"));
+
+        assertTrue(DcqlClaimValues.matchesAny(resolved, List.of("alice")));
+        assertFalse(DcqlClaimValues.matchesAny(resolved, List.of("bob")));
+    }
+
+    @Test
+    void matchesBooleanValue() {
+        List<JsonNode> resolved = List.of(JsonNodeFactory.instance.booleanNode(true));
+
+        assertTrue(DcqlClaimValues.matchesAny(resolved, List.of(true)));
+        assertFalse(DcqlClaimValues.matchesAny(resolved, List.of(false)));
+    }
+
+    @Test
+    void matchesIntegerValue() {
+        List<JsonNode> resolved = List.of(JsonNodeFactory.instance.numberNode(42));
+
+        assertTrue(DcqlClaimValues.matchesAny(resolved, List.of(42)));
+        assertFalse(DcqlClaimValues.matchesAny(resolved, List.of(7)));
+    }
+
+    @Test
+    void doesNotCoerceStringConstraintToOtherJsonTypes() {
+        assertFalse(DcqlClaimValues.matchesAny(List.of(JsonNodeFactory.instance.booleanNode(true)), List.of("true")));
+        assertFalse(DcqlClaimValues.matchesAny(List.of(JsonNodeFactory.instance.numberNode(42)), List.of("42")));
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlSatisfactionValidatorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/DcqlSatisfactionValidatorTest.java
@@ -1,0 +1,90 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.keycloak.VCFormat;
+import org.keycloak.sdjwt.IssuerSignedJWT;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+
+class DcqlSatisfactionValidatorTest {
+
+    private final DcqlSatisfactionValidator validator = new DcqlSatisfactionValidator();
+
+    @Test
+    void rejectsClaimWhenValuesDoNotMatch() {
+        Credential credentialQuery = credentialWithClaim("username", List.of("alice"));
+        SdJwtVP presentation = mockPresentationWithClaim("username", "bob");
+
+        PresentedCredential presented = new PresentedCredential("cred-1", credentialQuery, "vp", presentation);
+
+        assertThrows(
+                VpTokenValidationException.class,
+                () -> validator.validate(List.of(presented), queryWithCredentials(credentialQuery)));
+    }
+
+    @Test
+    void acceptsClaimWhenValuesMatch() {
+        Credential credentialQuery = credentialWithClaim("username", List.of("alice"));
+        SdJwtVP presentation = mockPresentationWithClaim("username", "alice");
+
+        PresentedCredential presented = new PresentedCredential("cred-1", credentialQuery, "vp", presentation);
+
+        assertDoesNotThrow(() -> validator.validate(List.of(presented), queryWithCredentials(credentialQuery)));
+    }
+
+    @Test
+    void acceptsClaimWhenBooleanValuesMatch() {
+        Credential credentialQuery = credentialWithClaim("adult", List.of(true));
+        SdJwtVP presentation = mockPresentationWithClaim("adult", true);
+
+        PresentedCredential presented = new PresentedCredential("cred-1", credentialQuery, "vp", presentation);
+
+        assertDoesNotThrow(() -> validator.validate(List.of(presented), queryWithCredentials(credentialQuery)));
+    }
+
+    private static DcqlQuery queryWithCredentials(Credential credential) {
+        DcqlQuery query = new DcqlQuery();
+        query.setCredentials(List.of(credential));
+        return query;
+    }
+
+    private static Credential credentialWithClaim(String claimName, List<Object> values) {
+        Claim claim = new Claim();
+        claim.setPath(List.of(claimName));
+        claim.setValues(values);
+
+        Credential credential = new Credential();
+        credential.setId("cred-1");
+        credential.setFormat(VCFormat.SD_JWT_VC);
+        credential.setMeta(new Meta());
+        credential.getMeta().setVctValues(List.of("https://example.com/vct"));
+        credential.setClaims(List.of(claim));
+        return credential;
+    }
+
+    private static SdJwtVP mockPresentationWithClaim(String claimName, Object claimValue) {
+        SdJwtVP presentation = mock(SdJwtVP.class);
+        IssuerSignedJWT issuerSignedJwt = mock(IssuerSignedJWT.class);
+        var payload = JsonNodeFactory.instance.objectNode();
+        payload.put("vct", "https://example.com/vct");
+        if (claimValue instanceof Boolean booleanValue) {
+            payload.put(claimName, booleanValue);
+        } else {
+            payload.put(claimName, String.valueOf(claimValue));
+        }
+        when(presentation.getIssuerSignedJWT()).thenReturn(issuerSignedJwt);
+        when(issuerSignedJwt.getPayload()).thenReturn(payload);
+        when(presentation.getDisclosuresString()).thenReturn(List.of());
+        return presentation;
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/HolderBindingAudienceResolverTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/HolderBindingAudienceResolverTest.java
@@ -1,0 +1,30 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import org.junit.jupiter.api.Test;
+
+class HolderBindingAudienceResolverTest {
+
+    @Test
+    void usesFullClientIdentifierIncludingPrefix() {
+        RequestObject request = new RequestObject().setClientId("redirect_uri:https://verifier.example.org/cb");
+
+        assertEquals("redirect_uri:https://verifier.example.org/cb", HolderBindingAudienceResolver.resolve(request));
+    }
+
+    @Test
+    void preservesOriginPrefixedClientIdentifier() {
+        RequestObject request = new RequestObject().setClientId("origin:https://verifier.example.org");
+
+        assertEquals("origin:https://verifier.example.org", HolderBindingAudienceResolver.resolve(request));
+    }
+
+    @Test
+    void derivesOriginAudienceFromResponseUriWhenClientIdMissing() {
+        RequestObject request = new RequestObject().setResponseUri("https://verifier.example.org/openid4vp/response");
+
+        assertEquals("origin:https://verifier.example.org", HolderBindingAudienceResolver.resolve(request));
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtPresentationRequirementsTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/SdJwtPresentationRequirementsTest.java
@@ -1,0 +1,62 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.VCFormat;
+import org.keycloak.common.VerificationException;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.sdjwt.consumer.PresentationRequirements;
+
+class SdJwtPresentationRequirementsTest {
+
+    @Test
+    void requiresNestedDcqlPathNotOnlyLeafName() throws Exception {
+        Claim claim = new Claim();
+        claim.setPath(List.of("address", "street_address"));
+
+        Credential credential = new Credential();
+        credential.setId("cred-1");
+        credential.setFormat(VCFormat.SD_JWT_VC);
+        credential.setMeta(new Meta());
+        credential.getMeta().setVctValues(List.of("https://example.com/vct"));
+        credential.setClaims(List.of(claim));
+
+        SdJwtAuthRequirements authRequirements = mock(SdJwtAuthRequirements.class);
+        when(authRequirements.getRequiredClaims()).thenReturn(List.of(JsonWebToken.SUBJECT, OAuth2Constants.USERNAME));
+        when(authRequirements.getVctPatternForCredential(credential))
+                .thenReturn(Pattern.quote("\"https://example.com/vct\""));
+        when(authRequirements.isVerifyIssuerClaim()).thenReturn(false);
+
+        PresentationRequirements requirements =
+                SdJwtPresentationRequirements.forCredential(authRequirements, credential);
+
+        var flatClaims = JsonNodeFactory.instance.objectNode();
+        flatClaims.put("street_address", "42 Market Street");
+        flatClaims.put("vct", "https://example.com/vct");
+        flatClaims.put("sub", "user-1");
+        flatClaims.put("username", "alice");
+
+        assertThrows(VerificationException.class, () -> requirements.checkIfSatisfiedBy(flatClaims));
+
+        var nestedClaims = JsonNodeFactory.instance.objectNode();
+        var address = nestedClaims.putObject("address");
+        address.put("street_address", "42 Market Street");
+        nestedClaims.put("vct", "https://example.com/vct");
+        nestedClaims.put("sub", "user-1");
+        nestedClaims.put("username", "alice");
+
+        assertDoesNotThrow(() -> requirements.checkIfSatisfiedBy(nestedClaims));
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenPresentationDecoderTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenPresentationDecoderTest.java
@@ -1,0 +1,37 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+class VpTokenPresentationDecoderTest {
+
+    private static final String RAW_SD_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature~disclosure";
+
+    @Test
+    void returnsRawSdJwtWithoutDecoding() {
+        assertEquals(RAW_SD_JWT, VpTokenPresentationDecoder.decodeIfBase64Url(RAW_SD_JWT));
+    }
+
+    @Test
+    void decodesBase64UrlWrappedPresentation() {
+        String wrapped = Base64.getUrlEncoder().encodeToString(RAW_SD_JWT.getBytes(StandardCharsets.UTF_8));
+        assertEquals(RAW_SD_JWT, VpTokenPresentationDecoder.decodeIfBase64Url(wrapped));
+    }
+
+    @Test
+    void detectsCompactJwtShape() {
+        assertTrue(VpTokenPresentationDecoder.looksLikeSdJwtPresentation(RAW_SD_JWT));
+        assertFalse(VpTokenPresentationDecoder.looksLikeSdJwtPresentation("not-a-jwt"));
+    }
+
+    @Test
+    void leavesNonJwtInputUntouchedWhenNotWrapped() {
+        String invalid = "not-a-jwt-or-wrapper";
+        assertEquals(invalid, VpTokenPresentationDecoder.decodeIfBase64Url(invalid));
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenStructureValidatorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenStructureValidatorTest.java
@@ -1,0 +1,133 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.CredentialSet;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.keycloak.VCFormat;
+
+class VpTokenStructureValidatorTest {
+
+    private final VpTokenStructureValidator validator = new VpTokenStructureValidator();
+
+    @Test
+    void acceptsMatchingVpToken() throws Exception {
+        DcqlQuery query = singleCredentialQuery("cred-1", false);
+        Map<String, List<String>> vpToken = Map.of("cred-1", List.of("eyJhbGciOiJIUzI1NiJ9.abc.def"));
+
+        Map<String, List<String>> validated = validator.validate(vpToken, query);
+        assertEquals(vpToken, validated);
+    }
+
+    @Test
+    void acceptsAlternativeCredentialSetOption() throws Exception {
+        Credential credA = credential("cred-a", false);
+        Credential credB = credential("cred-b", false);
+
+        CredentialSet credentialSet = new CredentialSet();
+        credentialSet.setOptions(List.of(List.of("cred-a"), List.of("cred-b")));
+
+        DcqlQuery query = new DcqlQuery();
+        query.setCredentials(List.of(credA, credB));
+        query.setCredentialSets(List.of(credentialSet));
+
+        Map<String, List<String>> vpToken = Map.of("cred-b", List.of("vp"));
+
+        Map<String, List<String>> validated = validator.validate(vpToken, query);
+        assertEquals(vpToken, validated);
+    }
+
+    @Test
+    void rejectsUnexpectedCredentialId() {
+        DcqlQuery query = singleCredentialQuery("cred-1", false);
+        Map<String, List<String>> vpToken = Map.of("cred-1", List.of("vp"), "extra-id", List.of("vp2"));
+
+        VpTokenValidationException error =
+                assertThrows(VpTokenValidationException.class, () -> validator.validate(vpToken, query));
+
+        assertEquals(VpTokenValidationException.Phase.STRUCTURE, error.getPhase());
+    }
+
+    @Test
+    void rejectsMissingCredentialIdWhenNoCredentialSets() {
+        DcqlQuery query = singleCredentialQuery("cred-1", false);
+        Map<String, List<String>> vpToken = Map.of("other-id", List.of("vp"));
+
+        assertThrows(VpTokenValidationException.class, () -> validator.validate(vpToken, query));
+    }
+
+    @Test
+    void rejectsMissingRequiredCredentialSetOption() {
+        Credential credA = credential("cred-a", false);
+        Credential credB = credential("cred-b", false);
+
+        CredentialSet credentialSet = new CredentialSet();
+        credentialSet.setOptions(List.of(List.of("cred-a", "cred-b")));
+
+        DcqlQuery query = new DcqlQuery();
+        query.setCredentials(List.of(credA, credB));
+        query.setCredentialSets(List.of(credentialSet));
+
+        Map<String, List<String>> vpToken = Map.of("cred-a", List.of("vp"));
+
+        assertThrows(VpTokenValidationException.class, () -> validator.validate(vpToken, query));
+    }
+
+    @Test
+    void rejectsCredentialOutsideSatisfiedCredentialSets() {
+        Credential credA = credential("cred-a", false);
+        Credential credB = credential("cred-b", false);
+        Credential credC = credential("cred-c", false);
+
+        CredentialSet credentialSet = new CredentialSet();
+        credentialSet.setOptions(List.of(List.of("cred-a"), List.of("cred-b")));
+
+        DcqlQuery query = new DcqlQuery();
+        query.setCredentials(List.of(credA, credB, credC));
+        query.setCredentialSets(List.of(credentialSet));
+
+        Map<String, List<String>> vpToken = Map.of(
+                "cred-a", List.of("vp"),
+                "cred-c", List.of("vp2"));
+
+        VpTokenValidationException error =
+                assertThrows(VpTokenValidationException.class, () -> validator.validate(vpToken, query));
+
+        assertEquals(VpTokenValidationException.Phase.STRUCTURE, error.getPhase());
+        assertTrue(error.getMessage().contains("outside satisfied DCQL credential_sets"));
+    }
+
+    @Test
+    void rejectsMultiplePresentationsWhenNotAllowed() {
+        Credential credential = credential("cred-1", false);
+
+        DcqlQuery query = new DcqlQuery();
+        query.setCredentials(List.of(credential));
+
+        Map<String, List<String>> vpToken = Map.of("cred-1", List.of("vp1", "vp2"));
+
+        assertThrows(VpTokenValidationException.class, () -> validator.validate(vpToken, query));
+    }
+
+    private static DcqlQuery singleCredentialQuery(String id, boolean multiple) {
+        Credential credential = credential(id, multiple);
+
+        DcqlQuery query = new DcqlQuery();
+        query.setCredentials(List.of(credential));
+        return query;
+    }
+
+    private static Credential credential(String id, boolean multiple) {
+        Credential credential = new Credential();
+        credential.setId(id);
+        credential.setFormat(VCFormat.SD_JWT_VC);
+        credential.setMultiple(multiple);
+        return credential;
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationPipelineTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationPipelineTest.java
@@ -1,0 +1,127 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseObject;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.keycloak.VCFormat;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.util.JsonSerialization;
+
+class VpTokenValidationPipelineTest {
+
+    private final VpTokenValidationPipeline pipeline =
+            new VpTokenValidationPipeline(new SdJwtPresentationValidator(mock(StatusListJwtFetcher.class)));
+
+    @Test
+    void rejectsUnsupportedCredentialFormat() throws Exception {
+        Credential credential = new Credential();
+        credential.setId("cred-1");
+        credential.setFormat("jwt_vc_json");
+
+        DcqlQuery dcqlQuery = new DcqlQuery();
+        dcqlQuery.setCredentials(List.of(credential));
+
+        RequestObject requestObject =
+                new RequestObject().setDcqlQuery(dcqlQuery).setNonce("nonce").setClientId("client");
+
+        ResponseObject responseObject = responseWithVpToken(Map.of("cred-1", List.of("not-a-real-vp")));
+
+        VpTokenValidationException error = assertThrows(
+                VpTokenValidationException.class,
+                () -> pipeline.validate(responseObject, validationContext(requestObject)));
+
+        assertEquals(VpTokenValidationException.Phase.FORMAT, error.getPhase());
+        assertEquals("Unsupported credential format: jwt_vc_json", error.getMessage());
+    }
+
+    @Test
+    void requireSinglePresentationRejectsMultipleValidatedCredentials() throws Exception {
+        PresentationFormatValidator acceptingValidator = new PresentationFormatValidator() {
+            @Override
+            public boolean supports(Credential credentialQuery) {
+                return true;
+            }
+
+            @Override
+            public ValidatedPresentation validate(
+                    String encodedPresentation, Credential credentialQuery, VpTokenValidationContext context) {
+                return new ValidatedPresentation(encodedPresentation, null);
+            }
+        };
+
+        var pipeline = new VpTokenValidationPipeline(acceptingValidator);
+        Credential credential = credential("cred-1");
+        credential.setMultiple(true);
+
+        DcqlQuery dcqlQuery = new DcqlQuery();
+        dcqlQuery.setCredentials(List.of(credential));
+
+        RequestObject requestObject =
+                new RequestObject().setDcqlQuery(dcqlQuery).setNonce("nonce").setClientId("client");
+
+        ResponseObject responseObject = responseWithVpToken(Map.of("cred-1", List.of("vp-1", "vp-2")));
+        VpTokenValidationResult result = pipeline.validate(responseObject, validationContext(requestObject));
+
+        VpTokenValidationException error =
+                assertThrows(VpTokenValidationException.class, result::requireSinglePresentation);
+
+        assertEquals(VpTokenValidationException.Phase.STRUCTURE, error.getPhase());
+        assertEquals("User authentication requires exactly one presented credential, found: 2", error.getMessage());
+    }
+
+    @Test
+    void validatesOnlyPresentedCredentialsWhenCredentialSetsAllowAlternatives() throws Exception {
+        Credential credA = credential("cred-a");
+        Credential credB = credential("cred-b");
+
+        DcqlQuery dcqlQuery = new DcqlQuery();
+        dcqlQuery.setCredentials(List.of(credA, credB));
+        dcqlQuery.setCredentialSets(List.of(credentialSet(List.of(List.of("cred-a"), List.of("cred-b")))));
+
+        RequestObject requestObject =
+                new RequestObject().setDcqlQuery(dcqlQuery).setNonce("nonce").setClientId("client");
+
+        ResponseObject responseObject = responseWithVpToken(Map.of("cred-b", List.of("not-a-real-vp")));
+
+        // Structure passes; format validation fails on unparseable VP — proves no NPE on missing cred-a.
+        VpTokenValidationException error = assertThrows(
+                VpTokenValidationException.class,
+                () -> pipeline.validate(responseObject, validationContext(requestObject)));
+
+        assertEquals(VpTokenValidationException.Phase.STRUCTURE, error.getPhase());
+    }
+
+    private static ResponseObject responseWithVpToken(Map<String, List<String>> vpToken) throws Exception {
+        return new ResponseObject(JsonSerialization.writeValueAsString(vpToken), "state");
+    }
+
+    private static VpTokenValidationContext validationContext(RequestObject requestObject) {
+        KeycloakSession session = mock(KeycloakSession.class);
+        SdJwtAuthRequirements authRequirements = mock(SdJwtAuthRequirements.class);
+        return new VpTokenValidationContext(session, requestObject, authRequirements, "nonce", "client");
+    }
+
+    private static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.CredentialSet credentialSet(
+            List<List<String>> options) {
+        var credentialSet = new io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.CredentialSet();
+        credentialSet.setOptions(options);
+        return credentialSet;
+    }
+
+    private static Credential credential(String id) {
+        Credential credential = new Credential();
+        credential.setId(id);
+        credential.setFormat(VCFormat.SD_JWT_VC);
+        return credential;
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationResultTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/validation/VpTokenValidationResultTest.java
@@ -1,0 +1,23 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class VpTokenValidationResultTest {
+
+    @Test
+    void requireSinglePresentationRejectsMultipleCredentials() {
+        var result =
+                new VpTokenValidationResult(List.of(mock(PresentedCredential.class), mock(PresentedCredential.class)));
+
+        VpTokenValidationException error =
+                assertThrows(VpTokenValidationException.class, result::requireSinglePresentation);
+
+        assertEquals(VpTokenValidationException.Phase.STRUCTURE, error.getPhase());
+        assertEquals("User authentication requires exactly one presented credential, found: 2", error.getMessage());
+    }
+}


### PR DESCRIPTION
This PR wires the verifier-side `vp_token` validation pipeline into the OpenID4VP login path and limits `SdJwtAuthenticator` to user resolution after validation (OpenID4VP §8.6, §14.9). 

Depends on PR 1 (DCQL model + satisfaction): #94  and PR 2 (SD-JWT format validator): #95. This PR orchestrates those pieces and connects them to `AuthorizationResponseService`.

## Review note

Nonce/aud replay protection and upstream `SdJwtPresentationConsumer` are not removed. They run in `SdJwtPresentationValidator` (PR 2) inside `VpTokenValidationPipeline`, before `AuthenticationProcessor.authenticateOnly()`. `SdJwtAuthenticator` only resolves the presenting user and requires `VP_TOKEN_VALIDATED_KEY` after the pipeline succeeds.

## What's included

### Pipeline (`validation`)

- `VpTokenStructureValidator` — `vp_token` map shape and credential ids
- `VpTokenValidationPipeline` — structure → format → DCQL
- `VpTokenValidationService` — builds validation context (`nonce`, audience, auth config) and runs the pipeline
- `VpTokenValidationResult` — `requireSinglePresentation()` for the one-credential login flow

### Login integration

- `AuthorizationResponseService` — runs the pipeline before auth; sets `VP_TOKEN_VALIDATED_KEY`
- `SdJwtAuthenticator` — user lookup only; fails closed without the pipeline marker
- `SdJwtAuthenticatorFactory` — stateless authenticator; `createStatusListJwtFetcher()` used by the pipeline
- `SdJwtAuthenticatorConfigResolver` — shared authenticator config for the pipeline and endpoint

### Tests

- `VpTokenStructureValidatorTest`, `VpTokenValidationPipelineTest`, `VpTokenValidationResultTest`
- `OID4VPUserAuthEndpointTest` — invalid `vp_token` rejected before the authenticator; successful login unchanged
- `OID4VPBaseUserAuthEndpointTest` — helpers for pipeline rejection and explicit `vp_token` maps
