### PR TITLE
fix(oid4vp): complete SD-JWT DCQL query-criteria validation for VP token

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/ClaimPathResolver.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/ClaimPathResolver.java
@@ -15,14 +15,6 @@ public final class ClaimPathResolver {
 
     private ClaimPathResolver() {}
 
-    public static boolean isPresentInJson(JsonNode root, List<String> path) {
-        return !resolveInJson(root, path).isEmpty();
-    }
-
-    public static boolean isPresentInSdJwt(SdJwtVP sdJwt, List<String> path) {
-        return !resolveInSdJwt(sdJwt, path).isEmpty();
-    }
-
     public static List<JsonNode> resolveInSdJwt(SdJwtVP sdJwt, List<String> path) {
         if (path == null || path.isEmpty()) {
             return List.of();

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/ClaimPathResolver.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/ClaimPathResolver.java
@@ -2,6 +2,7 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.util.ArrayList;
 import java.util.List;
 import org.keycloak.common.VerificationException;
 import org.keycloak.sdjwt.SdJwtUtils;
@@ -9,59 +10,129 @@ import org.keycloak.sdjwt.vp.SdJwtVP;
 
 /**
  * Resolves DCQL claim paths for presentation validation (VC root, not VP wrapper).
- *
- * <p><strong>Scope:</strong> Only JSON object property names ({@code List<String>} segments) are
- * supported. OpenID4VP 1.0 Claims Path Pointers for JSON credentials also allow {@code null} array
- * wildcards and non-negative integer array indexes; those are not modeled or resolved here yet.
  */
 public final class ClaimPathResolver {
 
     private ClaimPathResolver() {}
 
-    public static boolean isPresentInJson(JsonNode root, List<String> path) {
-        return isPresent(resolveInPayload(root, path));
+    public static boolean isPresentInJson(JsonNode root, List<Object> path) {
+        return !resolveInJson(root, path).isEmpty();
     }
 
-    public static boolean isPresentInSdJwt(SdJwtVP sdJwt, List<String> path) {
+    public static boolean isPresentInSdJwt(SdJwtVP sdJwt, List<Object> path) {
+        return !resolveInSdJwt(sdJwt, path).isEmpty();
+    }
+
+    public static List<JsonNode> resolveInSdJwt(SdJwtVP sdJwt, List<Object> path) {
         if (path == null || path.isEmpty()) {
-            return false;
+            return List.of();
         }
 
-        JsonNode resolved = resolveInPayload(sdJwt.getIssuerSignedJWT().getPayload(), path);
-        if (isPresent(resolved)) {
-            return true;
+        List<JsonNode> resolved = resolveInJson(sdJwt.getIssuerSignedJWT().getPayload(), path);
+        if (!resolved.isEmpty()) {
+            return resolved;
         }
 
-        if (path.size() == 1) {
-            return hasDisclosedClaim(sdJwt, path.getFirst());
-        }
-
-        return false;
-    }
-
-    private static JsonNode resolveInPayload(JsonNode root, List<String> path) {
-        JsonNode current = root;
-        for (String segment : path) {
-            if (current == null || current.isNull()) {
-                return null;
+        if (path.size() == 1 && path.getFirst() instanceof String claimName) {
+            JsonNode disclosedClaim = findDisclosedClaim(sdJwt, claimName);
+            if (isPresent(disclosedClaim)) {
+                return List.of(disclosedClaim);
             }
-            current = current.get(segment);
         }
-        return current;
+
+        return List.of();
     }
 
-    private static boolean hasDisclosedClaim(SdJwtVP sdJwt, String claimName) {
-        for (String disclosure : sdJwt.getDisclosuresString()) {
-            try {
-                ArrayNode arrayNode = SdJwtUtils.decodeDisclosureString(disclosure);
-                if (arrayNode.size() == 3 && arrayNode.get(1).asText().equals(claimName)) {
-                    return isPresent(arrayNode.get(2));
+    static List<JsonNode> resolveInJson(JsonNode root, List<Object> path) {
+        if (root == null || path == null || path.isEmpty()) {
+            return List.of();
+        }
+
+        List<JsonNode> selected = List.of(root);
+        for (Object segment : path) {
+            selected = resolvePathSegment(selected, segment);
+            if (selected.isEmpty()) {
+                return List.of();
+            }
+        }
+        return selected;
+    }
+
+    private static List<JsonNode> resolvePathSegment(List<JsonNode> selected, Object segment) {
+        if (segment instanceof String key) {
+            List<JsonNode> next = new ArrayList<>();
+            for (JsonNode node : selected) {
+                if (!node.isObject()) {
+                    return List.of();
                 }
-            } catch (VerificationException ignored) {
-                // skip malformed disclosure
+                JsonNode child = node.get(key);
+                if (isPresent(child)) {
+                    next.add(child);
+                }
+            }
+            return next;
+        }
+
+        if (segment == null) {
+            List<JsonNode> next = new ArrayList<>();
+            for (JsonNode node : selected) {
+                if (!node.isArray()) {
+                    return List.of();
+                }
+                node.forEach(next::add);
+            }
+            return next;
+        }
+
+        Integer index = asNonNegativeInteger(segment);
+        if (index == null) {
+            return List.of();
+        }
+
+        List<JsonNode> next = new ArrayList<>();
+        for (JsonNode node : selected) {
+            if (!node.isArray()) {
+                return List.of();
+            }
+            if (index < node.size()) {
+                next.add(node.get(index));
             }
         }
-        return false;
+        return next;
+    }
+
+    private static Integer asNonNegativeInteger(Object segment) {
+        if (segment instanceof Integer index) {
+            return index >= 0 ? index : null;
+        }
+        if (segment instanceof Number number) {
+            if (number.doubleValue() == Math.floor(number.doubleValue()) && number.longValue() >= 0) {
+                return number.intValue();
+            }
+        }
+        return null;
+    }
+
+    private static JsonNode findDisclosedClaim(SdJwtVP sdJwt, String claimName) {
+        for (String disclosure : sdJwt.getDisclosuresString()) {
+            JsonNode disclosedValue = decodeDisclosedValue(disclosure, claimName);
+            if (isPresent(disclosedValue)) {
+                return disclosedValue;
+            }
+        }
+        return null;
+    }
+
+    private static JsonNode decodeDisclosedValue(String disclosure, String claimName) {
+        try {
+            ArrayNode arrayNode = SdJwtUtils.decodeDisclosureString(disclosure);
+            if (arrayNode.size() == 3 && arrayNode.get(1).asText().equals(claimName)) {
+                return arrayNode.get(2);
+            }
+        } catch (VerificationException ignored) {
+            return null;
+        }
+        return null;
     }
 
     private static boolean isPresent(JsonNode node) {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/ClaimPathResolver.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/ClaimPathResolver.java
@@ -33,10 +33,13 @@ public final class ClaimPathResolver {
             return resolved;
         }
 
-        if (path.size() == 1 && path.getFirst() instanceof String claimName) {
+        if (path.getFirst() instanceof String claimName) {
             JsonNode disclosedClaim = findDisclosedClaim(sdJwt, claimName);
             if (isPresent(disclosedClaim)) {
-                return List.of(disclosedClaim);
+                if (path.size() == 1) {
+                    return List.of(disclosedClaim);
+                }
+                return resolveInJson(disclosedClaim, path.subList(1, path.size()));
             }
         }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/ClaimPathResolver.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/ClaimPathResolver.java
@@ -15,15 +15,15 @@ public final class ClaimPathResolver {
 
     private ClaimPathResolver() {}
 
-    public static boolean isPresentInJson(JsonNode root, List<Object> path) {
+    public static boolean isPresentInJson(JsonNode root, List<String> path) {
         return !resolveInJson(root, path).isEmpty();
     }
 
-    public static boolean isPresentInSdJwt(SdJwtVP sdJwt, List<Object> path) {
+    public static boolean isPresentInSdJwt(SdJwtVP sdJwt, List<String> path) {
         return !resolveInSdJwt(sdJwt, path).isEmpty();
     }
 
-    public static List<JsonNode> resolveInSdJwt(SdJwtVP sdJwt, List<Object> path) {
+    public static List<JsonNode> resolveInSdJwt(SdJwtVP sdJwt, List<String> path) {
         if (path == null || path.isEmpty()) {
             return List.of();
         }
@@ -33,36 +33,24 @@ public final class ClaimPathResolver {
             return resolved;
         }
 
-        if (path.getFirst() instanceof String claimName) {
-            JsonNode disclosedClaim = findDisclosedClaim(sdJwt, claimName);
-            if (isPresent(disclosedClaim)) {
-                if (path.size() == 1) {
-                    return List.of(disclosedClaim);
-                }
-                return resolveInJson(disclosedClaim, path.subList(1, path.size()));
+        JsonNode disclosedClaim = findDisclosedClaim(sdJwt, path.getFirst());
+        if (isPresent(disclosedClaim)) {
+            if (path.size() == 1) {
+                return List.of(disclosedClaim);
             }
+            return resolveInJson(disclosedClaim, path.subList(1, path.size()));
         }
 
         return List.of();
     }
 
-    static List<JsonNode> resolveInJson(JsonNode root, List<Object> path) {
+    static List<JsonNode> resolveInJson(JsonNode root, List<String> path) {
         if (root == null || path == null || path.isEmpty()) {
             return List.of();
         }
 
         List<JsonNode> selected = List.of(root);
-        for (Object segment : path) {
-            selected = resolvePathSegment(selected, segment);
-            if (selected.isEmpty()) {
-                return List.of();
-            }
-        }
-        return selected;
-    }
-
-    private static List<JsonNode> resolvePathSegment(List<JsonNode> selected, Object segment) {
-        if (segment instanceof String key) {
+        for (String key : path) {
             List<JsonNode> next = new ArrayList<>();
             for (JsonNode node : selected) {
                 if (!node.isObject()) {
@@ -73,47 +61,12 @@ public final class ClaimPathResolver {
                     next.add(child);
                 }
             }
-            return next;
-        }
-
-        if (segment == null) {
-            List<JsonNode> next = new ArrayList<>();
-            for (JsonNode node : selected) {
-                if (!node.isArray()) {
-                    return List.of();
-                }
-                node.forEach(next::add);
-            }
-            return next;
-        }
-
-        Integer index = asNonNegativeInteger(segment);
-        if (index == null) {
-            return List.of();
-        }
-
-        List<JsonNode> next = new ArrayList<>();
-        for (JsonNode node : selected) {
-            if (!node.isArray()) {
+            selected = next;
+            if (selected.isEmpty()) {
                 return List.of();
             }
-            if (index < node.size()) {
-                next.add(node.get(index));
-            }
         }
-        return next;
-    }
-
-    private static Integer asNonNegativeInteger(Object segment) {
-        if (segment instanceof Integer index) {
-            return index >= 0 ? index : null;
-        }
-        if (segment instanceof Number number) {
-            if (number.doubleValue() == Math.floor(number.doubleValue()) && number.longValue() >= 0) {
-                return number.intValue();
-            }
-        }
-        return null;
+        return selected;
     }
 
     private static JsonNode findDisclosedClaim(SdJwtVP sdJwt, String claimName) {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/ClaimPathResolver.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/ClaimPathResolver.java
@@ -69,6 +69,11 @@ public final class ClaimPathResolver {
         return selected;
     }
 
+    /**
+     * Returns the first selectively disclosed claim value matching {@code claimName} in presentation
+     * order. When multiple disclosures reuse the same claim name, only the first match is used for
+     * path resolution.
+     */
     private static JsonNode findDisclosedClaim(SdJwtVP sdJwt, String claimName) {
         for (String disclosure : sdJwt.getDisclosuresString()) {
             JsonNode disclosedValue = decodeDisclosedValue(disclosure, claimName);

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlPresentationValidator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlPresentationValidator.java
@@ -7,9 +7,13 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.keycloak.VCFormat;
 import org.keycloak.common.VerificationException;
 import org.keycloak.sdjwt.vp.SdJwtVP;
+import org.keycloak.util.JsonSerialization;
 import org.keycloak.utils.StringUtil;
 
 /**
@@ -70,11 +74,77 @@ public final class DcqlPresentationValidator {
             return;
         }
 
-        for (Claim claim : credentialQuery.getClaims()) {
-            if (!ClaimPathResolver.isPresentInSdJwt(presentation, claim.getPath())) {
-                throw new VerificationException(
-                        "Presented SD-JWT does not satisfy DCQL claim path: " + claim.getPath());
+        Map<String, ClaimValidationResult> claimResults = evaluateClaims(credentialQuery.getClaims(), presentation);
+
+        List<List<String>> claimSets = credentialQuery.getClaimSets();
+        if (claimSets == null || claimSets.isEmpty()) {
+            for (Claim claim : credentialQuery.getClaims()) {
+                ClaimValidationResult result = evaluateClaim(claim, presentation);
+                if (!result.satisfied()) {
+                    throw new VerificationException(result.errorMessage());
+                }
             }
+            return;
+        }
+
+        if (satisfiesAnyClaimSet(claimSets, claimResults)) {
+            return;
+        }
+        throw new VerificationException("Presented SD-JWT does not satisfy any DCQL claim_sets option");
+    }
+
+    private static Map<String, ClaimValidationResult> evaluateClaims(List<Claim> claims, SdJwtVP presentation) {
+        Map<String, ClaimValidationResult> claimResults = new HashMap<>();
+        for (Claim claim : claims) {
+            claimResults.put(claim.getId(), evaluateClaim(claim, presentation));
+        }
+        return claimResults;
+    }
+
+    private static boolean satisfiesAnyClaimSet(
+            List<List<String>> claimSets, Map<String, ClaimValidationResult> claimResults) {
+        return claimSets.stream().anyMatch(option -> option.stream()
+                .allMatch(claimId -> claimResults.containsKey(claimId)
+                        && claimResults.get(claimId).satisfied()));
+    }
+
+    private static ClaimValidationResult evaluateClaim(Claim claim, SdJwtVP presentation) {
+        List<JsonNode> selectedClaimValues = ClaimPathResolver.resolveInSdJwt(presentation, claim.getPath());
+        if (selectedClaimValues.isEmpty()) {
+            return ClaimValidationResult.failed(
+                    "Presented SD-JWT does not satisfy DCQL claim path: " + claim.getPath());
+        }
+        try {
+            validateRequestedClaimValues(claim, selectedClaimValues);
+            return ClaimValidationResult.ok();
+        } catch (VerificationException e) {
+            return ClaimValidationResult.failed(e.getMessage());
+        }
+    }
+
+    private static void validateRequestedClaimValues(Claim claim, List<JsonNode> selectedClaimValues)
+            throws VerificationException {
+        if (claim.getValues() == null || claim.getValues().isEmpty()) {
+            return;
+        }
+
+        boolean hasAnyExpectedMatch = claim.getValues().stream()
+                .map(JsonSerialization.mapper::valueToTree)
+                .anyMatch(expected -> selectedClaimValues.stream().anyMatch(expected::equals));
+
+        if (!hasAnyExpectedMatch) {
+            throw new VerificationException(
+                    "Presented SD-JWT does not satisfy DCQL claim values for path: " + claim.getPath());
+        }
+    }
+
+    private record ClaimValidationResult(boolean satisfied, String errorMessage) {
+        private static ClaimValidationResult ok() {
+            return new ClaimValidationResult(true, null);
+        }
+
+        private static ClaimValidationResult failed(String errorMessage) {
+            return new ClaimValidationResult(false, errorMessage);
         }
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryBuilder.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryBuilder.java
@@ -21,7 +21,7 @@ public final class DcqlQueryBuilder {
     public static Claim claimFromPath(List<String> path) {
         Claim claim = new Claim();
         claim.setId(UUID.randomUUID().toString());
-        claim.setPath(path.stream().map(segment -> (Object) segment).toList());
+        claim.setPath(path);
         return claim;
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryBuilder.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryBuilder.java
@@ -21,7 +21,7 @@ public final class DcqlQueryBuilder {
     public static Claim claimFromPath(List<String> path) {
         Claim claim = new Claim();
         claim.setId(UUID.randomUUID().toString());
-        claim.setPath(path);
+        claim.setPath(path.stream().map(segment -> (Object) segment).toList());
         return claim;
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidator.java
@@ -88,7 +88,7 @@ public final class DcqlQueryValidator {
         }
 
         Set<String> claimIds = new HashSet<>();
-        Set<List<Object>> claimPaths = new HashSet<>();
+        Set<List<String>> claimPaths = new HashSet<>();
         boolean claimSetsPresent = claimSets != null && !claimSets.isEmpty();
 
         for (Claim claim : claims) {
@@ -157,12 +157,16 @@ public final class DcqlQueryValidator {
             return;
         }
         for (Claim claim : credential.getClaims()) {
-            List<Object> path = claim.getPath();
+            List<String> path = claim.getPath();
             if (path == null || path.isEmpty()) {
                 throw new IllegalArgumentException("dcql_query claim path must be non-empty");
             }
-            for (Object segment : path) {
-                validatePathSegment(segment);
+            if (path.stream().anyMatch(StringUtil::isBlank)) {
+                throw new IllegalArgumentException("dcql_query claim path segments must be non-empty");
+            }
+            if (path.stream().anyMatch(DcqlQueryValidator::isUnsupportedPathSegment)) {
+                throw new IllegalArgumentException(
+                        "dcql_query claim path supports object property names only; array indexes and null wildcards are not supported");
             }
             validateClaimValues(claim.getValues());
             if (isVpWrapperPath(path)) {
@@ -173,69 +177,27 @@ public final class DcqlQueryValidator {
         }
     }
 
-    private static void validatePathSegment(Object segment) {
-        if (segment == null) {
-            return;
+    private static boolean isUnsupportedPathSegment(String segment) {
+        if ("null".equals(segment)) {
+            return true;
         }
-        if (segment instanceof String propertyName) {
-            if (StringUtil.isBlank(propertyName)) {
-                throw new IllegalArgumentException("dcql_query claim path segments must be non-empty");
-            }
-            return;
-        }
-        if (segment instanceof Integer index) {
-            if (index < 0) {
-                throw new IllegalArgumentException("dcql_query claim path indexes must be non-negative");
-            }
-            return;
-        }
-        if (segment instanceof Number number) {
-            if (number.doubleValue() != Math.floor(number.doubleValue()) || number.longValue() < 0) {
-                throw new IllegalArgumentException("dcql_query claim path indexes must be non-negative integers");
-            }
-            return;
-        }
-        throw new IllegalArgumentException("dcql_query claim path segments must be string, integer, or null");
+        return !segment.isEmpty() && segment.chars().allMatch(Character::isDigit);
     }
 
-    private static void validateClaimValues(List<Object> values) {
+    private static void validateClaimValues(List<String> values) {
         if (values == null) {
             return;
         }
         if (values.isEmpty()) {
             throw new IllegalArgumentException("dcql_query claim values must be non-empty when present");
         }
-        for (Object value : values) {
-            validateClaimValue(value);
-        }
     }
 
-    private static void validateClaimValue(Object value) {
-        if (value == null) {
-            throw new IllegalArgumentException("dcql_query claim values must be string, integer, or boolean literals");
-        }
-        if (value instanceof String || value instanceof Boolean) {
-            return;
-        }
-        if (value instanceof Integer) {
-            return;
-        }
-        if (value instanceof Number number) {
-            if (number.doubleValue() == Math.floor(number.doubleValue())) {
-                return;
-            }
-        }
-        throw new IllegalArgumentException("dcql_query claim values must be string, integer, or boolean literals");
-    }
-
-    private static boolean isVpWrapperPath(List<Object> path) {
+    private static boolean isVpWrapperPath(List<String> path) {
         if (path.isEmpty()) {
             return false;
         }
-        Object firstSegment = path.getFirst();
-        if (!(firstSegment instanceof String first)) {
-            return false;
-        }
+        String first = path.getFirst();
         return "verifiableCredential".equals(first) || "vp".equals(first);
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidator.java
@@ -191,6 +191,9 @@ public final class DcqlQueryValidator {
         if (values.isEmpty()) {
             throw new IllegalArgumentException("dcql_query claim values must be non-empty when present");
         }
+        if (values.stream().anyMatch(StringUtil::isBlank)) {
+            throw new IllegalArgumentException("dcql_query claim values must not contain blank entries");
+        }
     }
 
     private static boolean isVpWrapperPath(List<String> path) {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidator.java
@@ -164,6 +164,7 @@ public final class DcqlQueryValidator {
             for (Object segment : path) {
                 validatePathSegment(segment);
             }
+            validateClaimValues(claim.getValues());
             if (isVpWrapperPath(path)) {
                 throw new IllegalArgumentException(credential.getFormat()
                         + " claim paths must be relative to the VC root, not the VP wrapper: "
@@ -195,6 +196,36 @@ public final class DcqlQueryValidator {
             return;
         }
         throw new IllegalArgumentException("dcql_query claim path segments must be string, integer, or null");
+    }
+
+    private static void validateClaimValues(List<Object> values) {
+        if (values == null) {
+            return;
+        }
+        if (values.isEmpty()) {
+            throw new IllegalArgumentException("dcql_query claim values must be non-empty when present");
+        }
+        for (Object value : values) {
+            validateClaimValue(value);
+        }
+    }
+
+    private static void validateClaimValue(Object value) {
+        if (value == null) {
+            throw new IllegalArgumentException("dcql_query claim values must be string, integer, or boolean literals");
+        }
+        if (value instanceof String || value instanceof Boolean) {
+            return;
+        }
+        if (value instanceof Integer) {
+            return;
+        }
+        if (value instanceof Number number) {
+            if (number.doubleValue() == Math.floor(number.doubleValue())) {
+                return;
+            }
+        }
+        throw new IllegalArgumentException("dcql_query claim values must be string, integer, or boolean literals");
     }
 
     private static boolean isVpWrapperPath(List<Object> path) {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidator.java
@@ -10,12 +10,7 @@ import java.util.Set;
 import org.keycloak.VCFormat;
 import org.keycloak.utils.StringUtil;
 
-/**
- * Validates DCQL queries at build time per OpenID4VP 1.0 format-specific rules.
- *
- * <p>Claim {@code path} validation is limited to non-empty object property name segments; array
- * indexes and {@code null} wildcards from Claims Path Pointers are not supported yet.
- */
+/** Validates DCQL queries at build time per OpenID4VP 1.0 format-specific rules. */
 public final class DcqlQueryValidator {
 
     private DcqlQueryValidator() {}
@@ -93,7 +88,7 @@ public final class DcqlQueryValidator {
         }
 
         Set<String> claimIds = new HashSet<>();
-        Set<List<String>> claimPaths = new HashSet<>();
+        Set<List<Object>> claimPaths = new HashSet<>();
         boolean claimSetsPresent = claimSets != null && !claimSets.isEmpty();
 
         for (Claim claim : claims) {
@@ -162,36 +157,54 @@ public final class DcqlQueryValidator {
             return;
         }
         for (Claim claim : credential.getClaims()) {
-            if (claim.getPath() == null || claim.getPath().isEmpty()) {
+            List<Object> path = claim.getPath();
+            if (path == null || path.isEmpty()) {
                 throw new IllegalArgumentException("dcql_query claim path must be non-empty");
             }
-            if (claim.getPath().stream().anyMatch(StringUtil::isBlank)) {
-                throw new IllegalArgumentException("dcql_query claim path segments must be non-empty");
+            for (Object segment : path) {
+                validatePathSegment(segment);
             }
-            if (claim.getPath().stream().anyMatch(DcqlQueryValidator::isUnsupportedPathSegment)) {
-                throw new IllegalArgumentException(
-                        "dcql_query claim path supports object property names only; array indexes and null wildcards are not supported");
-            }
-            if (isVpWrapperPath(claim.getPath())) {
+            if (isVpWrapperPath(path)) {
                 throw new IllegalArgumentException(credential.getFormat()
                         + " claim paths must be relative to the VC root, not the VP wrapper: "
-                        + claim.getPath());
+                        + path);
             }
         }
     }
 
-    private static boolean isUnsupportedPathSegment(String segment) {
-        if ("null".equals(segment)) {
-            return true;
+    private static void validatePathSegment(Object segment) {
+        if (segment == null) {
+            return;
         }
-        return !segment.isEmpty() && segment.chars().allMatch(Character::isDigit);
+        if (segment instanceof String propertyName) {
+            if (StringUtil.isBlank(propertyName)) {
+                throw new IllegalArgumentException("dcql_query claim path segments must be non-empty");
+            }
+            return;
+        }
+        if (segment instanceof Integer index) {
+            if (index < 0) {
+                throw new IllegalArgumentException("dcql_query claim path indexes must be non-negative");
+            }
+            return;
+        }
+        if (segment instanceof Number number) {
+            if (number.doubleValue() != Math.floor(number.doubleValue()) || number.longValue() < 0) {
+                throw new IllegalArgumentException("dcql_query claim path indexes must be non-negative integers");
+            }
+            return;
+        }
+        throw new IllegalArgumentException("dcql_query claim path segments must be string, integer, or null");
     }
 
-    private static boolean isVpWrapperPath(List<String> path) {
+    private static boolean isVpWrapperPath(List<Object> path) {
         if (path.isEmpty()) {
             return false;
         }
-        String first = path.getFirst();
+        Object firstSegment = path.getFirst();
+        if (!(firstSegment instanceof String first)) {
+            return false;
+        }
         return "verifiableCredential".equals(first) || "vp".equals(first);
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Claim.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Claim.java
@@ -8,15 +8,11 @@ public class Claim {
     @JsonProperty("id")
     private String id;
 
-    /**
-     * Object-key path segments only (e.g. {@code credentialSubject}, {@code given_name}). Does not
-     * support {@code null} array wildcards or integer indexes from OpenID4VP Claims Path Pointers.
-     */
     @JsonProperty("path")
-    private List<String> path;
+    private List<Object> path;
 
     @JsonProperty("values")
-    private List<String> values;
+    private List<Object> values;
 
     public String getId() {
         return id;
@@ -26,19 +22,19 @@ public class Claim {
         this.id = id;
     }
 
-    public List<String> getPath() {
+    public List<Object> getPath() {
         return path;
     }
 
-    public void setPath(List<String> path) {
+    public void setPath(List<Object> path) {
         this.path = path;
     }
 
-    public List<String> getValues() {
+    public List<Object> getValues() {
         return values;
     }
 
-    public void setValues(List<String> values) {
+    public void setValues(List<Object> values) {
         this.values = values;
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Claim.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/model/dcql/Claim.java
@@ -8,11 +8,15 @@ public class Claim {
     @JsonProperty("id")
     private String id;
 
+    /**
+     * Object-key path segments (e.g. {@code credentialSubject}, {@code given_name}, {@code street_address}).
+     * Nested paths such as {@code ["address", "street_address"]} use multiple string segments.
+     */
     @JsonProperty("path")
-    private List<Object> path;
+    private List<String> path;
 
     @JsonProperty("values")
-    private List<Object> values;
+    private List<String> values;
 
     public String getId() {
         return id;
@@ -22,19 +26,19 @@ public class Claim {
         this.id = id;
     }
 
-    public List<Object> getPath() {
+    public List<String> getPath() {
         return path;
     }
 
-    public void setPath(List<Object> path) {
+    public void setPath(List<String> path) {
         this.path = path;
     }
 
-    public List<Object> getValues() {
+    public List<String> getValues() {
         return values;
     }
 
-    public void setValues(List<Object> values) {
+    public void setValues(List<String> values) {
         this.values = values;
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/ClaimPathResolverTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/ClaimPathResolverTest.java
@@ -1,0 +1,172 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.RSATestUtils;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.SdJwtVPTestUtils;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.crypto.AsymmetricSignatureSignerContext;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.sdjwt.DisclosureSpec;
+import org.keycloak.sdjwt.IssuerSignedJWT;
+import org.keycloak.sdjwt.SdJwt;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+import org.keycloak.util.JsonSerialization;
+
+class ClaimPathResolverTest {
+
+    private static final String VCT = "https://credentials.example.com/identity_credential";
+
+    @BeforeAll
+    static void initCrypto() {
+        CryptoIntegration.init(ClaimPathResolverTest.class.getClassLoader());
+    }
+
+    @Test
+    void resolveInJsonReturnsValueForNestedObjectPath() {
+        ObjectNode root = JsonSerialization.mapper.createObjectNode();
+        ObjectNode address = root.putObject("address");
+        address.put("street_address", "123 Main St");
+
+        List<JsonNode> resolved = ClaimPathResolver.resolveInJson(root, List.of("address", "street_address"));
+
+        assertEquals(1, resolved.size());
+        assertEquals("123 Main St", resolved.getFirst().asText());
+    }
+
+    @Test
+    void resolveInJsonReturnsEmptyForMissingPath() {
+        ObjectNode root = JsonSerialization.mapper.createObjectNode();
+        root.put("given_name", "Alice");
+
+        assertTrue(ClaimPathResolver.resolveInJson(root, List.of("family_name")).isEmpty());
+    }
+
+    @Test
+    void resolveInJsonReturnsEmptyForEmptyPath() {
+        ObjectNode root = JsonSerialization.mapper.createObjectNode();
+        root.put("given_name", "Alice");
+
+        assertTrue(ClaimPathResolver.resolveInJson(root, List.of()).isEmpty());
+    }
+
+    @Test
+    void resolveInJsonReturnsEmptyWhenPathTraversesNonObjectValue() {
+        ObjectNode root = JsonSerialization.mapper.createObjectNode();
+        root.put("age", 21);
+
+        assertTrue(
+                ClaimPathResolver.resolveInJson(root, List.of("age", "years")).isEmpty());
+    }
+
+    @Test
+    void resolveInJsonReturnsEmptyForNullRoot() {
+        assertTrue(ClaimPathResolver.resolveInJson(null, List.of("given_name")).isEmpty());
+    }
+
+    @Test
+    void resolveInSdJwtReturnsIssuerSignedClaim() throws Exception {
+        SdJwtVP sdJwt = sdJwtVp(
+                claimSet -> claimSet.put("given_name", "Alice"),
+                DisclosureSpec.builder().build());
+
+        List<JsonNode> resolved = ClaimPathResolver.resolveInSdJwt(sdJwt, List.of("given_name"));
+
+        assertEquals(1, resolved.size());
+        assertEquals("Alice", resolved.getFirst().asText());
+    }
+
+    @Test
+    void resolveInSdJwtReturnsNestedPathThroughDisclosedClaim() throws Exception {
+        SdJwtVP sdJwt = sdJwtVp(
+                claimSet -> {
+                    ObjectNode address = claimSet.putObject("address");
+                    address.put("street_address", "123 Main St");
+                },
+                DisclosureSpec.builder()
+                        .withUndisclosedClaim("address", "address-salt")
+                        .build());
+
+        List<JsonNode> resolved = ClaimPathResolver.resolveInSdJwt(sdJwt, List.of("address", "street_address"));
+
+        assertEquals(1, resolved.size());
+        assertEquals("123 Main St", resolved.getFirst().asText());
+    }
+
+    @Test
+    void resolveInSdJwtReturnsEmptyForNullPath() throws Exception {
+        SdJwtVP sdJwt = sdJwtVp(
+                claimSet -> claimSet.put("given_name", "Alice"),
+                DisclosureSpec.builder().build());
+
+        assertTrue(ClaimPathResolver.resolveInSdJwt(sdJwt, null).isEmpty());
+    }
+
+    @Test
+    void resolveInSdJwtReturnsSingleDisclosedClaim() throws Exception {
+        SdJwtVP sdJwt = sdJwtVp(
+                claimSet -> claimSet.put("given_name", "Alice"),
+                DisclosureSpec.builder()
+                        .withUndisclosedClaim("given_name", "given-name-salt")
+                        .build());
+
+        List<JsonNode> resolved = ClaimPathResolver.resolveInSdJwt(sdJwt, List.of("given_name"));
+
+        assertEquals(1, resolved.size());
+        assertEquals("Alice", resolved.getFirst().asText());
+    }
+
+    @Test
+    void resolveInSdJwtReturnsEmptyForMissingClaim() throws Exception {
+        SdJwtVP sdJwt = sdJwtVp(
+                claimSet -> claimSet.put("given_name", "Alice"),
+                DisclosureSpec.builder().build());
+
+        assertTrue(
+                ClaimPathResolver.resolveInSdJwt(sdJwt, List.of("family_name")).isEmpty());
+    }
+
+    @Test
+    void resolveInSdJwtReturnsEmptyForMissingNestedPathInDisclosedClaim() throws Exception {
+        SdJwtVP sdJwt = sdJwtVp(
+                claimSet -> {
+                    ObjectNode address = claimSet.putObject("address");
+                    address.put("street_address", "123 Main St");
+                },
+                DisclosureSpec.builder()
+                        .withUndisclosedClaim("address", "address-salt")
+                        .build());
+
+        assertTrue(ClaimPathResolver.resolveInSdJwt(sdJwt, List.of("address", "postal_code"))
+                .isEmpty());
+    }
+
+    private static SdJwtVP sdJwtVp(Consumer<ObjectNode> claimCustomizer, DisclosureSpec disclosureSpec)
+            throws Exception {
+        ObjectNode claimSet = JsonSerialization.mapper.createObjectNode();
+        claimSet.put("iss", "https://example.com/realms/test");
+        claimSet.put("vct", VCT);
+        claimSet.put("sub", "user-id");
+        claimCustomizer.accept(claimSet);
+
+        IssuerSignedJWT issuerSignedJWT =
+                IssuerSignedJWT.builder().withClaims(claimSet, disclosureSpec).build();
+
+        JWK issuerJwk = SdJwtVPTestUtils.getKeycloakJwk();
+        KeyWrapper issuerKey = RSATestUtils.getRsaKeyWrapper(issuerJwk);
+        String token = SdJwt.builder()
+                .withIssuerSignedJwt(issuerSignedJWT)
+                .withIssuerSigningContext(new AsymmetricSignatureSignerContext(issuerKey))
+                .build()
+                .toSdJwtString();
+        return SdJwtVP.of(token);
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlPresentationValidatorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlPresentationValidatorTest.java
@@ -1,6 +1,7 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -74,10 +75,22 @@ class DcqlPresentationValidatorTest {
 
         DcqlQuery query = queryWithClaims(claimWithValues("given-name", List.of("given_name"), List.of("Bob")));
 
-        assertThrows(
-                VerificationException.class,
-                () -> DcqlPresentationValidator.validatePresentation(query, token),
-                "Should reject presentation when claim values do not match");
+        VerificationException error = assertThrows(
+                VerificationException.class, () -> DcqlPresentationValidator.validatePresentation(query, token));
+        assertEquals("Presented SD-JWT does not satisfy DCQL claim values for path: [given_name]", error.getMessage());
+    }
+
+    @Test
+    void rejectsMissingRequestedClaimPath() throws Exception {
+        String token = buildSdJwtToken(
+                claimSet -> claimSet.put("given_name", "Alice"),
+                DisclosureSpec.builder().build());
+
+        DcqlQuery query = queryWithClaims(claim("family-name", List.of("family_name")));
+
+        VerificationException error = assertThrows(
+                VerificationException.class, () -> DcqlPresentationValidator.validatePresentation(query, token));
+        assertEquals("Presented SD-JWT does not satisfy DCQL claim path: [family_name]", error.getMessage());
     }
 
     @Test
@@ -114,10 +127,114 @@ class DcqlPresentationValidatorTest {
 
         DcqlQuery query = DcqlQueryBuilder.singleCredentialQuery(credential);
 
-        assertThrows(
-                VerificationException.class,
-                () -> DcqlPresentationValidator.validatePresentation(query, token),
-                "Should reject presentation when no claim_sets option is satisfied");
+        VerificationException error = assertThrows(
+                VerificationException.class, () -> DcqlPresentationValidator.validatePresentation(query, token));
+        assertEquals("Presented SD-JWT does not satisfy any DCQL claim_sets option", error.getMessage());
+    }
+
+    @Test
+    void rejectsMismatchedVct() throws Exception {
+        String token = buildSdJwtToken(
+                claimSet -> claimSet.put("given_name", "Alice"),
+                DisclosureSpec.builder().build());
+
+        DcqlQuery query = queryWithClaims(claim("given-name", List.of("given_name")));
+        query.getCredentials().getFirst().getMeta().setVctValues(List.of("https://credentials.example.com/other"));
+
+        VerificationException error = assertThrows(
+                VerificationException.class, () -> DcqlPresentationValidator.validatePresentation(query, token));
+        assertEquals("Presented SD-JWT vct does not match any value in meta.vct_values: " + VCT, error.getMessage());
+    }
+
+    @Test
+    void rejectsMissingVct() throws Exception {
+        String token = buildSdJwtToken(
+                claimSet -> claimSet.remove("vct"), DisclosureSpec.builder().build());
+
+        DcqlQuery query = queryWithClaims(claim("given-name", List.of("given_name")));
+
+        VerificationException error = assertThrows(
+                VerificationException.class, () -> DcqlPresentationValidator.validatePresentation(query, token));
+        assertEquals("Presented SD-JWT is missing required vct claim", error.getMessage());
+    }
+
+    @Test
+    void rejectsMultipleCredentialQueries() throws Exception {
+        String token = buildSdJwtToken(
+                claimSet -> claimSet.put("given_name", "Alice"),
+                DisclosureSpec.builder().build());
+
+        Credential first = credentialWithClaims(List.of(claim("given-name", List.of("given_name"))));
+        first.setId("cred-1");
+        Credential second = credentialWithClaims(List.of(claim("family-name", List.of("family_name"))));
+        second.setId("cred-2");
+        DcqlQuery query = new DcqlQuery();
+        query.setCredentials(List.of(first, second));
+
+        VerificationException error = assertThrows(
+                VerificationException.class, () -> DcqlPresentationValidator.validatePresentation(query, token));
+        assertEquals(
+                "Only single-credential DCQL queries are supported for presentation validation", error.getMessage());
+    }
+
+    @Test
+    void validatesPresentationWithNoRequestedClaims() throws Exception {
+        String token = buildSdJwtToken(
+                claimSet -> claimSet.put("given_name", "Alice"),
+                DisclosureSpec.builder().build());
+
+        Credential credential = credentialWithClaims(List.of());
+        DcqlQuery query = DcqlQueryBuilder.singleCredentialQuery(credential);
+
+        assertDoesNotThrow(() -> DcqlPresentationValidator.validatePresentation(query, token));
+    }
+
+    @Test
+    void rejectsClaimSetsWhenClaimValuesMismatch() throws Exception {
+        String token = buildSdJwtToken(
+                claimSet -> {
+                    claimSet.put("given_name", "Alice");
+                    claimSet.put("family_name", "Smith");
+                },
+                DisclosureSpec.builder().build());
+
+        Claim givenName = claimWithValues("given-name", List.of("given_name"), List.of("Bob"));
+        Claim familyName = claim("family-name", List.of("family_name"));
+        Credential credential = credentialWithClaims(List.of(givenName, familyName));
+        credential.setClaimSets(List.of(List.of("given-name", "family-name")));
+
+        DcqlQuery query = DcqlQueryBuilder.singleCredentialQuery(credential);
+
+        VerificationException error = assertThrows(
+                VerificationException.class, () -> DcqlPresentationValidator.validatePresentation(query, token));
+        assertEquals("Presented SD-JWT does not satisfy any DCQL claim_sets option", error.getMessage());
+    }
+
+    @Test
+    void rejectsMissingHolderBindingByDefault() throws Exception {
+        String token = buildSdJwtToken(
+                claimSet -> claimSet.put("given_name", "Alice"),
+                DisclosureSpec.builder().build());
+
+        Credential credential = credentialWithClaims(List.of(claim("given-name", List.of("given_name"))));
+        credential.setRequireCryptographicHolderBinding(null);
+        DcqlQuery query = DcqlQueryBuilder.singleCredentialQuery(credential);
+
+        VerificationException error = assertThrows(
+                VerificationException.class, () -> DcqlPresentationValidator.validatePresentation(query, token));
+        assertEquals("DCQL query requires cryptographic holder binding (Key Binding JWT)", error.getMessage());
+    }
+
+    @Test
+    void rejectsBlankVctInPresentation() throws Exception {
+        String token = buildSdJwtToken(
+                claimSet -> claimSet.put("vct", "  "), DisclosureSpec.builder().build());
+
+        DcqlQuery query = queryWithClaims(claim("given-name", List.of("given_name")));
+
+        VerificationException error = assertThrows(
+                VerificationException.class, () -> DcqlPresentationValidator.validatePresentation(query, token));
+        assertEquals("Presented SD-JWT is missing required vct claim", error.getMessage());
     }
 
     private static DcqlQuery queryWithClaims(Claim... claims) {

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlPresentationValidatorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlPresentationValidatorTest.java
@@ -1,0 +1,172 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.RSATestUtils;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.SdJwtVPTestUtils;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.keycloak.VCFormat;
+import org.keycloak.common.VerificationException;
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.crypto.AsymmetricSignatureSignerContext;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.sdjwt.DisclosureSpec;
+import org.keycloak.sdjwt.IssuerSignedJWT;
+import org.keycloak.sdjwt.SdJwt;
+import org.keycloak.util.JsonSerialization;
+
+class DcqlPresentationValidatorTest {
+
+    private static final String VCT = "https://credentials.example.com/identity_credential";
+
+    @BeforeAll
+    static void initCrypto() {
+        CryptoIntegration.init(DcqlPresentationValidatorTest.class.getClassLoader());
+    }
+
+    @Test
+    void validatesRequestedClaimsThroughNestedDisclosedPath() throws Exception {
+        String token = buildSdJwtToken(
+                claimSet -> {
+                    ObjectNode address = JsonSerialization.mapper.createObjectNode();
+                    address.put("street_address", "123 Main St");
+                    claimSet.set("address", address);
+                },
+                DisclosureSpec.builder()
+                        .withUndisclosedClaim("address", "address-salt")
+                        .build());
+
+        DcqlQuery query = queryWithClaims(claim("address-street", List.of("address", "street_address")));
+
+        assertDoesNotThrow(
+                () -> DcqlPresentationValidator.validatePresentation(query, token),
+                "Should accept presentation that satisfies nested disclosed claim path");
+    }
+
+    @Test
+    void validatesMatchingClaimValues() throws Exception {
+        String token = buildSdJwtToken(
+                claimSet -> claimSet.put("given_name", "Alice"),
+                DisclosureSpec.builder().build());
+
+        DcqlQuery query = queryWithClaims(claimWithValues("given-name", List.of("given_name"), List.of("Alice")));
+
+        assertDoesNotThrow(
+                () -> DcqlPresentationValidator.validatePresentation(query, token),
+                "Should accept presentation when claim values match");
+    }
+
+    @Test
+    void rejectsMismatchedClaimValues() throws Exception {
+        String token = buildSdJwtToken(
+                claimSet -> claimSet.put("given_name", "Alice"),
+                DisclosureSpec.builder().build());
+
+        DcqlQuery query = queryWithClaims(claimWithValues("given-name", List.of("given_name"), List.of("Bob")));
+
+        assertThrows(
+                VerificationException.class,
+                () -> DcqlPresentationValidator.validatePresentation(query, token),
+                "Should reject presentation when claim values do not match");
+    }
+
+    @Test
+    void validatesClaimSetsWhenOneOptionIsSatisfied() throws Exception {
+        String token = buildSdJwtToken(
+                claimSet -> {
+                    claimSet.put("given_name", "Alice");
+                    claimSet.put("family_name", "Smith");
+                },
+                DisclosureSpec.builder().build());
+
+        Claim givenName = claim("given-name", List.of("given_name"));
+        Claim familyName = claim("family-name", List.of("family_name"));
+        Credential credential = credentialWithClaims(List.of(givenName, familyName));
+        credential.setClaimSets(List.of(List.of("given-name", "family-name"), List.of("given-name")));
+
+        DcqlQuery query = DcqlQueryBuilder.singleCredentialQuery(credential);
+
+        assertDoesNotThrow(
+                () -> DcqlPresentationValidator.validatePresentation(query, token),
+                "Should accept presentation when any claim_sets option is fully satisfied");
+    }
+
+    @Test
+    void rejectsClaimSetsWhenNoOptionIsSatisfied() throws Exception {
+        String token = buildSdJwtToken(
+                claimSet -> claimSet.put("given_name", "Alice"),
+                DisclosureSpec.builder().build());
+
+        Claim givenName = claim("given-name", List.of("given_name"));
+        Claim familyName = claim("family-name", List.of("family_name"));
+        Credential credential = credentialWithClaims(List.of(givenName, familyName));
+        credential.setClaimSets(List.of(List.of("given-name", "family-name")));
+
+        DcqlQuery query = DcqlQueryBuilder.singleCredentialQuery(credential);
+
+        assertThrows(
+                VerificationException.class,
+                () -> DcqlPresentationValidator.validatePresentation(query, token),
+                "Should reject presentation when no claim_sets option is satisfied");
+    }
+
+    private static DcqlQuery queryWithClaims(Claim... claims) {
+        return DcqlQueryBuilder.singleCredentialQuery(credentialWithClaims(List.of(claims)));
+    }
+
+    private static Credential credentialWithClaims(List<Claim> claims) {
+        Meta meta = new Meta();
+        meta.setVctValues(List.of(VCT));
+
+        Credential credential = new Credential();
+        credential.setId("cred-1");
+        credential.setFormat(VCFormat.SD_JWT_VC);
+        credential.setMeta(meta);
+        credential.setClaims(claims);
+        credential.setRequireCryptographicHolderBinding(Boolean.FALSE);
+        return credential;
+    }
+
+    private static Claim claim(String id, List<String> path) {
+        Claim claim = new Claim();
+        claim.setId(id);
+        claim.setPath(path);
+        return claim;
+    }
+
+    private static Claim claimWithValues(String id, List<String> path, List<String> values) {
+        Claim claim = claim(id, path);
+        claim.setValues(values);
+        return claim;
+    }
+
+    private static String buildSdJwtToken(Consumer<ObjectNode> claimCustomizer, DisclosureSpec disclosureSpec)
+            throws Exception {
+        ObjectNode claimSet = JsonSerialization.mapper.createObjectNode();
+        claimSet.put("iss", "https://example.com/realms/test");
+        claimSet.put("vct", VCT);
+        claimSet.put("sub", "user-id");
+        claimCustomizer.accept(claimSet);
+
+        IssuerSignedJWT issuerSignedJWT =
+                IssuerSignedJWT.builder().withClaims(claimSet, disclosureSpec).build();
+
+        JWK issuerJwk = SdJwtVPTestUtils.getKeycloakJwk();
+        KeyWrapper issuerKey = RSATestUtils.getRsaKeyWrapper(issuerJwk);
+        return SdJwt.builder()
+                .withIssuerSignedJwt(issuerSignedJWT)
+                .withIssuerSigningContext(new AsymmetricSignatureSignerContext(issuerKey))
+                .build()
+                .toSdJwtString();
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidatorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidatorTest.java
@@ -22,7 +22,10 @@ class DcqlQueryValidatorTest {
         meta.setVctValues(List.of());
         credential.setMeta(meta);
 
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlQueryValidator.validateCredential(credential),
+                "Should reject SD-JWT credential with empty vct_values");
     }
 
     @Test
@@ -39,7 +42,10 @@ class DcqlQueryValidatorTest {
         claim.setPath(List.of("vp", "sub"));
         credential.setClaims(List.of(claim));
 
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlQueryValidator.validateCredential(credential),
+                "Should reject SD-JWT claim paths relative to the VP wrapper");
     }
 
     @Test
@@ -56,7 +62,10 @@ class DcqlQueryValidatorTest {
         claim.setPath(List.of("addresses", "0", "street"));
         credential.setClaims(List.of(claim));
 
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlQueryValidator.validateCredential(credential),
+                "Should reject array index path segments");
     }
 
     @Test
@@ -73,27 +82,37 @@ class DcqlQueryValidatorTest {
         claim.setPath(List.of("address", "street_address"));
         credential.setClaims(List.of(claim));
 
-        assertDoesNotThrow(() -> DcqlQueryValidator.validateCredential(credential));
+        assertDoesNotThrow(
+                () -> DcqlQueryValidator.validateCredential(credential), "Should accept nested object-key claim paths");
     }
 
     @Test
     void rejectsInvalidCredentialIdSyntax() {
         Credential credential = sdJwtCredential("cred.1", List.of());
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlQueryValidator.validateCredential(credential),
+                "Should reject credential ids with invalid characters");
     }
 
     @Test
     void rejectsDuplicateCredentialIds() {
         DcqlQuery query = new DcqlQuery();
         query.setCredentials(List.of(sdJwtCredential("cred-1", List.of()), sdJwtCredential("cred-1", List.of())));
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateQuery(query));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlQueryValidator.validateQuery(query),
+                "Should reject duplicate credential ids in dcql_query");
     }
 
     @Test
     void rejectsClaimSetsWithoutClaims() {
         Credential credential = sdJwtCredential("cred-1", List.of());
         credential.setClaimSets(List.of(List.of("claim-1")));
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlQueryValidator.validateCredential(credential),
+                "Should reject claim_sets when claims are absent");
     }
 
     @Test
@@ -103,7 +122,10 @@ class DcqlQueryValidatorTest {
         claim.setPath(List.of("given_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(claim));
         credential.setClaimSets(List.of(List.of("family_name")));
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlQueryValidator.validateCredential(credential),
+                "Should reject claim_sets that reference unknown claim ids");
     }
 
     @Test
@@ -116,7 +138,10 @@ class DcqlQueryValidatorTest {
         second.setPath(List.of("family_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(first, second));
         credential.setClaimSets(List.of(List.of("claim-1")));
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlQueryValidator.validateCredential(credential),
+                "Should reject duplicate claim ids within a credential");
     }
 
     @Test
@@ -128,7 +153,10 @@ class DcqlQueryValidatorTest {
         second.setId("claim-2");
         second.setPath(List.of("given_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(first, second));
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlQueryValidator.validateCredential(credential),
+                "Should reject duplicate claim paths within a credential");
     }
 
     @Test
@@ -141,7 +169,8 @@ class DcqlQueryValidatorTest {
         familyName.setPath(List.of("family_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(givenName, familyName));
         credential.setClaimSets(List.of(List.of("given_name", "family_name"), List.of("given_name")));
-        assertDoesNotThrow(() -> DcqlQueryValidator.validateCredential(credential));
+        assertDoesNotThrow(
+                () -> DcqlQueryValidator.validateCredential(credential), "Should accept valid claim_sets options");
     }
 
     @Test
@@ -151,7 +180,8 @@ class DcqlQueryValidatorTest {
         claim.setPath(List.of("age"));
         claim.setValues(List.of("adult", "verified"));
         Credential credential = sdJwtCredential("cred-1", List.of(claim));
-        assertDoesNotThrow(() -> DcqlQueryValidator.validateCredential(credential));
+        assertDoesNotThrow(
+                () -> DcqlQueryValidator.validateCredential(credential), "Should accept string claim values");
     }
 
     @Test
@@ -161,7 +191,10 @@ class DcqlQueryValidatorTest {
         claim.setPath(List.of("age"));
         claim.setValues(List.of());
         Credential credential = sdJwtCredential("cred-1", List.of(claim));
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlQueryValidator.validateCredential(credential),
+                "Should reject empty claim values arrays");
     }
 
     @Test
@@ -171,7 +204,10 @@ class DcqlQueryValidatorTest {
         claim.setPath(List.of("age"));
         claim.setValues(List.of(""));
         Credential credential = sdJwtCredential("cred-1", List.of(claim));
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlQueryValidator.validateCredential(credential),
+                "Should reject blank claim values entries");
     }
 
     @Test
@@ -179,7 +215,8 @@ class DcqlQueryValidatorTest {
         var query = new SdJwtCredentialConstrainer()
                 .buildQuery(
                         SdJwtCredentialConstrainer.QuerySpec.of(List.of("https://example.com/vct"), List.of("sub")));
-        assertDoesNotThrow(() -> DcqlQueryValidator.validateQuery(query));
+        assertDoesNotThrow(
+                () -> DcqlQueryValidator.validateQuery(query), "Should accept a valid SD-JWT credential query");
     }
 
     private static Credential sdJwtCredential(String id, List<Claim> claims) {

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidatorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidatorTest.java
@@ -7,6 +7,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.keycloak.VCFormat;
@@ -36,14 +37,14 @@ class DcqlQueryValidatorTest {
 
         Claim claim = new Claim();
         claim.setId("claim-1");
-        claim.setPath(List.of("vp", "sub"));
+        claim.setPath(path("vp", "sub"));
         credential.setClaims(List.of(claim));
 
         assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
     }
 
     @Test
-    void rejectsArrayIndexPathSegments() {
+    void acceptsArrayIndexAndWildcardPathSegments() {
         Credential credential = new Credential();
         credential.setId("cred-1");
         credential.setFormat(VCFormat.SD_JWT_VC);
@@ -53,7 +54,24 @@ class DcqlQueryValidatorTest {
 
         Claim claim = new Claim();
         claim.setId("claim-1");
-        claim.setPath(List.of("addresses", "0", "street"));
+        claim.setPath(path("addresses", null, 0, "street"));
+        credential.setClaims(List.of(claim));
+
+        assertDoesNotThrow(() -> DcqlQueryValidator.validateCredential(credential));
+    }
+
+    @Test
+    void rejectsNegativeArrayIndexPathSegments() {
+        Credential credential = new Credential();
+        credential.setId("cred-1");
+        credential.setFormat(VCFormat.SD_JWT_VC);
+        Meta meta = new Meta();
+        meta.setVctValues(List.of("https://example.com/vct"));
+        credential.setMeta(meta);
+
+        Claim claim = new Claim();
+        claim.setId("claim-1");
+        claim.setPath(path("addresses", -1));
         credential.setClaims(List.of(claim));
 
         assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
@@ -83,7 +101,7 @@ class DcqlQueryValidatorTest {
     void rejectsUnknownClaimIdInClaimSets() {
         Claim claim = new Claim();
         claim.setId("given_name");
-        claim.setPath(List.of("given_name"));
+        claim.setPath(path("given_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(claim));
         credential.setClaimSets(List.of(List.of("family_name")));
         assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
@@ -93,10 +111,10 @@ class DcqlQueryValidatorTest {
     void rejectsDuplicateClaimIds() {
         Claim first = new Claim();
         first.setId("claim-1");
-        first.setPath(List.of("given_name"));
+        first.setPath(path("given_name"));
         Claim second = new Claim();
         second.setId("claim-1");
-        second.setPath(List.of("family_name"));
+        second.setPath(path("family_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(first, second));
         credential.setClaimSets(List.of(List.of("claim-1")));
         assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
@@ -106,10 +124,10 @@ class DcqlQueryValidatorTest {
     void rejectsDuplicateClaimPaths() {
         Claim first = new Claim();
         first.setId("claim-1");
-        first.setPath(List.of("given_name"));
+        first.setPath(path("given_name"));
         Claim second = new Claim();
         second.setId("claim-2");
-        second.setPath(List.of("given_name"));
+        second.setPath(path("given_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(first, second));
         assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
     }
@@ -118,10 +136,10 @@ class DcqlQueryValidatorTest {
     void acceptsValidClaimSets() {
         Claim givenName = new Claim();
         givenName.setId("given_name");
-        givenName.setPath(List.of("given_name"));
+        givenName.setPath(path("given_name"));
         Claim familyName = new Claim();
         familyName.setId("family_name");
-        familyName.setPath(List.of("family_name"));
+        familyName.setPath(path("family_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(givenName, familyName));
         credential.setClaimSets(List.of(List.of("given_name", "family_name"), List.of("given_name")));
         assertDoesNotThrow(() -> DcqlQueryValidator.validateCredential(credential));
@@ -144,5 +162,9 @@ class DcqlQueryValidatorTest {
         credential.setMeta(meta);
         credential.setClaims(claims);
         return credential;
+    }
+
+    private static List<Object> path(Object... segments) {
+        return Arrays.asList(segments);
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidatorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidatorTest.java
@@ -165,6 +165,16 @@ class DcqlQueryValidatorTest {
     }
 
     @Test
+    void rejectsBlankStringClaimValues() {
+        Claim claim = new Claim();
+        claim.setId("claim-1");
+        claim.setPath(List.of("age"));
+        claim.setValues(List.of(""));
+        Credential credential = sdJwtCredential("cred-1", List.of(claim));
+        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+    }
+
+    @Test
     void acceptsValidSdJwtCredentialQuery() {
         var query = new SdJwtCredentialConstrainer()
                 .buildQuery(

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidatorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidatorTest.java
@@ -146,6 +146,56 @@ class DcqlQueryValidatorTest {
     }
 
     @Test
+    void acceptsStringIntegerAndBooleanClaimValues() {
+        Claim claim = new Claim();
+        claim.setId("claim-1");
+        claim.setPath(path("age"));
+        claim.setValues(List.of("adult", 18, true));
+        Credential credential = sdJwtCredential("cred-1", List.of(claim));
+        assertDoesNotThrow(() -> DcqlQueryValidator.validateCredential(credential));
+    }
+
+    @Test
+    void rejectsEmptyClaimValues() {
+        Claim claim = new Claim();
+        claim.setId("claim-1");
+        claim.setPath(path("age"));
+        claim.setValues(List.of());
+        Credential credential = sdJwtCredential("cred-1", List.of(claim));
+        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+    }
+
+    @Test
+    void rejectsUnsupportedClaimValueTypes() {
+        Claim claim = new Claim();
+        claim.setId("claim-1");
+        claim.setPath(path("address"));
+        claim.setValues(List.of(List.of("street")));
+        Credential credential = sdJwtCredential("cred-1", List.of(claim));
+        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+    }
+
+    @Test
+    void rejectsNonIntegerNumberClaimValues() {
+        Claim claim = new Claim();
+        claim.setId("claim-1");
+        claim.setPath(path("score"));
+        claim.setValues(List.of(1.5));
+        Credential credential = sdJwtCredential("cred-1", List.of(claim));
+        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+    }
+
+    @Test
+    void rejectsNullClaimValues() {
+        Claim claim = new Claim();
+        claim.setId("claim-1");
+        claim.setPath(path("age"));
+        claim.setValues(Arrays.asList((Object) null));
+        Credential credential = sdJwtCredential("cred-1", List.of(claim));
+        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+    }
+
+    @Test
     void acceptsValidSdJwtCredentialQuery() {
         var query = new SdJwtCredentialConstrainer()
                 .buildQuery(

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidatorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidatorTest.java
@@ -7,7 +7,6 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.keycloak.VCFormat;
@@ -37,14 +36,14 @@ class DcqlQueryValidatorTest {
 
         Claim claim = new Claim();
         claim.setId("claim-1");
-        claim.setPath(path("vp", "sub"));
+        claim.setPath(List.of("vp", "sub"));
         credential.setClaims(List.of(claim));
 
         assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
     }
 
     @Test
-    void acceptsArrayIndexAndWildcardPathSegments() {
+    void rejectsArrayIndexPathSegments() {
         Credential credential = new Credential();
         credential.setId("cred-1");
         credential.setFormat(VCFormat.SD_JWT_VC);
@@ -54,27 +53,27 @@ class DcqlQueryValidatorTest {
 
         Claim claim = new Claim();
         claim.setId("claim-1");
-        claim.setPath(path("addresses", null, 0, "street"));
+        claim.setPath(List.of("addresses", "0", "street"));
+        credential.setClaims(List.of(claim));
+
+        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+    }
+
+    @Test
+    void acceptsNestedObjectKeyPathSegments() {
+        Credential credential = new Credential();
+        credential.setId("cred-1");
+        credential.setFormat(VCFormat.SD_JWT_VC);
+        Meta meta = new Meta();
+        meta.setVctValues(List.of("https://example.com/vct"));
+        credential.setMeta(meta);
+
+        Claim claim = new Claim();
+        claim.setId("claim-1");
+        claim.setPath(List.of("address", "street_address"));
         credential.setClaims(List.of(claim));
 
         assertDoesNotThrow(() -> DcqlQueryValidator.validateCredential(credential));
-    }
-
-    @Test
-    void rejectsNegativeArrayIndexPathSegments() {
-        Credential credential = new Credential();
-        credential.setId("cred-1");
-        credential.setFormat(VCFormat.SD_JWT_VC);
-        Meta meta = new Meta();
-        meta.setVctValues(List.of("https://example.com/vct"));
-        credential.setMeta(meta);
-
-        Claim claim = new Claim();
-        claim.setId("claim-1");
-        claim.setPath(path("addresses", -1));
-        credential.setClaims(List.of(claim));
-
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
     }
 
     @Test
@@ -101,7 +100,7 @@ class DcqlQueryValidatorTest {
     void rejectsUnknownClaimIdInClaimSets() {
         Claim claim = new Claim();
         claim.setId("given_name");
-        claim.setPath(path("given_name"));
+        claim.setPath(List.of("given_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(claim));
         credential.setClaimSets(List.of(List.of("family_name")));
         assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
@@ -111,10 +110,10 @@ class DcqlQueryValidatorTest {
     void rejectsDuplicateClaimIds() {
         Claim first = new Claim();
         first.setId("claim-1");
-        first.setPath(path("given_name"));
+        first.setPath(List.of("given_name"));
         Claim second = new Claim();
         second.setId("claim-1");
-        second.setPath(path("family_name"));
+        second.setPath(List.of("family_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(first, second));
         credential.setClaimSets(List.of(List.of("claim-1")));
         assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
@@ -124,10 +123,10 @@ class DcqlQueryValidatorTest {
     void rejectsDuplicateClaimPaths() {
         Claim first = new Claim();
         first.setId("claim-1");
-        first.setPath(path("given_name"));
+        first.setPath(List.of("given_name"));
         Claim second = new Claim();
         second.setId("claim-2");
-        second.setPath(path("given_name"));
+        second.setPath(List.of("given_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(first, second));
         assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
     }
@@ -136,21 +135,21 @@ class DcqlQueryValidatorTest {
     void acceptsValidClaimSets() {
         Claim givenName = new Claim();
         givenName.setId("given_name");
-        givenName.setPath(path("given_name"));
+        givenName.setPath(List.of("given_name"));
         Claim familyName = new Claim();
         familyName.setId("family_name");
-        familyName.setPath(path("family_name"));
+        familyName.setPath(List.of("family_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(givenName, familyName));
         credential.setClaimSets(List.of(List.of("given_name", "family_name"), List.of("given_name")));
         assertDoesNotThrow(() -> DcqlQueryValidator.validateCredential(credential));
     }
 
     @Test
-    void acceptsStringIntegerAndBooleanClaimValues() {
+    void acceptsStringClaimValues() {
         Claim claim = new Claim();
         claim.setId("claim-1");
-        claim.setPath(path("age"));
-        claim.setValues(List.of("adult", 18, true));
+        claim.setPath(List.of("age"));
+        claim.setValues(List.of("adult", "verified"));
         Credential credential = sdJwtCredential("cred-1", List.of(claim));
         assertDoesNotThrow(() -> DcqlQueryValidator.validateCredential(credential));
     }
@@ -159,38 +158,8 @@ class DcqlQueryValidatorTest {
     void rejectsEmptyClaimValues() {
         Claim claim = new Claim();
         claim.setId("claim-1");
-        claim.setPath(path("age"));
+        claim.setPath(List.of("age"));
         claim.setValues(List.of());
-        Credential credential = sdJwtCredential("cred-1", List.of(claim));
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
-    }
-
-    @Test
-    void rejectsUnsupportedClaimValueTypes() {
-        Claim claim = new Claim();
-        claim.setId("claim-1");
-        claim.setPath(path("address"));
-        claim.setValues(List.of(List.of("street")));
-        Credential credential = sdJwtCredential("cred-1", List.of(claim));
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
-    }
-
-    @Test
-    void rejectsNonIntegerNumberClaimValues() {
-        Claim claim = new Claim();
-        claim.setId("claim-1");
-        claim.setPath(path("score"));
-        claim.setValues(List.of(1.5));
-        Credential credential = sdJwtCredential("cred-1", List.of(claim));
-        assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
-    }
-
-    @Test
-    void rejectsNullClaimValues() {
-        Claim claim = new Claim();
-        claim.setId("claim-1");
-        claim.setPath(path("age"));
-        claim.setValues(Arrays.asList((Object) null));
         Credential credential = sdJwtCredential("cred-1", List.of(claim));
         assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
     }
@@ -212,9 +181,5 @@ class DcqlQueryValidatorTest {
         credential.setMeta(meta);
         credential.setClaims(claims);
         return credential;
-    }
-
-    private static List<Object> path(Object... segments) {
-        return Arrays.asList(segments);
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidatorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryValidatorTest.java
@@ -1,10 +1,12 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.CredentialSet;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
 import java.util.List;
@@ -22,10 +24,9 @@ class DcqlQueryValidatorTest {
         meta.setVctValues(List.of());
         credential.setMeta(meta);
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> DcqlQueryValidator.validateCredential(credential),
-                "Should reject SD-JWT credential with empty vct_values");
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals("meta.vct_values must be non-empty for dc+sd-jwt credential queries", error.getMessage());
     }
 
     @Test
@@ -42,10 +43,11 @@ class DcqlQueryValidatorTest {
         claim.setPath(List.of("vp", "sub"));
         credential.setClaims(List.of(claim));
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> DcqlQueryValidator.validateCredential(credential),
-                "Should reject SD-JWT claim paths relative to the VP wrapper");
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals(
+                "dc+sd-jwt claim paths must be relative to the VC root, not the VP wrapper: [vp, sub]",
+                error.getMessage());
     }
 
     @Test
@@ -62,10 +64,11 @@ class DcqlQueryValidatorTest {
         claim.setPath(List.of("addresses", "0", "street"));
         credential.setClaims(List.of(claim));
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> DcqlQueryValidator.validateCredential(credential),
-                "Should reject array index path segments");
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals(
+                "dcql_query claim path supports object property names only; array indexes and null wildcards are not supported",
+                error.getMessage());
     }
 
     @Test
@@ -89,30 +92,29 @@ class DcqlQueryValidatorTest {
     @Test
     void rejectsInvalidCredentialIdSyntax() {
         Credential credential = sdJwtCredential("cred.1", List.of());
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> DcqlQueryValidator.validateCredential(credential),
-                "Should reject credential ids with invalid characters");
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals(
+                "dcql_query credential id must consist of alphanumeric, underscore, or hyphen characters: cred.1",
+                error.getMessage());
     }
 
     @Test
     void rejectsDuplicateCredentialIds() {
         DcqlQuery query = new DcqlQuery();
         query.setCredentials(List.of(sdJwtCredential("cred-1", List.of()), sdJwtCredential("cred-1", List.of())));
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> DcqlQueryValidator.validateQuery(query),
-                "Should reject duplicate credential ids in dcql_query");
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateQuery(query));
+        assertEquals("dcql_query credential id must be unique: cred-1", error.getMessage());
     }
 
     @Test
     void rejectsClaimSetsWithoutClaims() {
         Credential credential = sdJwtCredential("cred-1", List.of());
         credential.setClaimSets(List.of(List.of("claim-1")));
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> DcqlQueryValidator.validateCredential(credential),
-                "Should reject claim_sets when claims are absent");
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals("dcql_query claim_sets must not be present when claims is absent", error.getMessage());
     }
 
     @Test
@@ -122,10 +124,11 @@ class DcqlQueryValidatorTest {
         claim.setPath(List.of("given_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(claim));
         credential.setClaimSets(List.of(List.of("family_name")));
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> DcqlQueryValidator.validateCredential(credential),
-                "Should reject claim_sets that reference unknown claim ids");
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals(
+                "dcql_query claim_sets references unknown claim id: family_name in credential cred-1",
+                error.getMessage());
     }
 
     @Test
@@ -138,10 +141,9 @@ class DcqlQueryValidatorTest {
         second.setPath(List.of("family_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(first, second));
         credential.setClaimSets(List.of(List.of("claim-1")));
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> DcqlQueryValidator.validateCredential(credential),
-                "Should reject duplicate claim ids within a credential");
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals("dcql_query claim id must be unique within credential cred-1: claim-1", error.getMessage());
     }
 
     @Test
@@ -153,10 +155,11 @@ class DcqlQueryValidatorTest {
         second.setId("claim-2");
         second.setPath(List.of("given_name"));
         Credential credential = sdJwtCredential("cred-1", List.of(first, second));
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> DcqlQueryValidator.validateCredential(credential),
-                "Should reject duplicate claim paths within a credential");
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals(
+                "dcql_query must not reference the same claim more than once in credential cred-1: [given_name]",
+                error.getMessage());
     }
 
     @Test
@@ -191,10 +194,9 @@ class DcqlQueryValidatorTest {
         claim.setPath(List.of("age"));
         claim.setValues(List.of());
         Credential credential = sdJwtCredential("cred-1", List.of(claim));
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> DcqlQueryValidator.validateCredential(credential),
-                "Should reject empty claim values arrays");
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals("dcql_query claim values must be non-empty when present", error.getMessage());
     }
 
     @Test
@@ -204,10 +206,173 @@ class DcqlQueryValidatorTest {
         claim.setPath(List.of("age"));
         claim.setValues(List.of(""));
         Credential credential = sdJwtCredential("cred-1", List.of(claim));
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> DcqlQueryValidator.validateCredential(credential),
-                "Should reject blank claim values entries");
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals("dcql_query claim values must not contain blank entries", error.getMessage());
+    }
+
+    @Test
+    void rejectsNullQuery() {
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateQuery(null));
+        assertEquals("dcql_query.credentials must be non-empty", error.getMessage());
+    }
+
+    @Test
+    void rejectsNullCredential() {
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(null));
+        assertEquals("dcql_query credential must not be null", error.getMessage());
+    }
+
+    @Test
+    void rejectsBlankCredentialFormat() {
+        Credential credential = sdJwtCredential("cred-1", List.of());
+        credential.setFormat("  ");
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals("dcql_query credential format must be non-empty", error.getMessage());
+    }
+
+    @Test
+    void rejectsNullCredentialMeta() {
+        Credential credential = new Credential();
+        credential.setId("cred-1");
+        credential.setFormat(VCFormat.SD_JWT_VC);
+        credential.setMeta(null);
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals("dcql_query credential meta must be present for format " + VCFormat.SD_JWT_VC, error.getMessage());
+    }
+
+    @Test
+    void rejectsUnsupportedCredentialFormat() {
+        Credential credential = new Credential();
+        credential.setId("cred-1");
+        credential.setFormat("jwt_vc_json");
+        credential.setMeta(new Meta());
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals("Unsupported dcql_query credential format: jwt_vc_json", error.getMessage());
+    }
+
+    @Test
+    void rejectsBlankVctValueInMeta() {
+        Credential credential = sdJwtCredential("cred-1", List.of());
+        credential.getMeta().setVctValues(List.of("https://example.com/vct", "  "));
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals("meta.vct_values must not contain blank entries", error.getMessage());
+    }
+
+    @Test
+    void rejectsEmptyClaimPath() {
+        Claim claim = new Claim();
+        claim.setPath(List.of());
+        Credential credential = sdJwtCredential("cred-1", List.of(claim));
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals("dcql_query claim path must be non-empty", error.getMessage());
+    }
+
+    @Test
+    void rejectsBlankClaimPathSegment() {
+        Claim claim = new Claim();
+        claim.setPath(List.of("given_name", "  "));
+        Credential credential = sdJwtCredential("cred-1", List.of(claim));
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals("dcql_query claim path segments must be non-empty", error.getMessage());
+    }
+
+    @Test
+    void rejectsNullWildcardPathSegment() {
+        Claim claim = new Claim();
+        claim.setPath(List.of("addresses", "null", "street"));
+        Credential credential = sdJwtCredential("cred-1", List.of(claim));
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals(
+                "dcql_query claim path supports object property names only; array indexes and null wildcards are not supported",
+                error.getMessage());
+    }
+
+    @Test
+    void rejectsVerifiableCredentialWrapperPath() {
+        Claim claim = new Claim();
+        claim.setPath(List.of("verifiableCredential", "sub"));
+        Credential credential = sdJwtCredential("cred-1", List.of(claim));
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals(
+                "dc+sd-jwt claim paths must be relative to the VC root, not the VP wrapper: [verifiableCredential, sub]",
+                error.getMessage());
+    }
+
+    @Test
+    void rejectsDuplicateClaimIdsWithoutClaimSets() {
+        Claim first = new Claim();
+        first.setId("claim-1");
+        first.setPath(List.of("given_name"));
+        Claim second = new Claim();
+        second.setId("claim-1");
+        second.setPath(List.of("family_name"));
+        Credential credential = sdJwtCredential("cred-1", List.of(first, second));
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals("dcql_query claim id must be unique within credential cred-1: claim-1", error.getMessage());
+    }
+
+    @Test
+    void rejectsEmptyClaimSetsOption() {
+        Claim claim = new Claim();
+        claim.setId("claim-1");
+        claim.setPath(List.of("given_name"));
+        Credential credential = sdJwtCredential("cred-1", List.of(claim));
+        credential.setClaimSets(List.of(List.of()));
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals(
+                "dcql_query claim_sets option must be a non-empty array for credential cred-1", error.getMessage());
+    }
+
+    @Test
+    void rejectsBlankClaimIdInClaimSets() {
+        Claim claim = new Claim();
+        claim.setId("claim-1");
+        claim.setPath(List.of("given_name"));
+        Credential credential = sdJwtCredential("cred-1", List.of(claim));
+        credential.setClaimSets(List.of(List.of("  ")));
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateCredential(credential));
+        assertEquals(
+                "dcql_query claim_sets must reference non-empty claim ids for credential cred-1", error.getMessage());
+    }
+
+    @Test
+    void rejectsUnknownCredentialIdInCredentialSets() {
+        Credential credential = sdJwtCredential("cred-1", List.of());
+        DcqlQuery query = new DcqlQuery();
+        query.setCredentials(List.of(credential));
+        CredentialSet credentialSet = new CredentialSet();
+        credentialSet.setOptions(List.of(List.of("missing-cred")));
+        query.setCredentialSets(List.of(credentialSet));
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateQuery(query));
+        assertEquals("dcql_query credential_sets references unknown credential id: missing-cred", error.getMessage());
+    }
+
+    @Test
+    void rejectsEmptyCredentialSetOptions() {
+        Credential credential = sdJwtCredential("cred-1", List.of());
+        DcqlQuery query = new DcqlQuery();
+        query.setCredentials(List.of(credential));
+        CredentialSet credentialSet = new CredentialSet();
+        credentialSet.setOptions(List.of());
+        query.setCredentialSets(List.of(credentialSet));
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> DcqlQueryValidator.validateQuery(query));
+        assertEquals("dcql_query credential_sets.options must be non-empty when present", error.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Summary

This PR completes OpenID4VP 1.0 §8.6(2.2) DCQL query-criteria validation for the SD-JWT VC login flow.

Previously, VP token validation only checked whether requested claim paths were present. This PR validates full DCQL criteria satisfaction during presentation validation.

### What changed

- Resolve nested string object-key claim paths, including through selectively disclosed SD-JWT claims (e.g. `["address", "street_address"]`)
- Validate DCQL `claim.values` during presentation validation; reject empty `values` arrays at query build time
- Apply runtime `claim_sets` satisfaction (at least one option must match)
- Keep `Claim.path` and `Claim.values` as `List<String>`, matching the plugin’s current DCQL query builder
- Keep existing SD-JWT VC scope (single credential, `dc+sd-jwt`)

## Test plan

- [x] `DcqlQueryValidatorTest`