### PR TITLE
Implement transaction_data binding verification for mso_mdoc credentials

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocConstants.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocConstants.java
@@ -25,4 +25,6 @@ public class MdocConstants {
     public static final String L_DEVICE_SIGNATURE = "deviceSignature";
     public static final String L_DEVICE_AUTHENTICATION = "DeviceAuthentication";
     public static final String L_OPENID4VP_HANDOVER = "OpenID4VPHandover";
+    public static final String L_KEY_AUTHORIZATIONS = "keyAuthorizations";
+    public static final String L_DATA_ELEMENTS = "dataElements";
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationContext.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationContext.java
@@ -50,6 +50,7 @@ public class MdocVerificationContext {
 
     private final CBORPairList mdoc;
     private JsonNode verifiedMsoPayload;
+    private CBORTaggedItem deviceNameSpaces;
 
     public MdocVerificationContext(String mdoc) throws VerificationException {
         try {
@@ -57,16 +58,6 @@ public class MdocVerificationContext {
         } catch (MdocEncodingException e) {
             throw new VerificationException("Failed to parse subject as an mDoc device response", e);
         }
-    }
-
-    /**
-     * Returns the DeviceSigned namespaces from the parsed mDoc for use during
-     * presentation verification, including inspection of elements such as
-     * {@code transaction_data_hashes}.
-     */
-    public CBORTaggedItem getDeviceNameSpaces() throws VerificationException {
-        CBORPairList document = extractDocument(mdoc);
-        return extractDeviceNamespaces(document);
     }
 
     /**
@@ -90,6 +81,9 @@ public class MdocVerificationContext {
         CBORPairList document = extractDocument(mdoc);
         COSESign1 issuerAuth = extractIssuerAuth(document);
         verifyIssuerSignature(issuerAuth, truststoreProvider);
+
+        // Cache for getDeviceNameSpaces() to avoid re-parsing
+        this.deviceNameSpaces = extractDeviceNamespaces(document);
 
         // Verify device key binding
         CBORPairList mso = (CBORPairList) CborUtil.unwrap(issuerAuth.getPayload());
@@ -402,7 +396,18 @@ public class MdocVerificationContext {
         }
     }
 
+    /**
+     * Returns the verified MSO payload as JSON.
+     */
     public JsonNode getVerifiedMsoPayload() {
         return verifiedMsoPayload;
+    }
+
+    /**
+     * Returns the DeviceSigned nameSpaces from the parsed mDoc, cached during
+     * {@link #verifyPresentation(MdocVerificationOpts, PresentationRequirements, TrustAnchorProvider)}.
+     */
+    public CBORTaggedItem getDeviceNameSpaces() {
+        return deviceNameSpaces;
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationContext.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationContext.java
@@ -60,6 +60,16 @@ public class MdocVerificationContext {
     }
 
     /**
+     * Returns the DeviceSigned namespaces from the parsed mDoc for use during
+     * presentation verification, including inspection of elements such as
+     * {@code transaction_data_hashes}.
+     */
+    public CBORTaggedItem getDeviceNameSpaces() throws VerificationException {
+        CBORPairList document = extractDocument(mdoc);
+        return extractDeviceNamespaces(document);
+    }
+
+    /**
      * Verifies mDoc presentation.
      *
      * @param opts                            Options to parameterize the mDoc verification.

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/CredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/CredentialVerifier.java
@@ -49,17 +49,13 @@ public interface CredentialVerifier {
      * Validates {@code transaction_data_hashes} from the presented credential
      * against the verifier's {@code transaction_data} request, if any.
      *
-     * <p>Override when the credential format supports embedding transaction data
-     * hashes independently of {@link #verifyCredential} (e.g. SD-JWT KB-JWT).
-     * Formats where validation depends on verification state (e.g. mso_mdoc)
-     * handle this inside {@link #verifyCredential} instead.
+     * <p>Called by the authenticator after {@link #verifyCredential} succeeds.
+     * The verifier may use state cached during {@link #verifyCredential} to
+     * perform the validation (e.g. a post-verification {@code MdocVerificationContext}).
      *
      * @param authorizationContext  context containing the request object
      * @param token                 raw credential presentation token
      * @throws VerificationException if the hashes do not match the request
      */
-    default void validateTransactionData(AuthorizationContext authorizationContext, String token)
-            throws VerificationException {
-        // no-op: format does not support standalone transaction data validation
-    }
+    void validateTransactionData(AuthorizationContext authorizationContext, String token) throws VerificationException;
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/CredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/CredentialVerifier.java
@@ -44,4 +44,22 @@ public interface CredentialVerifier {
      * Reads claims according to format-specific rules.
      */
     String readClaim(JsonNode claims, String claimName);
+
+    /**
+     * Validates {@code transaction_data_hashes} from the presented credential
+     * against the verifier's {@code transaction_data} request, if any.
+     *
+     * <p>Override when the credential format supports embedding transaction data
+     * hashes independently of {@link #verifyCredential} (e.g. SD-JWT KB-JWT).
+     * Formats where validation depends on verification state (e.g. mso_mdoc)
+     * handle this inside {@link #verifyCredential} instead.
+     *
+     * @param authorizationContext  context containing the request object
+     * @param token                 raw credential presentation token
+     * @throws VerificationException if the hashes do not match the request
+     */
+    default void validateTransactionData(AuthorizationContext authorizationContext, String token)
+            throws VerificationException {
+        // no-op: format does not support standalone transaction data validation
+    }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
@@ -86,9 +86,6 @@ public class OID4VPAuthenticator implements Authenticator {
         try {
             primaryClaims = primaryVerifier.verifyCredential(
                     context, authContext, authRequirements, primaryCredential, primaryToken);
-            // SD-JWT validates transaction_data via the interface method (above).
-            // mso_mdoc validates internally inside verifyCredential() because it
-            // depends on the post-verification MdocVerificationContext state.
             primaryVerifier.validateTransactionData(authContext, primaryToken);
         } catch (VerificationException e) {
             logger.errorf(e, "Primary credential verification failed (authSession = %s)", correlationId(context));

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
@@ -86,6 +86,7 @@ public class OID4VPAuthenticator implements Authenticator {
         try {
             primaryClaims = primaryVerifier.verifyCredential(
                     context, authContext, authRequirements, primaryCredential, primaryToken);
+            primaryVerifier.validateTransactionData(authContext, primaryToken);
         } catch (VerificationException e) {
             logger.errorf(e, "Primary credential verification failed (authSession = %s)", correlationId(context));
             failRejectingPresentedCredential(context, e.getMessage(), e);

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
@@ -86,6 +86,9 @@ public class OID4VPAuthenticator implements Authenticator {
         try {
             primaryClaims = primaryVerifier.verifyCredential(
                     context, authContext, authRequirements, primaryCredential, primaryToken);
+            // SD-JWT validates transaction_data via the interface method (above).
+            // mso_mdoc validates internally inside verifyCredential() because it
+            // depends on the post-verification MdocVerificationContext state.
             primaryVerifier.validateTransactionData(authContext, primaryToken);
         } catch (VerificationException e) {
             logger.errorf(e, "Primary credential verification failed (authSession = %s)", correlationId(context));

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
@@ -2,7 +2,17 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.mdoc;
 
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants.L_NAME_SPACES;
 
+import com.authlete.cbor.CBORItem;
+import com.authlete.cbor.CBORItemList;
+import com.authlete.cbor.CBORPair;
+import com.authlete.cbor.CBORPairList;
+import com.authlete.cbor.CBORString;
+import com.authlete.cbor.CBORTaggedItem;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.CborUtil;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationOpts;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.CredentialFormat;
@@ -14,9 +24,11 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.Authorizat
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement.ClaimReference;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.trust.TrustAnchorProvider;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.TransactionDataValidator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.ReferencedTokenValidationException;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.keycloak.authentication.AuthenticationFlowContext;
@@ -25,6 +37,7 @@ import org.keycloak.common.util.Base64Url;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.sdjwt.consumer.PresentationRequirements;
 import org.keycloak.util.JWKSUtils;
+import org.keycloak.util.JsonSerialization;
 
 /**
  * {@link CredentialVerifier} implementation backing verification of {@code mso_mdoc}
@@ -96,7 +109,196 @@ public class MdocCredentialVerifier implements CredentialVerifier {
             }
         }
 
+        if (credential.isPrimary()) {
+            validateTransactionData(authorizationContext, verificationContext);
+        }
+
         return payloadRef.get().get(L_NAME_SPACES);
+    }
+
+    /**
+     * Validates {@code transaction_data_hashes} contained in
+     * {@code DeviceSigned.nameSpaces} against the verifier's
+     * {@code transaction_data} request.
+     */
+    void validateTransactionData(AuthorizationContext authorizationContext, MdocVerificationContext verificationContext)
+            throws VerificationException {
+        List<String> transactionDataWire =
+                authorizationContext.getRequestObject().getTransactionData();
+        if (transactionDataWire == null || transactionDataWire.isEmpty()) {
+            return;
+        }
+
+        ObjectNode hashesPayload = extractTransactionDataHashes(verificationContext);
+        if (hashesPayload == null) {
+            throw new VerificationException(
+                    "Device namespaces must contain transaction_data_hashes when transaction_data is requested");
+        }
+
+        try {
+            TransactionDataValidator.validate(transactionDataWire, hashesPayload);
+        } catch (IllegalArgumentException e) {
+            throw new VerificationException("transaction_data_hashes validation failed", e);
+        }
+    }
+
+    /** Builds an ObjectNode from DeviceSigned.nameSpaces for TransactionDataValidator.
+     *  Returns null when transaction_data_hashes is absent.
+     *  Checks that the namespace is authorized in the MSO's KeyAuthorizations per ISO 18013-5.
+     */
+    private static ObjectNode extractTransactionDataHashes(MdocVerificationContext verificationContext)
+            throws VerificationException {
+        CBORTaggedItem nameSpacesTagged = verificationContext.getDeviceNameSpaces();
+        CBORItem unwrapped = CborUtil.unwrap(nameSpacesTagged);
+
+        if (!(unwrapped instanceof CBORPairList nsMap)) {
+            throw new VerificationException("DeviceSigned.nameSpaces is not a valid CBOR map");
+        }
+
+        // First pass: find the namespace containing transaction_data_hashes
+        ArrayNode hashes = null;
+        String hashesNamespace = null;
+
+        for (CBORPair nsPair : nsMap.getPairs()) {
+            if (nsPair == null || !(nsPair.getValue() instanceof CBORPairList itemsMap)) {
+                continue;
+            }
+            var hashesPair = itemsMap.findByKey(TransactionDataValidator.TRANSACTION_DATA_HASHES_CLAIM);
+            if (hashesPair != null) {
+                if (hashesNamespace != null) {
+                    throw new VerificationException("transaction_data_hashes must not appear in multiple namespaces");
+                }
+                hashes = extractHashesArray(hashesPair.getValue());
+                hashesNamespace = CborUtil.asString(nsPair.getKey());
+            }
+        }
+
+        if (hashes == null) {
+            return null;
+        }
+
+        // Second pass: read alg only from the hashes namespace; reject alg in other namespaces
+        String hashesAlg = null;
+
+        for (CBORPair nsPair : nsMap.getPairs()) {
+            if (nsPair == null || !(nsPair.getValue() instanceof CBORPairList itemsMap)) {
+                continue;
+            }
+            String nsName = CborUtil.asString(nsPair.getKey());
+            var algPair = itemsMap.findByKey(TransactionDataValidator.TRANSACTION_DATA_HASHES_ALG_CLAIM);
+            if (algPair == null) {
+                continue;
+            }
+            if (!nsName.equals(hashesNamespace)) {
+                throw new VerificationException(
+                        "transaction_data_hashes_alg must not appear outside the namespace containing transaction_data_hashes");
+            }
+            hashesAlg = extractAlgString(algPair.getValue());
+        }
+
+        // Verify the namespace or elements are authorized in the MSO's KeyAuthorizations
+        verifyKeyAuthorization(
+                verificationContext.getVerifiedMsoPayload(),
+                hashesNamespace,
+                hashesAlg != null
+                        ? List.of(
+                                TransactionDataValidator.TRANSACTION_DATA_HASHES_CLAIM,
+                                TransactionDataValidator.TRANSACTION_DATA_HASHES_ALG_CLAIM)
+                        : List.of(TransactionDataValidator.TRANSACTION_DATA_HASHES_CLAIM));
+
+        ObjectNode result = JsonSerialization.mapper.createObjectNode();
+        result.set(TransactionDataValidator.TRANSACTION_DATA_HASHES_CLAIM, hashes);
+        if (hashesAlg != null) {
+            result.put(TransactionDataValidator.TRANSACTION_DATA_HASHES_ALG_CLAIM, hashesAlg);
+        }
+        return result;
+    }
+
+    private static String extractAlgString(CBORItem value) throws VerificationException {
+        if (value instanceof CBORString s) {
+            return s.getValue();
+        }
+        if (value instanceof CBORItemList list
+                && list.getItems().size() == 1
+                && list.getItems().get(0) instanceof CBORString s) {
+            return s.getValue();
+        }
+        throw new VerificationException("transaction_data_hashes_alg must be a string");
+    }
+
+    /**
+     * Verifies that the device key is authorized for the given elements in the given namespace
+     * {@code KeyAuthorizations}. Authorization can come via either:
+     * <ul>
+     *   <li>{@code nameSpaces[namespace]} — authorizes all elements in the namespace, or
+     *   <li>{@code dataElements[namespace]} — authorizes only the listed {@code elementIds}.
+     * </ul>
+     */
+    private static void verifyKeyAuthorization(JsonNode mso, String namespace, List<String> elementIds)
+            throws VerificationException {
+        JsonNode dki = mso.get(MdocConstants.L_DEVICE_KEY_INFO);
+        if (dki == null) {
+            throw new VerificationException("MSO is missing deviceKeyInfo");
+        }
+        JsonNode keyAuth = dki.get("keyAuthorizations");
+        if (keyAuth == null) {
+            throw new VerificationException("MSO deviceKeyInfo is missing keyAuthorizations");
+        }
+        // Check namespace-level authorization first
+        JsonNode nameSpaces = keyAuth.get("nameSpaces");
+        if (nameSpaces != null && nameSpaces.isArray()) {
+            for (JsonNode ns : nameSpaces) {
+                if (ns.asText().equals(namespace)) {
+                    return;
+                }
+            }
+        }
+        // Fall back to element-level authorization
+        JsonNode dataElements = keyAuth.get("dataElements");
+        if (dataElements != null && dataElements.isObject()) {
+            JsonNode elements = dataElements.get(namespace);
+            if (elements != null && elements.isArray()) {
+                boolean allFound = true;
+                for (String elementId : elementIds) {
+                    boolean found = false;
+                    for (JsonNode el : elements) {
+                        if (el.asText().equals(elementId)) {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        allFound = false;
+                        break;
+                    }
+                }
+                if (allFound) {
+                    return;
+                }
+            }
+        }
+        throw new VerificationException(
+                "Namespace '" + namespace + "' is not authorized for " + elementIds + " in the MSO");
+    }
+
+    // Converts a CBOR array of strings (or a single string) to a JSON ArrayNode.
+    // Rejects non-string entries to prevent silent hash filtering.
+    private static ArrayNode extractHashesArray(CBORItem value) throws VerificationException {
+        ArrayNode hashes = JsonSerialization.mapper.createArrayNode();
+        if (value instanceof CBORItemList list) {
+            for (CBORItem hashItem : list.getItems()) {
+                if (hashItem instanceof CBORString hashStr) {
+                    hashes.add(hashStr.getValue());
+                } else {
+                    throw new VerificationException("transaction_data_hashes entries must be strings");
+                }
+            }
+        } else if (value instanceof CBORString singleHash) {
+            hashes.add(singleHash.getValue());
+        } else {
+            throw new VerificationException("transaction_data_hashes must be a string or array of strings");
+        }
+        return hashes;
     }
 
     /**

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
@@ -162,7 +162,7 @@ public class MdocCredentialVerifier implements CredentialVerifier {
         ArrayNode hashes = null;
         String hashesNamespace = null;
         String hashesAlg = null;
-        String algNamespace = null;
+        String hashAlgNamespace = null;
 
         for (CBORPair nsPair : nsMap.getPairs()) {
             if (nsPair == null || !(nsPair.getValue() instanceof CBORPairList itemsMap)) {
@@ -181,11 +181,11 @@ public class MdocCredentialVerifier implements CredentialVerifier {
 
             var algPair = itemsMap.findByKey(TransactionDataValidator.TRANSACTION_DATA_HASHES_ALG_CLAIM);
             if (algPair != null) {
-                if (algNamespace != null) {
+                if (hashAlgNamespace != null) {
                     throw new VerificationException(
                             "transaction_data_hashes_alg must not appear in multiple namespaces");
                 }
-                algNamespace = nsName;
+                hashAlgNamespace = nsName;
                 hashesAlg = extractAlgString(algPair.getValue());
             }
         }
@@ -194,7 +194,7 @@ public class MdocCredentialVerifier implements CredentialVerifier {
             return null;
         }
 
-        if (algNamespace != null && !algNamespace.equals(hashesNamespace)) {
+        if (hashAlgNamespace != null && !hashAlgNamespace.equals(hashesNamespace)) {
             throw new VerificationException(
                     "transaction_data_hashes_alg must not appear outside the namespace containing transaction_data_hashes");
         }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
@@ -52,6 +52,7 @@ import org.keycloak.util.JsonSerialization;
 public class MdocCredentialVerifier implements CredentialVerifier {
 
     private final ReferencedTokenValidator tokenStatusValidator;
+    private MdocVerificationContext verificationContext;
 
     public MdocCredentialVerifier(StatusListJwtFetcher statusListJwtFetcher) {
         this.tokenStatusValidator = new ReferencedTokenValidator(statusListJwtFetcher);
@@ -93,7 +94,7 @@ public class MdocCredentialVerifier implements CredentialVerifier {
             authReqs.getPresentationRequirements().checkIfSatisfiedBy(payload);
         };
 
-        MdocVerificationContext verificationContext = new MdocVerificationContext(token);
+        verificationContext = new MdocVerificationContext(token);
         verificationContext.verifyPresentation(opts, requirements, truststore);
 
         if (authReqs.shouldEnforceRevocationStatus()) {
@@ -112,11 +113,16 @@ public class MdocCredentialVerifier implements CredentialVerifier {
             }
         }
 
-        if (credential.isPrimary()) {
-            validateTransactionData(authorizationContext, verificationContext);
-        }
-
         return payloadRef.get().get(L_NAME_SPACES);
+    }
+
+    @Override
+    public void validateTransactionData(AuthorizationContext authorizationContext, String token)
+            throws VerificationException {
+        if (verificationContext == null) {
+            throw new IllegalStateException("verifyCredential() must be called before validateTransactionData()");
+        }
+        validateTransactionData(authorizationContext, verificationContext);
     }
 
     /**

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
@@ -30,7 +30,10 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedToken
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Base64Url;
@@ -155,21 +158,35 @@ public class MdocCredentialVerifier implements CredentialVerifier {
             throw new VerificationException("DeviceSigned.nameSpaces is not a valid CBOR map");
         }
 
-        // First pass: find the namespace containing transaction_data_hashes
+        // Single pass: collect both hashes and alg while checking for duplicates and cross-namespace violations
         ArrayNode hashes = null;
         String hashesNamespace = null;
+        String hashesAlg = null;
+        String algNamespace = null;
 
         for (CBORPair nsPair : nsMap.getPairs()) {
             if (nsPair == null || !(nsPair.getValue() instanceof CBORPairList itemsMap)) {
                 continue;
             }
+            String nsName = CborUtil.asString(nsPair.getKey());
+
             var hashesPair = itemsMap.findByKey(TransactionDataValidator.TRANSACTION_DATA_HASHES_CLAIM);
             if (hashesPair != null) {
                 if (hashesNamespace != null) {
                     throw new VerificationException("transaction_data_hashes must not appear in multiple namespaces");
                 }
                 hashes = extractHashesArray(hashesPair.getValue());
-                hashesNamespace = CborUtil.asString(nsPair.getKey());
+                hashesNamespace = nsName;
+            }
+
+            var algPair = itemsMap.findByKey(TransactionDataValidator.TRANSACTION_DATA_HASHES_ALG_CLAIM);
+            if (algPair != null) {
+                if (algNamespace != null) {
+                    throw new VerificationException(
+                            "transaction_data_hashes_alg must not appear in multiple namespaces");
+                }
+                algNamespace = nsName;
+                hashesAlg = extractAlgString(algPair.getValue());
             }
         }
 
@@ -177,23 +194,9 @@ public class MdocCredentialVerifier implements CredentialVerifier {
             return null;
         }
 
-        // Second pass: read alg only from the hashes namespace; reject alg in other namespaces
-        String hashesAlg = null;
-
-        for (CBORPair nsPair : nsMap.getPairs()) {
-            if (nsPair == null || !(nsPair.getValue() instanceof CBORPairList itemsMap)) {
-                continue;
-            }
-            String nsName = CborUtil.asString(nsPair.getKey());
-            var algPair = itemsMap.findByKey(TransactionDataValidator.TRANSACTION_DATA_HASHES_ALG_CLAIM);
-            if (algPair == null) {
-                continue;
-            }
-            if (!nsName.equals(hashesNamespace)) {
-                throw new VerificationException(
-                        "transaction_data_hashes_alg must not appear outside the namespace containing transaction_data_hashes");
-            }
-            hashesAlg = extractAlgString(algPair.getValue());
+        if (algNamespace != null && !algNamespace.equals(hashesNamespace)) {
+            throw new VerificationException(
+                    "transaction_data_hashes_alg must not appear outside the namespace containing transaction_data_hashes");
         }
 
         // Verify the namespace or elements are authorized in the MSO's KeyAuthorizations
@@ -240,12 +243,12 @@ public class MdocCredentialVerifier implements CredentialVerifier {
         if (dki == null) {
             throw new VerificationException("MSO is missing deviceKeyInfo");
         }
-        JsonNode keyAuth = dki.get("keyAuthorizations");
+        JsonNode keyAuth = dki.get(MdocConstants.L_KEY_AUTHORIZATIONS);
         if (keyAuth == null) {
             throw new VerificationException("MSO deviceKeyInfo is missing keyAuthorizations");
         }
         // Check namespace-level authorization first
-        JsonNode nameSpaces = keyAuth.get("nameSpaces");
+        JsonNode nameSpaces = keyAuth.get(MdocConstants.L_NAME_SPACES);
         if (nameSpaces != null && nameSpaces.isArray()) {
             for (JsonNode ns : nameSpaces) {
                 if (ns.asText().equals(namespace)) {
@@ -254,25 +257,14 @@ public class MdocCredentialVerifier implements CredentialVerifier {
             }
         }
         // Fall back to element-level authorization
-        JsonNode dataElements = keyAuth.get("dataElements");
+        JsonNode dataElements = keyAuth.get(MdocConstants.L_DATA_ELEMENTS);
         if (dataElements != null && dataElements.isObject()) {
             JsonNode elements = dataElements.get(namespace);
             if (elements != null && elements.isArray()) {
-                boolean allFound = true;
-                for (String elementId : elementIds) {
-                    boolean found = false;
-                    for (JsonNode el : elements) {
-                        if (el.asText().equals(elementId)) {
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (!found) {
-                        allFound = false;
-                        break;
-                    }
-                }
-                if (allFound) {
+                Set<String> existingIds = StreamSupport.stream(elements.spliterator(), false)
+                        .map(JsonNode::asText)
+                        .collect(Collectors.toSet());
+                if (existingIds.containsAll(elementIds)) {
                     return;
                 }
             }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/sdjwt/SdJwtCredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/sdjwt/SdJwtCredentialVerifier.java
@@ -89,10 +89,6 @@ public class SdJwtCredentialVerifier implements CredentialVerifier {
             }
         }
 
-        if (credential.isPrimary()) {
-            validateTransactionData(authorizationContext, token);
-        }
-
         return payloadRef.get();
     }
 
@@ -101,7 +97,8 @@ public class SdJwtCredentialVerifier implements CredentialVerifier {
         return Optional.ofNullable(claims.get(claimName)).map(JsonNode::asText).orElse(null);
     }
 
-    void validateTransactionData(AuthorizationContext authorizationContext, String presentedToken) {
+    @Override
+    public void validateTransactionData(AuthorizationContext authorizationContext, String presentedToken) {
         List<String> transactionDataWire =
                 authorizationContext.getRequestObject().getTransactionData();
         if (transactionDataWire == null || transactionDataWire.isEmpty()) {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
@@ -1,13 +1,10 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config;
 
 import com.apicatalog.jsonld.StringUtils;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.CredentialFormat;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.OID4VPAuthenticatorFactory;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientIdentifierPrefix;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestUriMethod;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.AuthenticationProfile;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.OID4VPProfileConfig;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.TransactionDataSupport;
 import java.io.ByteArrayInputStream;
@@ -74,8 +71,7 @@ public class VerifierConfig {
 
         this.transactionDataRaw = validateTransactionData(
                 TransactionDataSupport.parseConfigValue(config.get(OID4VPAuthenticatorFactory.TRANSACTION_DATA_CONFIG)),
-                requireCryptographicHolderBinding,
-                profileConfig);
+                requireCryptographicHolderBinding);
 
         this.verifierInfoConfig = config.get(OID4VPAuthenticatorFactory.VERIFIER_INFO_CONFIG);
     }
@@ -143,9 +139,7 @@ public class VerifierConfig {
     }
 
     private static List<String> validateTransactionData(
-            List<String> transactionDataRaw,
-            boolean requireCryptographicHolderBinding,
-            OID4VPProfileConfig profileConfig) {
+            List<String> transactionDataRaw, boolean requireCryptographicHolderBinding) {
         if (transactionDataRaw.isEmpty()) {
             return transactionDataRaw;
         }
@@ -155,22 +149,7 @@ public class VerifierConfig {
                     "transactionData cannot be used when requireCryptographicHolderBinding is false (OpenID4VP B.3.3)");
         }
 
-        // TODO: Implement transaction_data binding verification for mso_mdoc credentials
-        // (follow-up ticket). Until then, transaction_data must not be requested when the
-        // primary credential of any profile is mso_mdoc — the mDoc equivalent of KB-JWT
-        // transaction_data_hashes binding is not yet enforced.
-        if (anyProfileHasMdocPrimary(profileConfig)) {
-            throw new IllegalStateException("transactionData is not yet supported for mso_mdoc primary credentials");
-        }
-
         return transactionDataRaw;
-    }
-
-    private static boolean anyProfileHasMdocPrimary(OID4VPProfileConfig profileConfig) {
-        return profileConfig.getProfiles().stream()
-                .map(AuthenticationProfile::getPrimaryCredential)
-                .map(CredentialRequirement::getFormat)
-                .anyMatch(CredentialFormat.MSO_MDOC.getValue()::equals);
     }
 
     public ClientIdentifierPrefix getClientIdentifierPrefix() {

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocBaseTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocBaseTest.java
@@ -6,6 +6,7 @@ import com.authlete.cbor.CBORByteArray;
 import com.authlete.cbor.CBORInteger;
 import com.authlete.cbor.CBORItemList;
 import com.authlete.cbor.CBORNull;
+import com.authlete.cbor.CBORPair;
 import com.authlete.cbor.CBORPairList;
 import com.authlete.cbor.CBORString;
 import com.authlete.cbor.CBORTaggedItem;
@@ -23,6 +24,7 @@ import com.authlete.cose.COSEUnprotectedHeaderBuilder;
 import com.authlete.cose.SigStructure;
 import com.authlete.cose.SigStructureBuilder;
 import com.authlete.cose.constants.COSEAlgorithms;
+import com.authlete.mdoc.AuthorizedDataElements;
 import com.authlete.mdoc.AuthorizedNameSpaces;
 import com.authlete.mdoc.DeviceAuth;
 import com.authlete.mdoc.DeviceKeyInfo;
@@ -195,7 +197,7 @@ public class MdocBaseTest {
      */
     public static DeviceResponse buildDeviceResponse(
             MdocVerificationOpts opts, Map<String, Object> claims, String docType) throws Exception {
-        return buildDeviceResponse(opts, claims, docType, null);
+        return buildDeviceResponse(opts, claims, docType, null, null);
     }
 
     /**
@@ -221,14 +223,35 @@ public class MdocBaseTest {
     private static DeviceResponse buildDeviceResponse(
             MdocVerificationOpts opts, Map<String, Object> claims, String docType, IssuerSignedCustomizer customizer)
             throws Exception {
+        return buildDeviceResponse(opts, claims, docType, customizer, null);
+    }
+
+    private static DeviceResponse buildDeviceResponse(
+            MdocVerificationOpts opts,
+            Map<String, Object> claims,
+            String docType,
+            IssuerSignedCustomizer customizer,
+            DeviceNameSpaces deviceNameSpaces)
+            throws Exception {
         BuiltStandard built = buildStandardComponents(claims, docType);
-        DeviceSigned deviceSigned = buildDeviceSigned(opts, docType);
+        DeviceSigned deviceSigned = buildDeviceSigned(opts, docType, deviceNameSpaces);
 
         IssueContext ctx =
                 new IssueContext(built.nameSpaces, built.mso, getIssuerKeyRef1(), List.of(getIssuerCertRef1()));
         IssuerSigned issuerSigned = (customizer == null) ? ctx.signMsoAndWrap() : customizer.customize(ctx);
 
         return new DeviceResponse(List.of(new Document(docType, issuerSigned, deviceSigned, null)));
+    }
+
+    /**
+     * Builds a device response with custom device-signed namespaces. Intended for tests that
+     * need to include extra data (e.g. {@code transaction_data_hashes}) in the DeviceSigned
+     * section of the mDoc.
+     */
+    public static DeviceResponse buildDeviceResponse(
+            MdocVerificationOpts opts, Map<String, Object> claims, String docType, DeviceNameSpaces deviceNameSpaces)
+            throws Exception {
+        return buildDeviceResponse(opts, claims, docType, null, deviceNameSpaces);
     }
 
     private record BuiltStandard(IssuerNameSpaces nameSpaces, MobileSecurityObject mso) {}
@@ -289,8 +312,10 @@ public class MdocBaseTest {
         return new ValueDigests(entries);
     }
 
-    private static DeviceSigned buildDeviceSigned(MdocVerificationOpts opts, String docType) throws COSEException {
-        DeviceNameSpacesBytes deviceNameSpaces = new DeviceNameSpacesBytes(new DeviceNameSpaces(List.of()));
+    private static DeviceSigned buildDeviceSigned(
+            MdocVerificationOpts opts, String docType, DeviceNameSpaces customNameSpaces) throws COSEException {
+        DeviceNameSpaces nameSpaces = customNameSpaces != null ? customNameSpaces : new DeviceNameSpaces(List.of());
+        DeviceNameSpacesBytes deviceNameSpaces = new DeviceNameSpacesBytes(nameSpaces);
         // Use the ISO-spec transcript when a mdocGeneratedNonce is supplied and the fallback
         // is enabled; otherwise default to the OpenID4VP-spec transcript.
         boolean useIsoTranscript = opts.getMdocGeneratedNonce() != null && opts.fallbackToIsoSpecSessionTranscript();
@@ -477,6 +502,18 @@ public class MdocBaseTest {
 
         return new DeviceResponse(List.of(
                 new Document(DOC_TYPE, issuerSigned, new DeviceSigned(deviceNameSpaces, new DeviceAuth(mac0)), null)));
+    }
+
+    /**
+     * Builds a {@link KeyAuthorizations} that authorizes the given element identifiers
+     * within the given namespace through {@code dataElements} only (no {@code nameSpaces}).
+     */
+    public static KeyAuthorizations dataElementsOnlyAuth(String namespace, List<String> elementIds) {
+        var ns = new CBORString(namespace);
+        var elements = elementIds.stream().map(CBORString::new).toList();
+        var elList = new CBORItemList(elements);
+        var pair = new CBORPair(ns, elList);
+        return new KeyAuthorizations(null, new AuthorizedDataElements((List) List.of(pair)));
     }
 
     public static MdocVerificationOpts.Builder getDefaultMdocVerificationOpts() {

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifierTransactionDataTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifierTransactionDataTest.java
@@ -1,0 +1,329 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.mdoc;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.authlete.cbor.CBORPair;
+import com.authlete.cbor.CBORPairList;
+import com.authlete.cbor.CBORString;
+import com.authlete.mdoc.DeviceKeyInfo;
+import com.authlete.mdoc.DeviceNameSpaces;
+import com.authlete.mdoc.DeviceNameSpacesEntry;
+import com.authlete.mdoc.DeviceResponse;
+import com.authlete.mdoc.DeviceSignedItems;
+import com.authlete.mdoc.DeviceSignedItemsEntry;
+import com.authlete.mdoc.KeyAuthorizations;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocBaseTest;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationContext;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationOpts;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.TestTruststoreProvider;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.TransactionDataSupport;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.keycloak.common.VerificationException;
+import org.keycloak.util.JsonSerialization;
+
+class MdocCredentialVerifierTransactionDataTest extends MdocBaseTest {
+
+    private static final String NAMESPACE = "com.example.namespace1";
+    private static final String DOC_TYPE = "com.example.doctype";
+
+    @Test
+    void acceptsMatchingTransactionData() throws Exception {
+        String wire = wireEntry("payment");
+        String hash = hashForWire(wire);
+
+        String mdoc = buildMdocWithTransactionData(hash);
+        MdocVerificationOpts opts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+        MdocVerificationContext verificationContext = new MdocVerificationContext(mdoc);
+        verificationContext.verifyPresentation(
+                opts, null, new TestTruststoreProvider(MdocBaseTest.getIssuerCertRef1()));
+        var authCtx = authContextWithWire(List.of(wire));
+
+        MdocCredentialVerifier handler = new MdocCredentialVerifier(mock(StatusListJwtFetcher.class));
+        assertDoesNotThrow(() -> handler.validateTransactionData(authCtx, verificationContext));
+    }
+
+    @Test
+    void rejectsTransactionData_WhenHashEntryIsNotString() throws Exception {
+        String wire = wireEntry("payment");
+        String hash = hashForWire(wire);
+        DeviceSignedItemsEntry txDataEntry =
+                new DeviceSignedItemsEntry("transaction_data_hashes", List.<Object>of(hash, 42));
+        DeviceSignedItems items = new DeviceSignedItems(List.of(txDataEntry));
+        DeviceNameSpacesEntry nsEntry = new DeviceNameSpacesEntry(NAMESPACE, items);
+        DeviceNameSpaces deviceNameSpaces = new DeviceNameSpaces(List.of(nsEntry));
+
+        MdocVerificationOpts opts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+        String mdoc = MdocBaseTest.buildDeviceResponse(
+                        opts, Map.of(NAMESPACE, Map.of("c", "v")), DOC_TYPE, deviceNameSpaces)
+                .encodeToBase64Url();
+
+        MdocVerificationOpts verifyOpts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+        MdocVerificationContext verificationContext = new MdocVerificationContext(mdoc);
+        verificationContext.verifyPresentation(
+                verifyOpts, null, new TestTruststoreProvider(MdocBaseTest.getIssuerCertRef1()));
+        var authCtx = authContextWithWire(List.of(wire));
+
+        MdocCredentialVerifier handler = new MdocCredentialVerifier(mock(StatusListJwtFetcher.class));
+        assertThrows(VerificationException.class, () -> handler.validateTransactionData(authCtx, verificationContext));
+    }
+
+    @Test
+    void rejectsTransactionData_WhenAlgInDifferentNamespaceThanHashes() throws Exception {
+        String wire = wireEntry("payment");
+        String hash = hashForWire(wire);
+
+        // Namespace A has alg but no hashes, namespace B has hashes but no alg
+        DeviceSignedItemsEntry algEntry = new DeviceSignedItemsEntry("transaction_data_hashes_alg", List.of("sha-256"));
+        DeviceSignedItems algItems = new DeviceSignedItems(List.of(algEntry));
+        DeviceNameSpacesEntry algNsEntry = new DeviceNameSpacesEntry("alg-ns", algItems);
+
+        DeviceSignedItemsEntry hashEntry = new DeviceSignedItemsEntry("transaction_data_hashes", List.of(hash));
+        DeviceSignedItems hashItems = new DeviceSignedItems(List.of(hashEntry));
+        DeviceNameSpacesEntry hashNsEntry = new DeviceNameSpacesEntry(NAMESPACE, hashItems);
+
+        DeviceNameSpaces deviceNameSpaces = new DeviceNameSpaces(List.of(algNsEntry, hashNsEntry));
+
+        MdocVerificationOpts opts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+        String mdoc = MdocBaseTest.buildDeviceResponse(
+                        opts, Map.of(NAMESPACE, Map.of("c", "v")), DOC_TYPE, deviceNameSpaces)
+                .encodeToBase64Url();
+
+        MdocVerificationOpts verifyOpts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+        MdocVerificationContext verificationContext = new MdocVerificationContext(mdoc);
+        verificationContext.verifyPresentation(
+                verifyOpts, null, new TestTruststoreProvider(MdocBaseTest.getIssuerCertRef1()));
+        var authCtx = authContextWithWire(List.of(wire));
+
+        MdocCredentialVerifier handler = new MdocCredentialVerifier(mock(StatusListJwtFetcher.class));
+        assertThrows(VerificationException.class, () -> handler.validateTransactionData(authCtx, verificationContext));
+    }
+
+    @Test
+    void rejectsTransactionData_WhenHashesInMultipleNamespaces() throws Exception {
+        String wire = wireEntry("payment");
+        String hash = hashForWire(wire);
+
+        DeviceSignedItemsEntry txEntry1 = new DeviceSignedItemsEntry("transaction_data_hashes", List.of(hash));
+        DeviceSignedItems items1 = new DeviceSignedItems(List.of(txEntry1));
+        DeviceNameSpacesEntry nsEntry1 = new DeviceNameSpacesEntry("ns1", items1);
+
+        DeviceSignedItemsEntry txEntry2 = new DeviceSignedItemsEntry("transaction_data_hashes", List.of(hash));
+        DeviceSignedItems items2 = new DeviceSignedItems(List.of(txEntry2));
+        DeviceNameSpacesEntry nsEntry2 = new DeviceNameSpacesEntry("ns2", items2);
+
+        DeviceNameSpaces deviceNameSpaces = new DeviceNameSpaces(List.of(nsEntry1, nsEntry2));
+
+        MdocVerificationOpts opts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+        String mdoc = MdocBaseTest.buildDeviceResponse(
+                        opts, Map.of(NAMESPACE, Map.of("c", "v")), DOC_TYPE, deviceNameSpaces)
+                .encodeToBase64Url();
+
+        MdocVerificationOpts verifyOpts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+        MdocVerificationContext verificationContext = new MdocVerificationContext(mdoc);
+        verificationContext.verifyPresentation(
+                verifyOpts, null, new TestTruststoreProvider(MdocBaseTest.getIssuerCertRef1()));
+        var authCtx = authContextWithWire(List.of(wire));
+
+        MdocCredentialVerifier handler = new MdocCredentialVerifier(mock(StatusListJwtFetcher.class));
+        assertThrows(VerificationException.class, () -> handler.validateTransactionData(authCtx, verificationContext));
+    }
+
+    @Test
+    void rejectsMismatchedTransactionData() throws Exception {
+        String wire = wireEntry("payment");
+        String mdoc = buildMdocWithTransactionData("different-hash");
+
+        MdocVerificationOpts opts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+        MdocVerificationContext verificationContext = new MdocVerificationContext(mdoc);
+        verificationContext.verifyPresentation(
+                opts, null, new TestTruststoreProvider(MdocBaseTest.getIssuerCertRef1()));
+        var authCtx = authContextWithWire(List.of(wire));
+
+        MdocCredentialVerifier handler = new MdocCredentialVerifier(mock(StatusListJwtFetcher.class));
+        assertThrows(VerificationException.class, () -> handler.validateTransactionData(authCtx, verificationContext));
+    }
+
+    @Test
+    void rejectsMissingTransactionDataHashes() throws Exception {
+        String wire = wireEntry("payment");
+        MdocVerificationOpts opts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+        String mdoc = MdocBaseTest.buildDeviceResponse(opts, Map.of(NAMESPACE, Map.of("c", "v")), DOC_TYPE)
+                .encodeToBase64Url();
+
+        MdocVerificationContext verificationContext = new MdocVerificationContext(mdoc);
+        verificationContext.verifyPresentation(
+                opts, null, new TestTruststoreProvider(MdocBaseTest.getIssuerCertRef1()));
+        var authCtx = authContextWithWire(List.of(wire));
+
+        MdocCredentialVerifier handler = new MdocCredentialVerifier(mock(StatusListJwtFetcher.class));
+        assertThrows(VerificationException.class, () -> handler.validateTransactionData(authCtx, verificationContext));
+    }
+
+    @Test
+    void rejectsTransactionData_WhenRequestExpectsAlgButMdocHasNone() throws Exception {
+        var tx = JsonSerialization.mapper.createObjectNode();
+        tx.put(TransactionDataSupport.TYPE_CLAIM, "payment");
+        tx.putArray(TransactionDataSupport.CREDENTIAL_IDS_CLAIM).add("cred-1");
+        tx.putArray(TransactionDataSupport.HASH_ALGS_CLAIM).add("sha-256");
+        String wire = TransactionDataSupport.prepareWireEntry(TransactionDataSupport.encodeWireObject(tx), "cred-1");
+
+        String hash = TransactionDataSupport.base64UrlEncodeHash(
+                TransactionDataSupport.hashWireString(wire, TransactionDataSupport.DEFAULT_HASH_ALG));
+
+        // mDoc has transaction_data_hashes but no transaction_data_hashes_alg
+        String mdoc = buildMdocWithTransactionData(hash);
+
+        MdocVerificationOpts opts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+        MdocVerificationContext verificationContext = new MdocVerificationContext(mdoc);
+        verificationContext.verifyPresentation(
+                opts, null, new TestTruststoreProvider(MdocBaseTest.getIssuerCertRef1()));
+        var authCtx = authContextWithWire(List.of(wire));
+
+        MdocCredentialVerifier handler = new MdocCredentialVerifier(mock(StatusListJwtFetcher.class));
+        assertThrows(VerificationException.class, () -> handler.validateTransactionData(authCtx, verificationContext));
+    }
+
+    @Test
+    void skipsValidationWhenNoTransactionDataOnSession() throws Exception {
+        MdocVerificationOpts opts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+        String mdoc = MdocBaseTest.buildDeviceResponse(opts, Map.of(NAMESPACE, Map.of("c", "v")), DOC_TYPE)
+                .encodeToBase64Url();
+
+        MdocVerificationContext verificationContext = new MdocVerificationContext(mdoc);
+        verificationContext.verifyPresentation(
+                opts, null, new TestTruststoreProvider(MdocBaseTest.getIssuerCertRef1()));
+        var authCtx = authContextWithWire(null);
+
+        MdocCredentialVerifier handler = new MdocCredentialVerifier(mock(StatusListJwtFetcher.class));
+        assertDoesNotThrow(() -> handler.validateTransactionData(authCtx, verificationContext));
+    }
+
+    @Test
+    void acceptsTransactionData_WhenAuthorizedViaDataElements() throws Exception {
+        String wire = wireEntry("payment");
+        String hash = hashForWire(wire);
+
+        MdocVerificationOpts opts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+
+        // Build mDoc with transaction_data_hashes, then modify MSO to use dataElements-only auth
+        DeviceResponse dr = MdocBaseTest.buildDeviceResponse(
+                opts,
+                Map.of(NAMESPACE, Map.of("c", "v")),
+                DOC_TYPE,
+                new DeviceNameSpaces(List.of(new DeviceNameSpacesEntry(
+                        NAMESPACE,
+                        new DeviceSignedItems(
+                                List.of(new DeviceSignedItemsEntry("transaction_data_hashes", List.of(hash))))))));
+        DeviceResponse modified =
+                replaceKeyAuthorization(dr, dataElementsOnlyAuth(NAMESPACE, List.of("transaction_data_hashes")));
+        String modifiedMdoc = modified.encodeToBase64Url();
+
+        MdocVerificationContext modifiedCtx = new MdocVerificationContext(modifiedMdoc);
+        modifiedCtx.verifyPresentation(opts, null, new TestTruststoreProvider(MdocBaseTest.getIssuerCertRef1()));
+        var authCtx = authContextWithWire(List.of(wire));
+
+        MdocCredentialVerifier handler = new MdocCredentialVerifier(mock(StatusListJwtFetcher.class));
+        assertDoesNotThrow(() -> handler.validateTransactionData(authCtx, modifiedCtx));
+    }
+
+    @Test
+    void rejectsTransactionData_WhenElementNotAuthorizedInDataElements() throws Exception {
+        String wire = wireEntry("payment");
+        String hash = hashForWire(wire);
+
+        // Build mDoc with transaction_data_hashes, then modify MSO to authorize only a different element
+        MdocVerificationOpts opts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+        DeviceResponse dr = MdocBaseTest.buildDeviceResponse(
+                opts,
+                Map.of(NAMESPACE, Map.of("c", "v")),
+                DOC_TYPE,
+                new DeviceNameSpaces(List.of(new DeviceNameSpacesEntry(
+                        NAMESPACE,
+                        new DeviceSignedItems(
+                                List.of(new DeviceSignedItemsEntry("transaction_data_hashes", List.of(hash))))))));
+        DeviceResponse modified =
+                replaceKeyAuthorization(dr, dataElementsOnlyAuth(NAMESPACE, List.of("some-other-element")));
+        String modifiedMdoc = modified.encodeToBase64Url();
+
+        MdocVerificationContext modifiedCtx = new MdocVerificationContext(modifiedMdoc);
+        modifiedCtx.verifyPresentation(opts, null, new TestTruststoreProvider(MdocBaseTest.getIssuerCertRef1()));
+        var authCtx = authContextWithWire(List.of(wire));
+
+        MdocCredentialVerifier handler = new MdocCredentialVerifier(mock(StatusListJwtFetcher.class));
+        assertThrows(VerificationException.class, () -> handler.validateTransactionData(authCtx, modifiedCtx));
+    }
+
+    private static DeviceResponse replaceKeyAuthorization(DeviceResponse dr, KeyAuthorizations keyAuth)
+            throws Exception {
+        return withModifiedMso(dr, mso -> {
+            List<CBORPair> newPairs = new ArrayList<>();
+            for (var pair : mso.getPairs()) {
+                if (pair != null
+                        && pair.getKey() instanceof CBORString keyStr
+                        && MdocConstants.L_DEVICE_KEY_INFO.equals(keyStr.getValue())) {
+                    newPairs.add(new CBORPair(pair.getKey(), new DeviceKeyInfo(getDeviceKeyRef1(), keyAuth, null)));
+                } else {
+                    newPairs.add(pair);
+                }
+            }
+            return new CBORPairList(newPairs);
+        });
+    }
+
+    private static AuthorizationContext authContextWithWire(List<String> wireEntries) {
+        var requestObject = mock(RequestObject.class);
+        when(requestObject.getTransactionData()).thenReturn(wireEntries);
+        var authCtx = mock(AuthorizationContext.class);
+        when(authCtx.getRequestObject()).thenReturn(requestObject);
+        return authCtx;
+    }
+
+    // Builds an mDoc with transaction_data_hashes in the authorized namespace.
+    private static String buildMdocWithTransactionData(String hash) throws Exception {
+        DeviceSignedItemsEntry txDataEntry = new DeviceSignedItemsEntry("transaction_data_hashes", List.of(hash));
+        DeviceSignedItems items = new DeviceSignedItems(List.of(txDataEntry));
+        DeviceNameSpacesEntry nsEntry = new DeviceNameSpacesEntry(NAMESPACE, items);
+        DeviceNameSpaces deviceNameSpaces = new DeviceNameSpaces(List.of(nsEntry));
+
+        MdocVerificationOpts opts =
+                MdocBaseTest.getDefaultMdocVerificationOpts().build();
+        DeviceResponse dr =
+                MdocBaseTest.buildDeviceResponse(opts, Map.of(NAMESPACE, Map.of("c", "v")), DOC_TYPE, deviceNameSpaces);
+        return dr.encodeToBase64Url();
+    }
+
+    private static String wireEntry(String type) {
+        var tx = JsonSerialization.mapper.createObjectNode();
+        tx.put(TransactionDataSupport.TYPE_CLAIM, type);
+        tx.putArray(TransactionDataSupport.CREDENTIAL_IDS_CLAIM).add("cred-1");
+        return TransactionDataSupport.prepareWireEntry(TransactionDataSupport.encodeWireObject(tx), "cred-1");
+    }
+
+    private static String hashForWire(String wire) {
+        return TransactionDataSupport.base64UrlEncodeHash(
+                TransactionDataSupport.hashWireString(wire, TransactionDataSupport.DEFAULT_HASH_ALG));
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
@@ -14,7 +14,11 @@ import com.authlete.cbor.CBORInteger;
 import com.authlete.cbor.CBORPair;
 import com.authlete.cbor.CBORPairList;
 import com.authlete.cbor.CBORString;
+import com.authlete.mdoc.DeviceNameSpaces;
+import com.authlete.mdoc.DeviceNameSpacesEntry;
 import com.authlete.mdoc.DeviceResponse;
+import com.authlete.mdoc.DeviceSignedItems;
+import com.authlete.mdoc.DeviceSignedItemsEntry;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocBaseTest;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationOpts;
@@ -23,19 +27,23 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.AuthRequireme
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRole;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.TrustPolicy;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.trust.TrustAnchorProvider;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.TransactionDataSupport;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.ReferencedTokenValidationException;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.common.VerificationException;
 import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.util.JsonSerialization;
 
 public class MdocRevocationStatusTest extends MdocBaseTest {
 
@@ -141,6 +149,91 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
                 assertThrows(ReferencedTokenValidationException.class, () -> new ReferencedTokenValidator(mockFetcher)
                         .validate(ctx.getVerifiedMsoPayload()));
         assertTrue(exception.getMessage().contains("Token status is not valid"));
+    }
+
+    @Test
+    public void shouldVerifyCredential_WithBothRevocationAndTransactionData() throws Exception {
+        // Setup transaction data wire and hash
+        var tx = JsonSerialization.mapper.createObjectNode();
+        tx.put(TransactionDataSupport.TYPE_CLAIM, "payment");
+        tx.putArray(TransactionDataSupport.CREDENTIAL_IDS_CLAIM).add("cred-1");
+        String wire = TransactionDataSupport.prepareWireEntry(TransactionDataSupport.encodeWireObject(tx), "cred-1");
+        String hash = TransactionDataSupport.base64UrlEncodeHash(
+                TransactionDataSupport.hashWireString(wire, TransactionDataSupport.DEFAULT_HASH_ALG));
+
+        // Build mDoc with matching transaction_data_hashes in the authorized namespace
+        DeviceSignedItemsEntry txEntry = new DeviceSignedItemsEntry("transaction_data_hashes", List.of(hash));
+        DeviceSignedItems items = new DeviceSignedItems(List.of(txEntry));
+        DeviceNameSpacesEntry nsEntry = new DeviceNameSpacesEntry(NAMESPACE, items);
+        DeviceNameSpaces deviceNameSpaces = new DeviceNameSpaces(List.of(nsEntry));
+
+        // Setup auth config with revocation enabled
+        var authConfig = new AuthenticatorConfigModel();
+        authConfig.getConfig().put(ENFORCE_REVOCATION_STATUS_CONFIG, "true");
+
+        var requestObject = new RequestObject()
+                .setClientId("x509_san_dns:example.com")
+                .setNonce("exc7gBkxjx1rdc9udRrveKvSsJIq80avlXeLHhGwqtA")
+                .setResponseUri("https://example.com/response")
+                .setTransactionData(List.of(wire));
+
+        var authCtx = new AuthorizationContext().setRequestObject(requestObject);
+        var authReqs = new AuthRequirements(authConfig);
+
+        var context = mock(AuthenticationFlowContext.class);
+        when(context.getAuthenticatorConfig()).thenReturn(authConfig);
+
+        var credential = new CredentialRequirement()
+                .setId("test")
+                .setRole(CredentialRole.PRIMARY)
+                .setCredentialTypes(List.of(DOC_TYPE))
+                .setTrust(List.of(new TrustPolicy().setType(TrustPolicy.X5C).setAnchors(List.of(getIssuerCertRef1()))));
+
+        var verifier = new MdocCredentialVerifier(mockFetcher);
+
+        byte[] thumbprint = MdocCredentialVerifier.computeJwkThumbprint(requestObject);
+        var optsFromRequest = MdocVerificationOpts.builder()
+                .withClientId(requestObject.getClientId())
+                .withOid4vpNonce(requestObject.getNonce())
+                .withResponseUri(requestObject.getResponseUri())
+                .withJwkThumbprint(thumbprint)
+                .build();
+
+        // Build mDoc with valid status (idx 1) + transaction_data_hashes
+        DeviceResponse dr =
+                buildDeviceResponse(optsFromRequest, Map.of(NAMESPACE, Map.of("c", "v")), DOC_TYPE, deviceNameSpaces);
+        DeviceResponse withStatus = withModifiedMso(dr, mso -> getCborPairList(1, mso));
+        String validMdoc = withStatus.encodeToBase64Url();
+
+        assertDoesNotThrow(() -> verifier.verifyCredential(context, authCtx, authReqs, credential, validMdoc));
+
+        // Build mDoc with revoked status (idx 0) + matching transaction_data_hashes
+        DeviceResponse revokedDr =
+                buildDeviceResponse(optsFromRequest, Map.of(NAMESPACE, Map.of("c", "v")), DOC_TYPE, deviceNameSpaces);
+        DeviceResponse withRevokedStatus = withModifiedMso(revokedDr, mso -> getCborPairList(0, mso));
+        String revokedMdoc = withRevokedStatus.encodeToBase64Url();
+
+        VerificationException exception = assertThrows(
+                VerificationException.class,
+                () -> verifier.verifyCredential(context, authCtx, authReqs, credential, revokedMdoc));
+        assertTrue(exception.getMessage().contains("Token status verification failed"));
+
+        // Build mDoc with matching hashes but unauthorized namespace (DOC_TYPE not in KeyAuthorizations)
+        DeviceSignedItemsEntry unauthorizedTxEntry =
+                new DeviceSignedItemsEntry("transaction_data_hashes", List.of(hash));
+        DeviceSignedItems unauthorizedItems = new DeviceSignedItems(List.of(unauthorizedTxEntry));
+        DeviceNameSpacesEntry unauthorizedNsEntry = new DeviceNameSpacesEntry(DOC_TYPE, unauthorizedItems);
+        DeviceNameSpaces unauthorizedNameSpaces = new DeviceNameSpaces(List.of(unauthorizedNsEntry));
+
+        DeviceResponse unauthorizedDr = buildDeviceResponse(
+                optsFromRequest, Map.of(NAMESPACE, Map.of("c", "v")), DOC_TYPE, unauthorizedNameSpaces);
+        DeviceResponse unauthorizedWithStatus = withModifiedMso(unauthorizedDr, mso -> getCborPairList(1, mso));
+        String unauthorizedMdoc = unauthorizedWithStatus.encodeToBase64Url();
+
+        VerificationException unauthorizedException = assertThrows(
+                VerificationException.class,
+                () -> verifier.verifyCredential(context, authCtx, authReqs, credential, unauthorizedMdoc));
+        assertTrue(unauthorizedException.getMessage().contains("not authorized"));
     }
 
     private String buildMdocWithStatus(int idx) throws Exception {

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
@@ -230,9 +230,9 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
         DeviceResponse unauthorizedWithStatus = withModifiedMso(unauthorizedDr, mso -> getCborPairList(1, mso));
         String unauthorizedMdoc = unauthorizedWithStatus.encodeToBase64Url();
 
+        assertDoesNotThrow(() -> verifier.verifyCredential(context, authCtx, authReqs, credential, unauthorizedMdoc));
         VerificationException unauthorizedException = assertThrows(
-                VerificationException.class,
-                () -> verifier.verifyCredential(context, authCtx, authReqs, credential, unauthorizedMdoc));
+                VerificationException.class, () -> verifier.validateTransactionData(authCtx, unauthorizedMdoc));
         assertTrue(unauthorizedException.getMessage().contains("not authorized"));
     }
 

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
@@ -202,6 +202,34 @@ public class OID4VPProfileConfigTest {
     }
 
     @Test
+    void shouldAcceptTransactionDataWithMdocPrimaryCredential() {
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put(PROFILES_CONFIG, """
+                [
+                  {
+                    "id": "default",
+                    "credentials": [
+                      {
+                        "id": "primary",
+                        "role": "primary",
+                        "format": "mso_mdoc",
+                        "credentialTypes": ["com.example.doctype"],
+                        "claims": ["com.example.namespace1/sub", "com.example.namespace1/username"],
+                        "trust": [{ "type": "x5c", "anchors": ["%s"] }]
+                      }
+                    ]
+                  }
+                ]
+                """.formatted(MdocBaseTest.getIssuerCertBase64()));
+        configMap.put(TRANSACTION_DATA_CONFIG, "{\"type\":\"qrat\",\"credential_ids\":[\"primary\"]}");
+
+        AuthenticatorConfigModel config = new AuthenticatorConfigModel();
+        config.setConfig(configMap);
+
+        assertDoesNotThrow(() -> new VerifierConfig(config));
+    }
+
+    @Test
     void shouldRejectCredentialIdentityPrimaryWithoutSubAndUsername() {
         AuthenticatorConfigModel config = new AuthenticatorConfigModel();
         config.setConfig(Map.of(PROFILES_CONFIG, """
@@ -278,35 +306,6 @@ public class OID4VPProfileConfigTest {
         assertEquals(
                 "OpenID4VP session-identity primary credential must define binding rules: stb-issuance/pid",
                 error.getMessage());
-    }
-
-    @Test
-    void shouldRejectTransactionDataWhenPrimaryCredentialIsMdoc() {
-        Map<String, String> configMap = new HashMap<>();
-        configMap.put(PROFILES_CONFIG, """
-                [
-                  {
-                    "id": "default",
-                    "credentials": [
-                      {
-                        "id": "primary",
-                        "role": "primary",
-                        "format": "mso_mdoc",
-                        "credentialTypes": ["com.example.doctype"],
-                        "claims": ["com.example.namespace1/sub", "com.example.namespace1/username"],
-                        "trust": [{ "type": "x5c", "anchors": ["%s"] }]
-                      }
-                    ]
-                  }
-                ]
-                """.formatted(MdocBaseTest.getIssuerCertBase64()));
-        configMap.put(TRANSACTION_DATA_CONFIG, "{\"type\":\"qrat\",\"credential_ids\":[\"primary\"]}");
-
-        AuthenticatorConfigModel config = new AuthenticatorConfigModel();
-        config.setConfig(configMap);
-
-        IllegalStateException error = assertThrows(IllegalStateException.class, () -> new VerifierConfig(config));
-        assertEquals("transactionData is not yet supported for mso_mdoc primary credentials", error.getMessage());
     }
 
     // ---- Binding rule validation -------------------------------------------


### PR DESCRIPTION
This PR adds `transaction_data_hashes` validation for `mso_mdoc` credentials, analogous to the existing SD-JWT KB-JWT validation.

The wallet includes the hashes in `DeviceSigned.nameSpaces`, where they are covered by the device signature. During presentation verification, the verifier extracts these hashes and validates them against the transaction data supplied in the
authorization request.

### Changes

- **VerifierConfig**: Removed the guard preventing `transaction_data` from being used with `mso_mdoc` as the primary credential.
- **MdocVerificationContext**: Added `getDeviceNameSpaces()` to expose `DeviceSigned.nameSpaces` during verification.
- **MdocCredentialVerifier**: Added `validateTransactionData()`, which reads `transaction_data_hashes` from the device namespaces and delegates validation to `TransactionDataValidator`.
- **MdocBaseTest**: Added builder support for custom `DeviceNameSpaces` in test mDocs.
- **Tests**: Updated the profile configuration test and added four transaction data verification tests for mDoc credentials.

Closes #124 