### PR TITLE
Add stable subject ID to claim set in WalletPresentationService

### DIFF
--- a/demo/lib/WalletPresentationService.java
+++ b/demo/lib/WalletPresentationService.java
@@ -36,7 +36,6 @@ public final class WalletPresentationService {
         ObjectNode claimSet = JsonSerialization.mapper.createObjectNode();
         claimSet.put(OAuth2Constants.ISSUER, cfg.issuer());
         claimSet.put("vct", cfg.vct());
-        // DCQL requires sub (see SdJwtAuthRequirements); tests use username + "-id" as a stable subject id.
         claimSet.put(JsonWebToken.SUBJECT, scenario.username(cfg) + "-id");
         claimSet.put(OAuth2Constants.USERNAME, scenario.username(cfg));
         claimSet.put("iat", now);

--- a/demo/lib/WalletPresentationService.java
+++ b/demo/lib/WalletPresentationService.java
@@ -36,6 +36,8 @@ public final class WalletPresentationService {
         ObjectNode claimSet = JsonSerialization.mapper.createObjectNode();
         claimSet.put(OAuth2Constants.ISSUER, cfg.issuer());
         claimSet.put("vct", cfg.vct());
+        // DCQL requires sub (see SdJwtAuthRequirements); tests use username + "-id" as a stable subject id.
+        claimSet.put(JsonWebToken.SUBJECT, scenario.username(cfg) + "-id");
         claimSet.put(OAuth2Constants.USERNAME, scenario.username(cfg));
         claimSet.put("iat", now);
         claimSet.put("exp", now + scenario.expirationOffsetSeconds(ISSUER_SIGNED_JWT_LIFESPAN_SECS));


### PR DESCRIPTION
Why testing, I came across this issue

<img width="1615" height="130" alt="image" src="https://github.com/user-attachments/assets/652c47aa-6e20-4740-bba0-311c373fb772" />

Which has been addressed in this PR by updating the WalletPresentationService under the /demo directory