### PR TITLE
fix(oid4vp): enforce revocation status validation for mDoc presentations

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationContext.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationContext.java
@@ -13,6 +13,7 @@ import com.authlete.cose.COSEException;
 import com.authlete.cose.COSEKey;
 import com.authlete.cose.COSESign1;
 import com.authlete.cose.COSEVerifier;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.crypto.PKIXVerificationUtil;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.trust.TrustAnchorProvider;
 import java.io.IOException;
@@ -48,6 +49,7 @@ public class MdocVerificationContext {
             List.of(JavaAlgorithm.SHA256, JavaAlgorithm.SHA384, JavaAlgorithm.SHA512);
 
     private final CBORPairList mdoc;
+    private JsonNode verifiedMsoPayload;
 
     public MdocVerificationContext(String mdoc) throws VerificationException {
         try {
@@ -81,6 +83,7 @@ public class MdocVerificationContext {
 
         // Verify device key binding
         CBORPairList mso = (CBORPairList) CborUtil.unwrap(issuerAuth.getPayload());
+        storeVerifiedMsoPayload(mso);
         verifyDeviceKeyBinding(document, mso, opts);
 
         // Verify that presented claims are protected by digests in MSO
@@ -303,7 +306,7 @@ public class MdocVerificationContext {
         }
     }
 
-    public static CBORPairList extractDocument(CBORPairList root) throws VerificationException {
+    static CBORPairList extractDocument(CBORPairList root) throws VerificationException {
         var documentsEntry = root.findByKey(MdocConstants.L_DOCUMENTS);
         if (documentsEntry == null) {
             throw new VerificationException("mDoc response is missing the 'documents' field");
@@ -338,7 +341,7 @@ public class MdocVerificationContext {
                 deviceSigned.findByKey(MdocConstants.L_NAME_SPACES).getValue();
     }
 
-    public static COSESign1 extractIssuerAuth(CBORPairList document) throws VerificationException {
+    static COSESign1 extractIssuerAuth(CBORPairList document) throws VerificationException {
         var issuerSigned =
                 (CBORPairList) document.findByKey(MdocConstants.L_ISSUER_SIGNED).getValue();
         var issuerAuth = (CBORItemList)
@@ -379,5 +382,21 @@ public class MdocVerificationContext {
         } catch (COSEException e) {
             throw new VerificationException("Failure parsing deviceSignature as COSE_Sign1", e);
         }
+    }
+
+    private void storeVerifiedMsoPayload(CBORPairList mso) throws VerificationException {
+        try {
+            this.verifiedMsoPayload = JsonSerialization.mapper.valueToTree(new CBORParser(mso.encode()).next());
+        } catch (IOException e) {
+            throw new VerificationException("Failed to serialize verified MSO", e);
+        }
+    }
+
+    /**
+     * @see <a href="https://learn.mattr.global/docs/holding/credential-claiming-guides/revocation-status-check#how-status-information-is-stored">
+     * MATTR docs — status information in the MSO</a>
+     */
+    public JsonNode getVerifiedMsoPayload() {
+        return verifiedMsoPayload;
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationContext.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationContext.java
@@ -83,8 +83,8 @@ public class MdocVerificationContext {
 
         // Verify device key binding
         CBORPairList mso = (CBORPairList) CborUtil.unwrap(issuerAuth.getPayload());
-        storeVerifiedMsoPayload(mso);
         verifyDeviceKeyBinding(document, mso, opts);
+        storeVerifiedMsoPayload(mso);
 
         // Verify that presented claims are protected by digests in MSO
         CBORPairList namespaces = extractNamespaces(document);
@@ -392,10 +392,6 @@ public class MdocVerificationContext {
         }
     }
 
-    /**
-     * @see <a href="https://learn.mattr.global/docs/holding/credential-claiming-guides/revocation-status-check#how-status-information-is-stored">
-     * MATTR docs — status information in the MSO</a>
-     */
     public JsonNode getVerifiedMsoPayload() {
         return verifiedMsoPayload;
     }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationContext.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationContext.java
@@ -303,7 +303,7 @@ public class MdocVerificationContext {
         }
     }
 
-    private static CBORPairList extractDocument(CBORPairList root) throws VerificationException {
+    public static CBORPairList extractDocument(CBORPairList root) throws VerificationException {
         var documentsEntry = root.findByKey(MdocConstants.L_DOCUMENTS);
         if (documentsEntry == null) {
             throw new VerificationException("mDoc response is missing the 'documents' field");
@@ -338,7 +338,7 @@ public class MdocVerificationContext {
                 deviceSigned.findByKey(MdocConstants.L_NAME_SPACES).getValue();
     }
 
-    private static COSESign1 extractIssuerAuth(CBORPairList document) throws VerificationException {
+    public static COSESign1 extractIssuerAuth(CBORPairList document) throws VerificationException {
         var issuerSigned =
                 (CBORPairList) document.findByKey(MdocConstants.L_ISSUER_SIGNED).getValue();
         var issuerAuth = (CBORItemList)

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticatorFactory.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticatorFactory.java
@@ -250,7 +250,7 @@ public class OID4VPAuthenticatorFactory implements AuthenticatorFactory, OID4VPE
         StatusListJwtFetcher httpFetcher = new TrustedStatusListJwtFetcher(session);
         Map<String, CredentialVerifier> handlers = new LinkedHashMap<>();
         handlers.put(CredentialFormat.SD_JWT_VC.getValue(), new SdJwtCredentialVerifier(httpFetcher));
-        handlers.put(CredentialFormat.MSO_MDOC.getValue(), new MdocCredentialVerifier());
+        handlers.put(CredentialFormat.MSO_MDOC.getValue(), new MdocCredentialVerifier(httpFetcher));
         return handlers;
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
@@ -2,11 +2,7 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.mdoc;
 
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants.L_NAME_SPACES;
 
-import com.authlete.cbor.CBORParser;
 import com.fasterxml.jackson.databind.JsonNode;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.CborUtil;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocEncodingException;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocParser;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationOpts;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.CredentialFormat;
@@ -20,7 +16,6 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.trust.TrustAnchorPro
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.ReferencedTokenValidationException;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
-import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.keycloak.authentication.AuthenticationFlowContext;
@@ -29,7 +24,6 @@ import org.keycloak.common.util.Base64Url;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.sdjwt.consumer.PresentationRequirements;
 import org.keycloak.util.JWKSUtils;
-import org.keycloak.util.JsonSerialization;
 
 /**
  * {@link CredentialVerifier} implementation backing verification of {@code mso_mdoc}
@@ -82,12 +76,12 @@ public class MdocCredentialVerifier implements CredentialVerifier {
             authReqs.getPresentationRequirements().checkIfSatisfiedBy(payload);
         };
 
-        new MdocVerificationContext(token).verifyPresentation(opts, requirements, truststore);
+        MdocVerificationContext verificationContext = new MdocVerificationContext(token);
+        verificationContext.verifyPresentation(opts, requirements, truststore);
 
         if (authReqs.shouldEnforceRevocationStatus()) {
             try {
-                JsonNode msoPayload = extractMsoPayload(token);
-                tokenStatusValidator.validate(msoPayload);
+                tokenStatusValidator.validate(verificationContext.getVerifiedMsoPayload());
             } catch (ReferencedTokenValidationException e) {
                 throw new VerificationException(
                         String.format(
@@ -98,24 +92,6 @@ public class MdocCredentialVerifier implements CredentialVerifier {
         }
 
         return payloadRef.get().get(L_NAME_SPACES);
-    }
-
-    /**
-     * Extracts the Mobile Security Object (MSO) payload from an mDoc device response
-     * and converts it to a {@link JsonNode} for verification and status checks.
-     *
-     * @see https://learn.mattr.global/docs/holding/credential-claiming-guides/revocation-status-check#how-status-information-is-stored
-     */
-    static JsonNode extractMsoPayload(String mdocToken) throws VerificationException {
-        try {
-            var response = MdocParser.parseBase64Url(mdocToken);
-            var document = MdocVerificationContext.extractDocument(response);
-            var issuerAuth = MdocVerificationContext.extractIssuerAuth(document);
-            var msoPayload = CborUtil.unwrap(issuerAuth.getPayload());
-            return JsonSerialization.mapper.valueToTree(new CBORParser(msoPayload.encode()).next());
-        } catch (MdocEncodingException | IOException e) {
-            throw new VerificationException("Failed to extract MSO payload for status verification", e);
-        }
     }
 
     /**

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
@@ -2,15 +2,9 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.mdoc;
 
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants.L_NAME_SPACES;
 
-import com.authlete.cbor.CBORItem;
-import com.authlete.cbor.CBORItemList;
-import com.authlete.cbor.CBORPairList;
 import com.authlete.cbor.CBORParser;
-import com.authlete.cose.COSEException;
-import com.authlete.cose.COSESign1;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.CborUtil;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocEncodingException;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocParser;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationContext;
@@ -106,44 +100,22 @@ public class MdocCredentialVerifier implements CredentialVerifier {
         return payloadRef.get().get(L_NAME_SPACES);
     }
 
+    /**
+     * Extracts the Mobile Security Object (MSO) payload from an mDoc device response
+     * and converts it to a {@link JsonNode} for verification and status checks.
+     *
+     * @see https://learn.mattr.global/docs/holding/credential-claiming-guides/revocation-status-check#how-status-information-is-stored
+     */
     static JsonNode extractMsoPayload(String mdocToken) throws VerificationException {
         try {
             var response = MdocParser.parseBase64Url(mdocToken);
-            var documents = findRequired(response, MdocConstants.L_DOCUMENTS, CBORItemList.class);
-            var document = firstDocument(documents);
-            var issuerSigned = findRequired(document, MdocConstants.L_ISSUER_SIGNED, CBORPairList.class);
-            var issuerAuthList = findRequired(issuerSigned, MdocConstants.L_ISSUER_AUTH, CBORItemList.class);
-            var payload = CborUtil.unwrap(COSESign1.build(issuerAuthList).getPayload());
-            return JsonSerialization.mapper.valueToTree(new CBORParser(payload.encode()).next());
-        } catch (MdocEncodingException | COSEException | IOException e) {
+            var document = MdocVerificationContext.extractDocument(response);
+            var issuerAuth = MdocVerificationContext.extractIssuerAuth(document);
+            var msoPayload = CborUtil.unwrap(issuerAuth.getPayload());
+            return JsonSerialization.mapper.valueToTree(new CBORParser(msoPayload.encode()).next());
+        } catch (MdocEncodingException | IOException e) {
             throw new VerificationException("Failed to extract MSO payload for status verification", e);
         }
-    }
-
-    private static <T extends CBORItem> T findRequired(CBORPairList parent, String key, Class<T> type)
-            throws VerificationException {
-        var entry = parent.findByKey(key);
-        if (entry == null || !type.isInstance(entry.getValue())) {
-            throw new VerificationException("mDoc response has invalid or missing '" + key + "'");
-        }
-        return type.cast(entry.getValue());
-    }
-
-    private static CBORPairList firstDocument(CBORItemList documents) throws VerificationException {
-
-        var items = documents.getItems();
-
-        if (items.isEmpty()) {
-            throw new VerificationException("mDoc response contains no documents");
-        }
-
-        var first = items.getFirst();
-
-        if (!(first instanceof CBORPairList doc)) {
-            throw new VerificationException("mDoc document has invalid format");
-        }
-
-        return doc;
     }
 
     /**

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
@@ -81,6 +81,10 @@ public class MdocCredentialVerifier implements CredentialVerifier {
 
         if (authReqs.shouldEnforceRevocationStatus()) {
             try {
+                // Status is stored in the MSO payload per IETF Token Status List §Referenced Token
+                // (https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-11.html#name-referenced-token-in-cose)
+                // and MATTR docs
+                // (https://learn.mattr.global/docs/holding/credential-claiming-guides/revocation-status-check).
                 tokenStatusValidator.validate(verificationContext.getVerifiedMsoPayload());
             } catch (ReferencedTokenValidationException e) {
                 throw new VerificationException(

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
@@ -2,7 +2,17 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.mdoc;
 
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants.L_NAME_SPACES;
 
+import com.authlete.cbor.CBORItem;
+import com.authlete.cbor.CBORItemList;
+import com.authlete.cbor.CBORPairList;
+import com.authlete.cbor.CBORParser;
+import com.authlete.cose.COSEException;
+import com.authlete.cose.COSESign1;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.CborUtil;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocEncodingException;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocParser;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationOpts;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.CredentialFormat;
@@ -13,15 +23,19 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.Authorizat
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement.ClaimReference;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.trust.TrustAnchorProvider;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.ReferencedTokenValidationException;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
+import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.sdjwt.consumer.PresentationRequirements;
 import org.keycloak.util.JWKSUtils;
+import org.keycloak.util.JsonSerialization;
 
 /**
  * {@link CredentialVerifier} implementation backing verification of {@code mso_mdoc}
@@ -32,7 +46,11 @@ import org.keycloak.util.JWKSUtils;
  */
 public class MdocCredentialVerifier implements CredentialVerifier {
 
-    private static final Logger logger = Logger.getLogger(MdocCredentialVerifier.class);
+    private final ReferencedTokenValidator tokenStatusValidator;
+
+    public MdocCredentialVerifier(StatusListJwtFetcher statusListJwtFetcher) {
+        this.tokenStatusValidator = new ReferencedTokenValidator(statusListJwtFetcher);
+    }
 
     @Override
     public CredentialFormat format() {
@@ -70,15 +88,62 @@ public class MdocCredentialVerifier implements CredentialVerifier {
             authReqs.getPresentationRequirements().checkIfSatisfiedBy(payload);
         };
 
-        // TODO: Implement revocation status check for mDoc credentials
-        if (authReqs.shouldEnforceRevocationStatus()) {
-            throw new VerificationException(
-                    "Revocation status enforcement is not yet implemented for mso_mdoc credentials");
-        }
-
         new MdocVerificationContext(token).verifyPresentation(opts, requirements, truststore);
 
+        if (authReqs.shouldEnforceRevocationStatus()) {
+            try {
+                JsonNode msoPayload = extractMsoPayload(token);
+                tokenStatusValidator.validate(msoPayload);
+            } catch (ReferencedTokenValidationException e) {
+                throw new VerificationException(
+                        String.format(
+                                "Token status verification failed for credential to requirement '%s'",
+                                credential.getId()),
+                        e);
+            }
+        }
+
         return payloadRef.get().get(L_NAME_SPACES);
+    }
+
+    static JsonNode extractMsoPayload(String mdocToken) throws VerificationException {
+        try {
+            var response = MdocParser.parseBase64Url(mdocToken);
+            var documents = findRequired(response, MdocConstants.L_DOCUMENTS, CBORItemList.class);
+            var document = firstDocument(documents);
+            var issuerSigned = findRequired(document, MdocConstants.L_ISSUER_SIGNED, CBORPairList.class);
+            var issuerAuthList = findRequired(issuerSigned, MdocConstants.L_ISSUER_AUTH, CBORItemList.class);
+            var payload = CborUtil.unwrap(COSESign1.build(issuerAuthList).getPayload());
+            return JsonSerialization.mapper.valueToTree(new CBORParser(payload.encode()).next());
+        } catch (MdocEncodingException | COSEException | IOException e) {
+            throw new VerificationException("Failed to extract MSO payload for status verification", e);
+        }
+    }
+
+    private static <T extends CBORItem> T findRequired(CBORPairList parent, String key, Class<T> type)
+            throws VerificationException {
+        var entry = parent.findByKey(key);
+        if (entry == null || !type.isInstance(entry.getValue())) {
+            throw new VerificationException("mDoc response has invalid or missing '" + key + "'");
+        }
+        return type.cast(entry.getValue());
+    }
+
+    private static CBORPairList firstDocument(CBORItemList documents) throws VerificationException {
+
+        var items = documents.getItems();
+
+        if (items.isEmpty()) {
+            throw new VerificationException("mDoc response contains no documents");
+        }
+
+        var first = items.getFirst();
+
+        if (!(first instanceof CBORPairList doc)) {
+            throw new VerificationException("mDoc document has invalid format");
+        }
+
+        return doc;
     }
 
     /**

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocBaseTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocBaseTest.java
@@ -60,6 +60,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.keycloak.crypto.JavaAlgorithm;
@@ -404,6 +405,35 @@ public class MdocBaseTest {
         CBORItemList documents =
                 (CBORItemList) dr.findByKey(MdocConstants.L_DOCUMENTS).getValue();
         return (Document) documents.getItems().getFirst();
+    }
+
+    /**
+     * Returns a new {@link DeviceResponse} whose MSO has been replaced by applying
+     * {@code msoCustomizer} to the original MSO payload and re-signing it. The device
+     * signature and namespaces are carried over unchanged.
+     */
+    protected static DeviceResponse withModifiedMso(DeviceResponse dr, UnaryOperator<CBORPairList> msoCustomizer)
+            throws Exception {
+        Document doc = extractDocument(dr);
+        IssuerSigned issuerSigned =
+                (IssuerSigned) doc.findByKey(MdocConstants.L_ISSUER_SIGNED).getValue();
+        CBORItemList issuerAuthList = (CBORItemList)
+                issuerSigned.findByKey(MdocConstants.L_ISSUER_AUTH).getValue();
+        CBORPairList originalMso =
+                (CBORPairList) CborUtil.unwrap(COSESign1.build(issuerAuthList).getPayload());
+
+        CBORPairList modifiedMso = msoCustomizer.apply(originalMso);
+        COSESign1 newIssuerAuth = signRawCbor(modifiedMso, getIssuerKeyRef1(), List.of(getIssuerCertRef1()));
+        IssuerSigned newIssuerSigned = new IssuerSigned(
+                (IssuerNameSpaces)
+                        issuerSigned.findByKey(MdocConstants.L_NAME_SPACES).getValue(),
+                newIssuerAuth);
+
+        return new DeviceResponse(List.of(new Document(
+                DOC_TYPE,
+                newIssuerSigned,
+                (DeviceSigned) doc.findByKey(MdocConstants.L_DEVICE_SIGNED).getValue(),
+                null)));
     }
 
     protected static ValueDigests extractValueDigests(MobileSecurityObject mso) {

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocBaseTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocBaseTest.java
@@ -6,6 +6,7 @@ import com.authlete.cbor.CBORByteArray;
 import com.authlete.cbor.CBORInteger;
 import com.authlete.cbor.CBORItemList;
 import com.authlete.cbor.CBORNull;
+import com.authlete.cbor.CBORPairList;
 import com.authlete.cbor.CBORString;
 import com.authlete.cbor.CBORTaggedItem;
 import com.authlete.cose.COSEEC2Key;
@@ -44,8 +45,11 @@ import com.authlete.mdoc.ValueDigestsEntry;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.mdoc.MdocCredentialVerifier;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -514,6 +518,35 @@ public class MdocBaseTest {
                 .ec2YInBase64Url("nZDEU7-G2Ij3gNA2I5Y8ngAf7r-vGeBeI9p9bj8glFc")
                 .ec2DInBase64Url("6hgQOsgeFUXDmEA8wsxslFSqYF5EoJ858ebE29HdV5w")
                 .buildEC2Key();
+    }
+
+    public static COSESign1 signRawCbor(CBORPairList mso, COSEEC2Key issuerKey, List<X509Certificate> x5chain)
+            throws IOException, COSEException, CertificateEncodingException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        mso.encode(baos);
+        byte[] msoBytes = baos.toByteArray();
+        CBORTaggedItem wrapped = CborUtil.wrap(msoBytes);
+
+        COSEProtectedHeaderBuilder protectedBuilder = new COSEProtectedHeaderBuilder().alg(COSEAlgorithms.ES256);
+        COSEUnprotectedHeader unprotectedHeader = (x5chain == null || x5chain.isEmpty())
+                ? null
+                : new COSEUnprotectedHeaderBuilder().x5chain(x5chain).build();
+
+        var sigStructure = new SigStructureBuilder()
+                .signature1()
+                .bodyAttributes(protectedBuilder.build())
+                .payload(wrapped.encode())
+                .build();
+        byte[] signature = new COSESigner(issuerKey.toECPrivateKey()).sign(sigStructure, COSEAlgorithms.ES256);
+
+        var builder = new COSESign1Builder()
+                .protectedHeader(protectedBuilder.build())
+                .payload(new CBORByteArray(wrapped.encode()))
+                .signature(signature);
+        if (unprotectedHeader != null) {
+            builder.unprotectedHeader(unprotectedHeader);
+        }
+        return builder.build();
     }
 
     public static X509Certificate toCert(String cert) {

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationTest.java
@@ -69,6 +69,22 @@ public class MdocVerificationTest extends MdocBaseTest {
     }
 
     @Test
+    public void shouldExtractMsoAsJson() throws Exception {
+        MdocVerificationOpts opts = getDefaultMdocVerificationOpts().build();
+        String mdoc = buildDeviceResponse(opts).encodeToBase64Url();
+        var ctx = new MdocVerificationContext(mdoc);
+        ctx.verifyPresentation(opts, null, new TestTruststoreProvider(getIssuerCertRef1()));
+        JsonNode mso = ctx.getVerifiedMsoPayload();
+
+        assertNotNull(mso);
+        assertEquals("1.0", mso.get("version").asText());
+        assertEquals("SHA-256", mso.get("digestAlgorithm").asText());
+        assertNotNull(mso.get("valueDigests"));
+        assertNotNull(mso.get("deviceKeyInfo"));
+        assertNotNull(mso.get("validityInfo"));
+    }
+
+    @Test
     public void shouldFail_OnExpiredResponses() throws Exception {
         MdocVerificationOpts opts = getDefaultMdocVerificationOpts().build();
         String mdoc = buildDeviceResponse(opts).encodeToBase64Url();

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
@@ -5,6 +5,7 @@ import static io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.Referenc
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,6 +46,7 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -101,35 +103,32 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
     @Test
     public void shouldFail_WhenRevocationEnforcedAndStatusMissing() throws Exception {
         String mdoc = buildDeviceResponse(opts).encodeToBase64Url();
-        JsonNode mso = MdocCredentialVerifier.extractMsoPayload(mdoc);
+        var mso = MdocCredentialVerifier.extractMsoPayload(mdoc);
 
-        assertTrue(mso.get(STATUS_FIELD) == null || mso.get(STATUS_FIELD).isNull());
-
-        ReferencedTokenValidator validator = new ReferencedTokenValidator(mockFetcher);
-        var exception = assertThrows(ReferencedTokenValidationException.class, () -> validator.validate(mso));
+        assertNull(mso.get(STATUS_FIELD));
+        ReferencedTokenValidationException exception =
+                assertThrows(ReferencedTokenValidationException.class, () -> new ReferencedTokenValidator(mockFetcher)
+                        .validate(mso));
         assertTrue(exception.getMessage().contains("Missing required '" + STATUS_FIELD + "'"));
     }
 
     @Test
     public void shouldPass_WhenRevocationEnforcedAndStatusValid() throws Exception {
-        String mdoc = buildMdocWithStatus(1, STATUS_LIST_URI);
-        JsonNode mso = MdocCredentialVerifier.extractMsoPayload(mdoc);
-
-        ReferencedTokenValidator validator = new ReferencedTokenValidator(mockFetcher);
-        assertDoesNotThrow(() -> validator.validate(mso));
+        String mdoc = buildMdocWithStatus(1);
+        assertDoesNotThrow(() ->
+                new ReferencedTokenValidator(mockFetcher).validate(MdocCredentialVerifier.extractMsoPayload(mdoc)));
     }
 
     @Test
     public void shouldFail_WhenRevocationEnforcedAndStatusInvalid() throws Exception {
-        String mdoc = buildMdocWithStatus(0, STATUS_LIST_URI);
-        JsonNode mso = MdocCredentialVerifier.extractMsoPayload(mdoc);
-
-        ReferencedTokenValidator validator = new ReferencedTokenValidator(mockFetcher);
-        var exception = assertThrows(ReferencedTokenValidationException.class, () -> validator.validate(mso));
+        String mdoc = buildMdocWithStatus(0);
+        ReferencedTokenValidationException exception =
+                assertThrows(ReferencedTokenValidationException.class, () -> new ReferencedTokenValidator(mockFetcher)
+                        .validate(MdocCredentialVerifier.extractMsoPayload(mdoc)));
         assertTrue(exception.getMessage().contains("Token status is not valid"));
     }
 
-    private String buildMdocWithStatus(int idx, String uri) throws Exception {
+    private String buildMdocWithStatus(int idx) throws Exception {
         DeviceResponse dr = buildDeviceResponse(opts);
         Document doc = extractDocument(dr);
         IssuerSigned issuerSigned =
@@ -141,15 +140,7 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
                                 .getValue()))
                 .getPayload());
 
-        CBORPairList statusList = new CBORPairList(
-                new CBORPair(new CBORString("idx"), new CBORInteger(idx)),
-                new CBORPair(new CBORString("uri"), new CBORString(uri)));
-        CBORPairList statusWrapper = new CBORPairList(new CBORPair(new CBORString(STATUS_LIST_FIELD), statusList));
-        CBORPair statusPair = new CBORPair(new CBORString(STATUS_FIELD), statusWrapper);
-
-        List<CBORPair> newPairs = new ArrayList<>(originalMso.getPairs());
-        newPairs.add(statusPair);
-        CBORPairList msoWithStatus = new CBORPairList(newPairs);
+        CBORPairList msoWithStatus = getCborPairList(idx, originalMso);
 
         COSESign1 newIssuerAuth = signRawMso(msoWithStatus, getIssuerKeyRef1(), List.of(getIssuerCertRef1()));
         IssuerSigned newIssuerSigned = new IssuerSigned(
@@ -164,6 +155,19 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
                         doc.findByKey(MdocConstants.L_DEVICE_SIGNED).getValue(),
                 null)));
         return newDr.encodeToBase64Url();
+    }
+
+    private static @NotNull CBORPairList getCborPairList(int idx, CBORPairList originalMso) {
+        CBORPairList statusList = new CBORPairList(
+                new CBORPair(new CBORString("idx"), new CBORInteger(idx)),
+                new CBORPair(new CBORString("uri"), new CBORString(MdocRevocationStatusTest.STATUS_LIST_URI)));
+        CBORPairList statusWrapper = new CBORPairList(new CBORPair(new CBORString(STATUS_LIST_FIELD), statusList));
+        CBORPair statusPair = new CBORPair(new CBORString(STATUS_FIELD), statusWrapper);
+
+        List<CBORPair> newPairs = new ArrayList<>(originalMso.getPairs());
+        newPairs.add(statusPair);
+        CBORPairList msoWithStatus = new CBORPairList(newPairs);
+        return msoWithStatus;
     }
 
     private static COSESign1 signRawMso(CBORPairList mso, COSEEC2Key issuerKey, List<X509Certificate> x5chain)

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
@@ -1,0 +1,197 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.mdoc;
+
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.STATUS_FIELD;
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.STATUS_LIST_FIELD;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.authlete.cbor.CBORByteArray;
+import com.authlete.cbor.CBORInteger;
+import com.authlete.cbor.CBORPair;
+import com.authlete.cbor.CBORPairList;
+import com.authlete.cbor.CBORString;
+import com.authlete.cbor.CBORTaggedItem;
+import com.authlete.cose.COSEEC2Key;
+import com.authlete.cose.COSEException;
+import com.authlete.cose.COSEProtectedHeaderBuilder;
+import com.authlete.cose.COSESign1;
+import com.authlete.cose.COSESign1Builder;
+import com.authlete.cose.COSESigner;
+import com.authlete.cose.COSEUnprotectedHeader;
+import com.authlete.cose.COSEUnprotectedHeaderBuilder;
+import com.authlete.cose.SigStructureBuilder;
+import com.authlete.cose.constants.COSEAlgorithms;
+import com.authlete.mdoc.DeviceResponse;
+import com.authlete.mdoc.Document;
+import com.authlete.mdoc.IssuerSigned;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.CborUtil;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocBaseTest;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationContext;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationOpts;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.TestTruststoreProvider;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.trust.TrustAnchorProvider;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.ReferencedTokenValidationException;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MdocRevocationStatusTest extends MdocBaseTest {
+
+    private static final String STATUS_LIST_URI = "https://status.example.com/list";
+
+    // IETF 1-bit small test vector: 16 entries, idx 0 = INVALID (1), idx 1 = VALID (0)
+    private static final String IETF_1BIT_SMALL_TEST_VECTOR = "eNrbuRgAAhcBXQ";
+
+    private MdocVerificationOpts opts;
+    private TrustAnchorProvider trust;
+    private StatusListJwtFetcher mockFetcher;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        opts = getDefaultMdocVerificationOpts().build();
+        trust = new TestTruststoreProvider(getIssuerCertRef1());
+
+        mockFetcher = uri -> {
+            String mockJwtPayload = """
+                    {
+                        "status_list": {
+                            "bits": 1,
+                            "lst": "%s"
+                        }
+                    }
+                    """.formatted(IETF_1BIT_SMALL_TEST_VECTOR);
+            String header = "eyJ0eXAiOiJzdGF0dXNsaXN0K2p3dCJ9"; // {"typ":"statuslist+jwt"}
+            String payload = Base64.getUrlEncoder().withoutPadding().encodeToString(mockJwtPayload.getBytes());
+            return header + "." + payload + ".mock_signature";
+        };
+    }
+
+    @Test
+    public void shouldExtractMsoAsJson() throws Exception {
+        String mdoc = buildDeviceResponse(opts).encodeToBase64Url();
+        JsonNode mso = MdocCredentialVerifier.extractMsoPayload(mdoc);
+
+        assertNotNull(mso);
+        assertEquals("1.0", mso.get("version").asText());
+        assertEquals("SHA-256", mso.get("digestAlgorithm").asText());
+        assertNotNull(mso.get("valueDigests"));
+        assertNotNull(mso.get("deviceKeyInfo"));
+        assertNotNull(mso.get("validityInfo"));
+    }
+
+    @Test
+    public void shouldVerifyMdoc_WhenRevocationEnforcementDisabled() throws Exception {
+        String mdoc = buildDeviceResponse(opts).encodeToBase64Url();
+        assertDoesNotThrow(() -> new MdocVerificationContext(mdoc).verifyPresentation(opts, null, trust));
+    }
+
+    @Test
+    public void shouldFail_WhenRevocationEnforcedAndStatusMissing() throws Exception {
+        String mdoc = buildDeviceResponse(opts).encodeToBase64Url();
+        JsonNode mso = MdocCredentialVerifier.extractMsoPayload(mdoc);
+
+        assertTrue(mso.get(STATUS_FIELD) == null || mso.get(STATUS_FIELD).isNull());
+
+        ReferencedTokenValidator validator = new ReferencedTokenValidator(mockFetcher);
+        var exception = assertThrows(ReferencedTokenValidationException.class, () -> validator.validate(mso));
+        assertTrue(exception.getMessage().contains("Missing required '" + STATUS_FIELD + "'"));
+    }
+
+    @Test
+    public void shouldPass_WhenRevocationEnforcedAndStatusValid() throws Exception {
+        String mdoc = buildMdocWithStatus(1, STATUS_LIST_URI);
+        JsonNode mso = MdocCredentialVerifier.extractMsoPayload(mdoc);
+
+        ReferencedTokenValidator validator = new ReferencedTokenValidator(mockFetcher);
+        assertDoesNotThrow(() -> validator.validate(mso));
+    }
+
+    @Test
+    public void shouldFail_WhenRevocationEnforcedAndStatusInvalid() throws Exception {
+        String mdoc = buildMdocWithStatus(0, STATUS_LIST_URI);
+        JsonNode mso = MdocCredentialVerifier.extractMsoPayload(mdoc);
+
+        ReferencedTokenValidator validator = new ReferencedTokenValidator(mockFetcher);
+        var exception = assertThrows(ReferencedTokenValidationException.class, () -> validator.validate(mso));
+        assertTrue(exception.getMessage().contains("Token status is not valid"));
+    }
+
+    private String buildMdocWithStatus(int idx, String uri) throws Exception {
+        DeviceResponse dr = buildDeviceResponse(opts);
+        Document doc = extractDocument(dr);
+        IssuerSigned issuerSigned =
+                (IssuerSigned) doc.findByKey(MdocConstants.L_ISSUER_SIGNED).getValue();
+
+        CBORPairList originalMso = (CBORPairList) CborUtil.unwrap(((com.authlete.cose.COSESign1)
+                        com.authlete.cose.COSESign1.build((com.authlete.cbor.CBORItemList) issuerSigned
+                                .findByKey(MdocConstants.L_ISSUER_AUTH)
+                                .getValue()))
+                .getPayload());
+
+        CBORPairList statusList = new CBORPairList(
+                new CBORPair(new CBORString("idx"), new CBORInteger(idx)),
+                new CBORPair(new CBORString("uri"), new CBORString(uri)));
+        CBORPairList statusWrapper = new CBORPairList(new CBORPair(new CBORString(STATUS_LIST_FIELD), statusList));
+        CBORPair statusPair = new CBORPair(new CBORString(STATUS_FIELD), statusWrapper);
+
+        List<CBORPair> newPairs = new ArrayList<>(originalMso.getPairs());
+        newPairs.add(statusPair);
+        CBORPairList msoWithStatus = new CBORPairList(newPairs);
+
+        COSESign1 newIssuerAuth = signRawMso(msoWithStatus, getIssuerKeyRef1(), List.of(getIssuerCertRef1()));
+        IssuerSigned newIssuerSigned = new IssuerSigned(
+                (com.authlete.mdoc.IssuerNameSpaces)
+                        issuerSigned.findByKey(MdocConstants.L_NAME_SPACES).getValue(),
+                newIssuerAuth);
+
+        DeviceResponse newDr = new DeviceResponse(List.of(new Document(
+                DOC_TYPE,
+                newIssuerSigned,
+                (com.authlete.mdoc.DeviceSigned)
+                        doc.findByKey(MdocConstants.L_DEVICE_SIGNED).getValue(),
+                null)));
+        return newDr.encodeToBase64Url();
+    }
+
+    private static COSESign1 signRawMso(CBORPairList mso, COSEEC2Key issuerKey, List<X509Certificate> x5chain)
+            throws COSEException, IOException, CertificateEncodingException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        mso.encode(baos);
+        byte[] msoBytes = baos.toByteArray();
+        CBORTaggedItem wrapped = CborUtil.wrap(msoBytes);
+
+        COSEProtectedHeaderBuilder protectedBuilder = new COSEProtectedHeaderBuilder().alg(COSEAlgorithms.ES256);
+        COSEUnprotectedHeader unprotectedHeader = (x5chain == null || x5chain.isEmpty())
+                ? null
+                : new COSEUnprotectedHeaderBuilder().x5chain(x5chain).build();
+
+        var sigStructure = new SigStructureBuilder()
+                .signature1()
+                .bodyAttributes(protectedBuilder.build())
+                .payload(wrapped.encode())
+                .build();
+        byte[] signature = new COSESigner(issuerKey.toECPrivateKey()).sign(sigStructure, COSEAlgorithms.ES256);
+
+        var builder = new COSESign1Builder()
+                .protectedHeader(protectedBuilder.build())
+                .payload(new CBORByteArray(wrapped.encode()))
+                .signature(signature);
+        if (unprotectedHeader != null) {
+            builder.unprotectedHeader(unprotectedHeader);
+        }
+        return builder.build();
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
@@ -85,7 +85,9 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
     @Test
     public void shouldExtractMsoAsJson() throws Exception {
         String mdoc = buildDeviceResponse(opts).encodeToBase64Url();
-        JsonNode mso = MdocCredentialVerifier.extractMsoPayload(mdoc);
+        var ctx = new MdocVerificationContext(mdoc);
+        ctx.verifyPresentation(opts, null, trust);
+        JsonNode mso = ctx.getVerifiedMsoPayload();
 
         assertNotNull(mso);
         assertEquals("1.0", mso.get("version").asText());
@@ -104,7 +106,9 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
     @Test
     public void shouldFail_WhenRevocationEnforcedAndStatusMissing() throws Exception {
         String mdoc = buildDeviceResponse(opts).encodeToBase64Url();
-        var mso = MdocCredentialVerifier.extractMsoPayload(mdoc);
+        var ctx = new MdocVerificationContext(mdoc);
+        ctx.verifyPresentation(opts, null, trust);
+        var mso = ctx.getVerifiedMsoPayload();
 
         assertNull(mso.get(STATUS_FIELD));
         ReferencedTokenValidationException exception =
@@ -116,8 +120,9 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
     @Test
     public void shouldPass_WhenRevocationEnforcedAndStatusValid() throws Exception {
         String mdoc = buildMdocWithStatus(1);
-        assertDoesNotThrow(() ->
-                new ReferencedTokenValidator(mockFetcher).validate(MdocCredentialVerifier.extractMsoPayload(mdoc)));
+        var ctx = new MdocVerificationContext(mdoc);
+        ctx.verifyPresentation(opts, null, trust);
+        assertDoesNotThrow(() -> new ReferencedTokenValidator(mockFetcher).validate(ctx.getVerifiedMsoPayload()));
     }
 
     @Test
@@ -170,9 +175,11 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
     @Test
     public void shouldFail_WhenRevocationEnforcedAndStatusInvalid() throws Exception {
         String mdoc = buildMdocWithStatus(0);
+        var ctx = new MdocVerificationContext(mdoc);
+        ctx.verifyPresentation(opts, null, trust);
         ReferencedTokenValidationException exception =
                 assertThrows(ReferencedTokenValidationException.class, () -> new ReferencedTokenValidator(mockFetcher)
-                        .validate(MdocCredentialVerifier.extractMsoPayload(mdoc)));
+                        .validate(ctx.getVerifiedMsoPayload()));
         assertTrue(exception.getMessage().contains("Token status is not valid"));
     }
 

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
@@ -1,5 +1,6 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.mdoc;
 
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.OID4VPAuthenticatorFactory.ENFORCE_REVOCATION_STATUS_CONFIG;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.STATUS_FIELD;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.STATUS_LIST_FIELD;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -8,25 +9,20 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import com.authlete.cbor.CBORByteArray;
 import com.authlete.cbor.CBORInteger;
+import com.authlete.cbor.CBORItemList;
 import com.authlete.cbor.CBORPair;
 import com.authlete.cbor.CBORPairList;
 import com.authlete.cbor.CBORString;
-import com.authlete.cbor.CBORTaggedItem;
 import com.authlete.cose.COSEEC2Key;
-import com.authlete.cose.COSEException;
-import com.authlete.cose.COSEProtectedHeaderBuilder;
 import com.authlete.cose.COSESign1;
-import com.authlete.cose.COSESign1Builder;
-import com.authlete.cose.COSESigner;
-import com.authlete.cose.COSEUnprotectedHeader;
-import com.authlete.cose.COSEUnprotectedHeaderBuilder;
-import com.authlete.cose.SigStructureBuilder;
-import com.authlete.cose.constants.COSEAlgorithms;
 import com.authlete.mdoc.DeviceResponse;
+import com.authlete.mdoc.DeviceSigned;
 import com.authlete.mdoc.Document;
+import com.authlete.mdoc.IssuerNameSpaces;
 import com.authlete.mdoc.IssuerSigned;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.CborUtil;
@@ -35,13 +31,15 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationOpts;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.TestTruststoreProvider;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.CredentialFormat;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.TrustPolicy;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.trust.TrustAnchorProvider;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.ReferencedTokenValidationException;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -49,6 +47,9 @@ import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.common.VerificationException;
+import org.keycloak.models.AuthenticatorConfigModel;
 
 public class MdocRevocationStatusTest extends MdocBaseTest {
 
@@ -120,6 +121,53 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
     }
 
     @Test
+    public void shouldConstructVerifier_WithFetcher() throws Exception {
+        var verifier = new MdocCredentialVerifier(mockFetcher);
+        assertEquals(CredentialFormat.MSO_MDOC, verifier.format());
+    }
+
+    @Test
+    public void shouldFailVerification_WhenCredentialRevoked() throws Exception {
+        var authConfig = new AuthenticatorConfigModel();
+        authConfig.getConfig().put(ENFORCE_REVOCATION_STATUS_CONFIG, "true");
+
+        var requestObject = new RequestObject()
+                .setClientId("x509_san_dns:example.com")
+                .setNonce("exc7gBkxjx1rdc9udRrveKvSsJIq80avlXeLHhGwqtA")
+                .setResponseUri("https://example.com/response");
+
+        var authCtx = new AuthorizationContext().setRequestObject(requestObject);
+
+        var context = mock(AuthenticationFlowContext.class);
+        when(context.getAuthenticatorConfig()).thenReturn(authConfig);
+
+        var credential = new CredentialRequirement()
+                .setId("test")
+                .setCredentialTypes(List.of(DOC_TYPE))
+                .setTrust(List.of(new TrustPolicy().setType(TrustPolicy.X5C).setAnchors(List.of(getIssuerCertRef1()))));
+
+        var verifier = new MdocCredentialVerifier(mockFetcher);
+
+        // Build mDoc with opts matching what verifyCredential will derive from the requestObject
+        byte[] thumbprint = MdocCredentialVerifier.computeJwkThumbprint(requestObject);
+        var optsFromRequest = MdocVerificationOpts.builder()
+                .withClientId(requestObject.getClientId())
+                .withOid4vpNonce(requestObject.getNonce())
+                .withResponseUri(requestObject.getResponseUri())
+                .withJwkThumbprint(thumbprint)
+                .build();
+
+        String validMdoc = buildMdocWithStatus(1, optsFromRequest);
+        assertDoesNotThrow(() -> verifier.verifyCredential(context, authCtx, credential, validMdoc, false));
+
+        String revokedMdoc = buildMdocWithStatus(0, optsFromRequest);
+        VerificationException exception = assertThrows(
+                VerificationException.class,
+                () -> verifier.verifyCredential(context, authCtx, credential, revokedMdoc, false));
+        assertTrue(exception.getMessage().contains("Token status verification failed"));
+    }
+
+    @Test
     public void shouldFail_WhenRevocationEnforcedAndStatusInvalid() throws Exception {
         String mdoc = buildMdocWithStatus(0);
         ReferencedTokenValidationException exception =
@@ -129,30 +177,32 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
     }
 
     private String buildMdocWithStatus(int idx) throws Exception {
-        DeviceResponse dr = buildDeviceResponse(opts);
+        return buildMdocWithStatus(idx, opts);
+    }
+
+    private String buildMdocWithStatus(int idx, MdocVerificationOpts mdocOpts) throws Exception {
+        DeviceResponse dr = buildDeviceResponse(mdocOpts);
         Document doc = extractDocument(dr);
         IssuerSigned issuerSigned =
                 (IssuerSigned) doc.findByKey(MdocConstants.L_ISSUER_SIGNED).getValue();
 
-        CBORPairList originalMso = (CBORPairList) CborUtil.unwrap(((com.authlete.cose.COSESign1)
-                        com.authlete.cose.COSESign1.build((com.authlete.cbor.CBORItemList) issuerSigned
-                                .findByKey(MdocConstants.L_ISSUER_AUTH)
-                                .getValue()))
-                .getPayload());
+        CBORItemList issuerAuthList = (CBORItemList)
+                issuerSigned.findByKey(MdocConstants.L_ISSUER_AUTH).getValue();
+        CBORPairList originalMso =
+                (CBORPairList) CborUtil.unwrap(COSESign1.build(issuerAuthList).getPayload());
 
         CBORPairList msoWithStatus = getCborPairList(idx, originalMso);
 
         COSESign1 newIssuerAuth = signRawMso(msoWithStatus, getIssuerKeyRef1(), List.of(getIssuerCertRef1()));
         IssuerSigned newIssuerSigned = new IssuerSigned(
-                (com.authlete.mdoc.IssuerNameSpaces)
+                (IssuerNameSpaces)
                         issuerSigned.findByKey(MdocConstants.L_NAME_SPACES).getValue(),
                 newIssuerAuth);
 
         DeviceResponse newDr = new DeviceResponse(List.of(new Document(
                 DOC_TYPE,
                 newIssuerSigned,
-                (com.authlete.mdoc.DeviceSigned)
-                        doc.findByKey(MdocConstants.L_DEVICE_SIGNED).getValue(),
+                (DeviceSigned) doc.findByKey(MdocConstants.L_DEVICE_SIGNED).getValue(),
                 null)));
         return newDr.encodeToBase64Url();
     }
@@ -171,31 +221,7 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
     }
 
     private static COSESign1 signRawMso(CBORPairList mso, COSEEC2Key issuerKey, List<X509Certificate> x5chain)
-            throws COSEException, IOException, CertificateEncodingException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        mso.encode(baos);
-        byte[] msoBytes = baos.toByteArray();
-        CBORTaggedItem wrapped = CborUtil.wrap(msoBytes);
-
-        COSEProtectedHeaderBuilder protectedBuilder = new COSEProtectedHeaderBuilder().alg(COSEAlgorithms.ES256);
-        COSEUnprotectedHeader unprotectedHeader = (x5chain == null || x5chain.isEmpty())
-                ? null
-                : new COSEUnprotectedHeaderBuilder().x5chain(x5chain).build();
-
-        var sigStructure = new SigStructureBuilder()
-                .signature1()
-                .bodyAttributes(protectedBuilder.build())
-                .payload(wrapped.encode())
-                .build();
-        byte[] signature = new COSESigner(issuerKey.toECPrivateKey()).sign(sigStructure, COSEAlgorithms.ES256);
-
-        var builder = new COSESign1Builder()
-                .protectedHeader(protectedBuilder.build())
-                .payload(new CBORByteArray(wrapped.encode()))
-                .signature(signature);
-        if (unprotectedHeader != null) {
-            builder.unprotectedHeader(unprotectedHeader);
-        }
-        return builder.build();
+            throws Exception {
+        return MdocBaseTest.signRawCbor(mso, issuerKey, x5chain);
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
@@ -4,8 +4,6 @@ import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.STATUS_FIELD;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.STATUS_LIST_FIELD;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -13,25 +11,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.authlete.cbor.CBORInteger;
-import com.authlete.cbor.CBORItemList;
 import com.authlete.cbor.CBORPair;
 import com.authlete.cbor.CBORPairList;
 import com.authlete.cbor.CBORString;
-import com.authlete.cose.COSEEC2Key;
-import com.authlete.cose.COSESign1;
 import com.authlete.mdoc.DeviceResponse;
-import com.authlete.mdoc.DeviceSigned;
-import com.authlete.mdoc.Document;
-import com.authlete.mdoc.IssuerNameSpaces;
-import com.authlete.mdoc.IssuerSigned;
-import com.fasterxml.jackson.databind.JsonNode;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.CborUtil;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocBaseTest;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationOpts;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.TestTruststoreProvider;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.CredentialFormat;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
@@ -40,11 +27,9 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.trust.TrustAnchorPro
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.ReferencedTokenValidationException;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.keycloak.authentication.AuthenticationFlowContext;
@@ -83,27 +68,6 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
     }
 
     @Test
-    public void shouldExtractMsoAsJson() throws Exception {
-        String mdoc = buildDeviceResponse(opts).encodeToBase64Url();
-        var ctx = new MdocVerificationContext(mdoc);
-        ctx.verifyPresentation(opts, null, trust);
-        JsonNode mso = ctx.getVerifiedMsoPayload();
-
-        assertNotNull(mso);
-        assertEquals("1.0", mso.get("version").asText());
-        assertEquals("SHA-256", mso.get("digestAlgorithm").asText());
-        assertNotNull(mso.get("valueDigests"));
-        assertNotNull(mso.get("deviceKeyInfo"));
-        assertNotNull(mso.get("validityInfo"));
-    }
-
-    @Test
-    public void shouldVerifyMdoc_WhenRevocationEnforcementDisabled() throws Exception {
-        String mdoc = buildDeviceResponse(opts).encodeToBase64Url();
-        assertDoesNotThrow(() -> new MdocVerificationContext(mdoc).verifyPresentation(opts, null, trust));
-    }
-
-    @Test
     public void shouldFail_WhenRevocationEnforcedAndStatusMissing() throws Exception {
         String mdoc = buildDeviceResponse(opts).encodeToBase64Url();
         var ctx = new MdocVerificationContext(mdoc);
@@ -123,12 +87,6 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
         var ctx = new MdocVerificationContext(mdoc);
         ctx.verifyPresentation(opts, null, trust);
         assertDoesNotThrow(() -> new ReferencedTokenValidator(mockFetcher).validate(ctx.getVerifiedMsoPayload()));
-    }
-
-    @Test
-    public void shouldConstructVerifier_WithFetcher() throws Exception {
-        var verifier = new MdocCredentialVerifier(mockFetcher);
-        assertEquals(CredentialFormat.MSO_MDOC, verifier.format());
     }
 
     @Test
@@ -189,32 +147,11 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
 
     private String buildMdocWithStatus(int idx, MdocVerificationOpts mdocOpts) throws Exception {
         DeviceResponse dr = buildDeviceResponse(mdocOpts);
-        Document doc = extractDocument(dr);
-        IssuerSigned issuerSigned =
-                (IssuerSigned) doc.findByKey(MdocConstants.L_ISSUER_SIGNED).getValue();
-
-        CBORItemList issuerAuthList = (CBORItemList)
-                issuerSigned.findByKey(MdocConstants.L_ISSUER_AUTH).getValue();
-        CBORPairList originalMso =
-                (CBORPairList) CborUtil.unwrap(COSESign1.build(issuerAuthList).getPayload());
-
-        CBORPairList msoWithStatus = getCborPairList(idx, originalMso);
-
-        COSESign1 newIssuerAuth = signRawMso(msoWithStatus, getIssuerKeyRef1(), List.of(getIssuerCertRef1()));
-        IssuerSigned newIssuerSigned = new IssuerSigned(
-                (IssuerNameSpaces)
-                        issuerSigned.findByKey(MdocConstants.L_NAME_SPACES).getValue(),
-                newIssuerAuth);
-
-        DeviceResponse newDr = new DeviceResponse(List.of(new Document(
-                DOC_TYPE,
-                newIssuerSigned,
-                (DeviceSigned) doc.findByKey(MdocConstants.L_DEVICE_SIGNED).getValue(),
-                null)));
-        return newDr.encodeToBase64Url();
+        DeviceResponse modified = withModifiedMso(dr, mso -> getCborPairList(idx, mso));
+        return modified.encodeToBase64Url();
     }
 
-    private static @NotNull CBORPairList getCborPairList(int idx, CBORPairList originalMso) {
+    private static CBORPairList getCborPairList(int idx, CBORPairList originalMso) {
         CBORPairList statusList = new CBORPairList(
                 new CBORPair(new CBORString("idx"), new CBORInteger(idx)),
                 new CBORPair(new CBORString("uri"), new CBORString(MdocRevocationStatusTest.STATUS_LIST_URI)));
@@ -223,12 +160,6 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
 
         List<CBORPair> newPairs = new ArrayList<>(originalMso.getPairs());
         newPairs.add(statusPair);
-        CBORPairList msoWithStatus = new CBORPairList(newPairs);
-        return msoWithStatus;
-    }
-
-    private static COSESign1 signRawMso(CBORPairList mso, COSEEC2Key issuerKey, List<X509Certificate> x5chain)
-            throws Exception {
-        return MdocBaseTest.signRawCbor(mso, issuerKey, x5chain);
+        return new CBORPairList(newPairs);
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/stub/CustomOID4VPAuthenticatorFactory.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/stub/CustomOID4VPAuthenticatorFactory.java
@@ -38,7 +38,7 @@ public class CustomOID4VPAuthenticatorFactory extends OID4VPAuthenticatorFactory
         Map<String, CredentialVerifier> handlers = new LinkedHashMap<>();
         StatusListJwtFetcher httpFetcher = new MockTrustedStatusListJwtFetcher(session);
         handlers.put(CredentialFormat.SD_JWT_VC.getValue(), new SdJwtCredentialVerifier(httpFetcher));
-        handlers.put(CredentialFormat.MSO_MDOC.getValue(), new MdocCredentialVerifier());
+        handlers.put(CredentialFormat.MSO_MDOC.getValue(), new MdocCredentialVerifier(httpFetcher));
         return new OID4VPAuthenticator(handlers);
     }
 


### PR DESCRIPTION
This PR adds credential status validation for mso_mdoc credentials, bringing mDoc verification in line with the existing SD-JWT VC revocation status validation flow.

When `enforceRevocationStatus` is enabled, the MSO (Mobile Security Object) extracted from the mDoc `issuerAuth` is validated against the configured Token Status List to ensure the presented credential has a valid status.

Key changes:
- Add `StatusListJwtFetcher` and `ReferencedTokenValidator` support to `MdocCredentialVerifier`
- Add `extractMsoPayload()` to extract and convert the issuer-signed MSO payload into JSON format
- Inject `httpFetcher` into `MdocCredentialVerifier` through `OID4VPAuthenticatorFactory`
- Add `MdocRevocationStatusTest` covering missing, valid, and invalid credential status scenarios

Closes #118