### PR TITLE
refactor(oid4vp): Use sdjwt_tokens as sole SD-JWT auth note

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticator.java
@@ -61,14 +61,11 @@ public class SdJwtAuthenticator implements Authenticator {
     public static final String CHALLENGE_AUD_KEY = "aud";
 
     /**
-     * The authenticating party presents a non-replayable SD-JWT token for authentication.
-     */
-    public static final String SDJWT_TOKEN_KEY = "sdjwt_token";
-
-    /**
-     * Optional serialized map of DCQL credential IDs to presented SD-JWT VP tokens.
+     * Serialized map of DCQL credential IDs to presented SD-JWT VP tokens.
      */
     public static final String SDJWT_TOKENS_KEY = "sdjwt_tokens";
+
+    public static final String PROFILE_ID_KEY = "oid4vp_profile_id";
 
     public static final String REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING_KEY = "require_cryptographic_holder_binding";
 
@@ -91,7 +88,15 @@ public class SdJwtAuthenticator implements Authenticator {
         String aud = authSession.getAuthNote(CHALLENGE_AUD_KEY);
         boolean requireCryptographicHolderBinding = parseRequireCryptographicHolderBinding(
                 authSession.getAuthNote(REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING_KEY));
-        SdJwtVP sdJwt = SdJwtVP.of(authSession.getAuthNote(SDJWT_TOKEN_KEY));
+
+        Map<String, String> sdJwtVpTokens = getPresentedSdJwtTokens(authSession);
+        String primaryToken = sdJwtVpTokens.get(primaryCredential.getId());
+        if (StringUtil.isBlank(primaryToken)) {
+            failRejectingPresentedSdJwtToken(
+                    context, "Missing SD-JWT presentation for credential: " + primaryCredential.getId());
+            return;
+        }
+        SdJwtVP sdJwt = SdJwtVP.of(primaryToken);
 
         try {
             consumer.verifySdJwtPresentation(
@@ -137,7 +142,6 @@ public class SdJwtAuthenticator implements Authenticator {
         }
 
         try {
-            Map<String, String> sdJwtVpTokens = getPresentedSdJwtTokens(authSession);
             new SdJwtSupportingCredentialVerifier(context.getSession(), consumer, tokenStatusValidator)
                     .verify(
                             profile,
@@ -174,9 +178,16 @@ public class SdJwtAuthenticator implements Authenticator {
     }
 
     private AuthenticationProfile getAuthenticationProfile(AuthenticationFlowContext context) {
+        AuthenticationSessionModel authSession = context.getAuthenticationSession();
         OID4VPProfileConfig profileConfig =
                 new OID4VPProfileConfig(context.getSession().getContext(), context.getAuthenticatorConfig());
-        AuthenticationSessionStore store = new AuthenticationSessionStore(context.getAuthenticationSession());
+
+        String profileId = authSession.getAuthNote(PROFILE_ID_KEY);
+        if (!StringUtil.isBlank(profileId)) {
+            return profileConfig.getProfile(profileId);
+        }
+
+        AuthenticationSessionStore store = new AuthenticationSessionStore(authSession);
         if (!store.hasAuthorizationContext()) {
             return profileConfig.getProfile(AuthenticationProfile.DEFAULT_PROFILE_ID);
         }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticator.java
@@ -16,6 +16,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusList
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -64,8 +65,6 @@ public class SdJwtAuthenticator implements Authenticator {
      * Serialized map of DCQL credential IDs to presented SD-JWT VP tokens.
      */
     public static final String SDJWT_TOKENS_KEY = "sdjwt_tokens";
-
-    public static final String PROFILE_ID_KEY = "oid4vp_profile_id";
 
     public static final String REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING_KEY = "require_cryptographic_holder_binding";
 
@@ -145,7 +144,7 @@ public class SdJwtAuthenticator implements Authenticator {
             new SdJwtSupportingCredentialVerifier(context.getSession(), consumer, tokenStatusValidator)
                     .verify(
                             profile,
-                            sdJwtVpTokens,
+                            supportingSdJwtVpTokens(sdJwtVpTokens, primaryCredential.getId()),
                             sdJwt,
                             user,
                             context.getAuthenticatorConfig(),
@@ -178,16 +177,9 @@ public class SdJwtAuthenticator implements Authenticator {
     }
 
     private AuthenticationProfile getAuthenticationProfile(AuthenticationFlowContext context) {
-        AuthenticationSessionModel authSession = context.getAuthenticationSession();
         OID4VPProfileConfig profileConfig =
                 new OID4VPProfileConfig(context.getSession().getContext(), context.getAuthenticatorConfig());
-
-        String profileId = authSession.getAuthNote(PROFILE_ID_KEY);
-        if (!StringUtil.isBlank(profileId)) {
-            return profileConfig.getProfile(profileId);
-        }
-
-        AuthenticationSessionStore store = new AuthenticationSessionStore(authSession);
+        AuthenticationSessionStore store = new AuthenticationSessionStore(context.getAuthenticationSession());
         if (!store.hasAuthorizationContext()) {
             return profileConfig.getProfile(AuthenticationProfile.DEFAULT_PROFILE_ID);
         }
@@ -206,6 +198,17 @@ public class SdJwtAuthenticator implements Authenticator {
         } catch (IOException e) {
             throw new IllegalStateException("Invalid SD-JWT tokens auth note", e);
         }
+    }
+
+    private static Map<String, String> supportingSdJwtVpTokens(
+            Map<String, String> presentedTokens, String primaryCredentialId) {
+        Map<String, String> supportingTokens = new HashMap<>();
+        presentedTokens.forEach((credentialId, token) -> {
+            if (!primaryCredentialId.equals(credentialId)) {
+                supportingTokens.put(credentialId, token);
+            }
+        });
+        return supportingTokens;
     }
 
     private static boolean parseRequireCryptographicHolderBinding(String note) {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlCredentialCapability.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlCredentialCapability.java
@@ -5,6 +5,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientMetadata
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
 import java.util.List;
+import java.util.Map;
 import org.keycloak.common.VerificationException;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
@@ -26,7 +27,7 @@ public interface DcqlCredentialCapability {
 
     void setupAuthenticationSession(
             AuthenticationSessionModel authenticationSession,
-            String presentedToken,
+            Map<String, String> presentedTokens,
             AuthorizationContext authorizationContext);
 
     void contributeVpFormatsSupported(ClientMetadata.VpFormat vpFormat, List<String> signatureAlgorithms);

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/SdJwtDcqlCredentialCapability.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/SdJwtDcqlCredentialCapability.java
@@ -13,7 +13,6 @@ import org.keycloak.VCFormat;
 import org.keycloak.common.VerificationException;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.JsonSerialization;
-import org.keycloak.utils.StringUtil;
 
 /** Production DCQL path for {@code dc+sd-jwt} user authentication. */
 public final class SdJwtDcqlCredentialCapability implements DcqlCredentialCapability {
@@ -48,9 +47,6 @@ public final class SdJwtDcqlCredentialCapability implements DcqlCredentialCapabi
             AuthorizationContext authorizationContext) {
         authenticationSession.setAuthNote(
                 SdJwtAuthenticator.SDJWT_TOKENS_KEY, JsonSerialization.valueAsString(presentedTokens));
-        if (!StringUtil.isBlank(authorizationContext.getProfileId())) {
-            authenticationSession.setAuthNote(SdJwtAuthenticator.PROFILE_ID_KEY, authorizationContext.getProfileId());
-        }
         String nonce = authorizationContext.getRequestObject().getNonce();
         String aud = authorizationContext.getRequestObject().getClientId();
         authenticationSession.setAuthNote(SdJwtAuthenticator.CHALLENGE_NONCE_KEY, nonce);

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/SdJwtDcqlCredentialCapability.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/SdJwtDcqlCredentialCapability.java
@@ -8,10 +8,12 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.SdGenericFormat;
 import java.util.List;
+import java.util.Map;
 import org.keycloak.VCFormat;
 import org.keycloak.common.VerificationException;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.JsonSerialization;
+import org.keycloak.utils.StringUtil;
 
 /** Production DCQL path for {@code dc+sd-jwt} user authentication. */
 public final class SdJwtDcqlCredentialCapability implements DcqlCredentialCapability {
@@ -42,11 +44,15 @@ public final class SdJwtDcqlCredentialCapability implements DcqlCredentialCapabi
     @Override
     public void setupAuthenticationSession(
             AuthenticationSessionModel authenticationSession,
-            String presentedToken,
+            Map<String, String> presentedTokens,
             AuthorizationContext authorizationContext) {
+        authenticationSession.setAuthNote(
+                SdJwtAuthenticator.SDJWT_TOKENS_KEY, JsonSerialization.valueAsString(presentedTokens));
+        if (!StringUtil.isBlank(authorizationContext.getProfileId())) {
+            authenticationSession.setAuthNote(SdJwtAuthenticator.PROFILE_ID_KEY, authorizationContext.getProfileId());
+        }
         String nonce = authorizationContext.getRequestObject().getNonce();
         String aud = authorizationContext.getRequestObject().getClientId();
-        authenticationSession.setAuthNote(SdJwtAuthenticator.SDJWT_TOKEN_KEY, presentedToken);
         authenticationSession.setAuthNote(SdJwtAuthenticator.CHALLENGE_NONCE_KEY, nonce);
         authenticationSession.setAuthNote(SdJwtAuthenticator.CHALLENGE_AUD_KEY, aud);
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationResponseService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationResponseService.java
@@ -93,6 +93,7 @@ public class AuthorizationResponseService {
         var dcqlCapability =
                 dcqlCapabilities.resolveForPresentation(singleCredentialQuery(dcqlQuery, primaryCredential.getId()));
         dcqlCapability.setupAuthenticationSession(processorSession, sdJwtVpTokens, authContext);
+        new AuthenticationSessionStore(processorSession).storeAuthorizationContext(authContext);
 
         // Run authentication processor to validate the SD-JWT VP token
         logger.debug("Running authentication processor to validate SD-JWT VP token...");

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationResponseService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationResponseService.java
@@ -3,7 +3,6 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oidc.freemarker.OID4VPUserAuthBean.LOGIN_METHOD_OID4VP;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oidc.freemarker.OID4VPUserAuthBean.PARAM_LOGIN_METHOD;
 
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.SdJwtAuthenticator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql.DcqlCredentialCapabilities;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql.DcqlQueryBuilder;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseObject;
@@ -36,7 +35,6 @@ import org.keycloak.protocol.oidc.utils.OAuth2CodeParser;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.services.Urls;
 import org.keycloak.sessions.AuthenticationSessionModel;
-import org.keycloak.util.JsonSerialization;
 import org.keycloak.utils.MediaType;
 
 /**
@@ -86,18 +84,15 @@ public class AuthorizationResponseService {
                     store);
         }
 
-        CredentialRequirement primaryCredential = profile.getPrimaryCredential();
         HashMap<String, String> sdJwtVpTokens = extractSdJwtVpTokens(responseObject, profile, store, authContext);
-        String primarySdJwtVp = sdJwtVpTokens.get(primaryCredential.getId());
 
-        logger.debugf("Initializing authentication with extracted SD-JWT VP token");
+        logger.debugf("Initializing authentication with extracted SD-JWT VP tokens");
         var processorSession = authProcessor.getAuthenticationSession();
         var dcqlQuery = authContext.getRequestObject().getDcqlQuery();
+        CredentialRequirement primaryCredential = profile.getPrimaryCredential();
         var dcqlCapability =
                 dcqlCapabilities.resolveForPresentation(singleCredentialQuery(dcqlQuery, primaryCredential.getId()));
-        dcqlCapability.setupAuthenticationSession(processorSession, primarySdJwtVp, authContext);
-        processorSession.setAuthNote(
-                SdJwtAuthenticator.SDJWT_TOKENS_KEY, JsonSerialization.valueAsString(sdJwtVpTokens));
+        dcqlCapability.setupAuthenticationSession(processorSession, sdJwtVpTokens, authContext);
 
         // Run authentication processor to validate the SD-JWT VP token
         logger.debug("Running authentication processor to validate SD-JWT VP token...");


### PR DESCRIPTION
## Summary

Closes #108 by removing the redundant `sdjwt_token` auth note and using `sdjwt_tokens` as the single store for presented SD-JWT VPs (single- and multi-credential flows).

The authenticator resolves the primary credential from the map by profile credential id. Supporting credentials are passed to the verifier as a filtered subset (excluding the primary). The authorization context is stored on the ephemeral processor session via `AuthenticationSessionStore.storeAuthorizationContext()` so profile resolution works correctly.

## Test plan

- [x] `mvn test` (161 tests)