### PR TITLE
Improve readability of OID4VPAuthenticator

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/CredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/CredentialVerifier.java
@@ -1,10 +1,7 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.AuthRequirements;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
-import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.common.VerificationException;
 
 /**
@@ -23,6 +20,12 @@ public interface CredentialVerifier {
     CredentialFormat format();
 
     /**
+     * Returns a fresh, independent verifier for a single authentication run so that
+     * per-verification state is not shared across sessions.
+     */
+    CredentialVerifier copy();
+
+    /**
      * Verifies a credential presentation and returns the verified claims.
      *
      * <p>The orchestrator uses the returned claims for binding-rule evaluation and
@@ -32,18 +35,8 @@ public interface CredentialVerifier {
      * @throws VerificationException if cryptographic verification, claim requirements, or trust
      *         policy validation fails
      */
-    JsonNode verifyCredential(
-            AuthenticationFlowContext context,
-            AuthorizationContext authorizationContext,
-            AuthRequirements authRequirements,
-            CredentialRequirement credential,
-            String token)
+    JsonNode verifyCredential(OID4VPAuthenticator.Context context, CredentialRequirement credential, String token)
             throws VerificationException;
-
-    /**
-     * Reads claims according to format-specific rules.
-     */
-    String readClaim(JsonNode claims, String claimName);
 
     /**
      * Validates {@code transaction_data_hashes} from the presented credential
@@ -53,9 +46,14 @@ public interface CredentialVerifier {
      * The verifier may use state cached during {@link #verifyCredential} to
      * perform the validation (e.g. a post-verification {@code MdocVerificationContext}).
      *
-     * @param authorizationContext  context containing the request object
-     * @param token                 raw credential presentation token
+     * @param context  authenticator context for accessing transaction data
+     * @param token    raw credential presentation token
      * @throws VerificationException if the hashes do not match the request
      */
-    void validateTransactionData(AuthorizationContext authorizationContext, String token) throws VerificationException;
+    void validateTransactionData(OID4VPAuthenticator.Context context, String token) throws VerificationException;
+
+    /**
+     * Reads claims according to format-specific rules.
+     */
+    String readClaim(JsonNode claims, String claimName);
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/CredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/CredentialVerifier.java
@@ -35,7 +35,7 @@ public interface CredentialVerifier {
      * @throws VerificationException if cryptographic verification, claim requirements, or trust
      *         policy validation fails
      */
-    JsonNode verifyCredential(OID4VPAuthenticator.Context context, CredentialRequirement credential, String token)
+    JsonNode verifyCredential(OID4VPAuthenticator.Context context, CredentialRequirement credentialReq, String token)
             throws VerificationException;
 
     /**

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
@@ -24,6 +24,7 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.FlowStatus;
 import org.keycloak.common.VerificationException;
 import org.keycloak.events.Errors;
 import org.keycloak.models.KeycloakSession;
@@ -71,7 +72,9 @@ public class OID4VPAuthenticator implements Authenticator {
         try {
             authUser = verifyPrimaryCredential(ctx);
         } catch (VerificationException e) {
-            logger.errorf(e, "Primary credential verification failed (authSession = %s)", ctx.id());
+            String msg = "Primary credential verification failed";
+            logger.errorf(e, "%s (authSession = %s)", msg, ctx.id());
+            failRejectingPresentedCredential(ctx, msg);
             return;
         }
 
@@ -79,7 +82,9 @@ public class OID4VPAuthenticator implements Authenticator {
         try {
             verifySupportingCredentials(ctx, authUser);
         } catch (VerificationException e) {
-            logger.errorf(e, "Supporting credential verification failed (authSession = %s)", ctx.id());
+            String msg = "Supporting credential verification failed";
+            logger.errorf(e, "%s (authSession = %s)", msg, ctx.id());
+            failRejectingPresentedCredential(ctx, msg);
             return;
         }
 
@@ -161,13 +166,8 @@ public class OID4VPAuthenticator implements Authenticator {
                 continue;
             }
 
-            String token = ctx.presentedTokens().get(credential.getId());
-            if (StringUtil.isBlank(token)) {
-                throw new VerificationException(String.format(
-                        "Supporting credential '%s' is missing from the presentation", credential.getId()));
-            }
-
             try {
+                String token = ctx.presentedTokens().get(credential.getId());
                 CredentialVerifier supportingVerifier =
                         ctx.credentialVerifiers().get(credential.getId());
                 JsonNode supportingClaims = supportingVerifier.verifyCredential(ctx, credential, token);
@@ -219,11 +219,27 @@ public class OID4VPAuthenticator implements Authenticator {
         logger.infof("Recovering authenticating user (authSession = %s)", ctx.id());
         CredentialRequirement primaryCredentialReq = ctx.authenticationProfile().getPrimaryCredential();
 
-        if (primaryCredentialReq.isSessionIdentity()) {
-            // User is to be recovered from session, not primary claims
-            return recoverPresentationDuringIssuanceUser(ctx);
+        UserModel user = primaryCredentialReq.isSessionIdentity()
+                ? recoverPresentationDuringIssuanceUser(ctx)
+                : recoverUserFromClaims(ctx, primaryCredentialReq, primaryClaims);
+
+        if (user == null) {
+            return null;
         }
 
+        logger.debugf("Recovered authenticating user has id '%s'", user.getId());
+
+        if (!user.isEnabled()) {
+            logger.debugf("Rejecting authentication for disabled user '%s'", user.getUsername());
+            failDenyingDisabledUser(ctx);
+            return null;
+        }
+
+        return user;
+    }
+
+    private UserModel recoverUserFromClaims(
+            Context ctx, CredentialRequirement primaryCredentialReq, JsonNode primaryClaims) {
         CredentialVerifier verifier = ctx.credentialVerifiers().get(primaryCredentialReq.getId());
         String subject = verifier.readClaim(primaryClaims, JsonWebToken.SUBJECT);
         String username = verifier.readClaim(primaryClaims, OAuth2Constants.USERNAME);
@@ -250,21 +266,11 @@ public class OID4VPAuthenticator implements Authenticator {
             return null;
         }
 
-        logger.debugf("Recovered authenticating user has id '%s'", user.getId());
-
-        // Running additional checks on the recovered user
-
         if (StringUtil.isNotBlank(username) && !username.equals(user.getUsername())) {
             logger.warnf(
                     "Username mismatch for subject '%s': credential='%s', user='%s'",
                     subject, username, user.getUsername());
             failRejectingPresentedCredential(ctx, "Username mismatch");
-            return null;
-        }
-
-        if (!user.isEnabled()) {
-            logger.debugf("Rejecting authentication for disabled user '%s'", user.getUsername());
-            failDenyingDisabledUser(ctx);
             return null;
         }
 
@@ -376,6 +382,14 @@ public class OID4VPAuthenticator implements Authenticator {
 
     private void failAuthentication(
             Context ctx, AuthenticationFlowError flowError, String errorCode, String description) {
+        if (ctx.authenticationFlowContext().getStatus() == FlowStatus.FAILED) {
+            logger.debugf(
+                    "A failure has already been set; skipping '%s' (errorCode=%s) to preserve the "
+                            + "previous failure (authSession = %s)",
+                    description, errorCode, ctx.id());
+            return;
+        }
+
         var errorRep = new OAuth2ErrorRepresentation(errorCode, description);
         ctx.authenticationFlowContext()
                 .failure(

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
@@ -17,6 +17,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.ErrorResponseS
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.jboss.logging.Logger;
@@ -311,7 +312,7 @@ public class OID4VPAuthenticator implements Authenticator {
         }
     }
 
-    private Map<String, CredentialVerifier> resolveVerifiers(AuthorizationContext authContext) {
+    Map<String, CredentialVerifier> resolveVerifiers(AuthorizationContext authContext) {
         DcqlQuery dcqlQuery = authContext.getRequestObject().getDcqlQuery();
         if (dcqlQuery == null || dcqlQuery.getCredentials() == null) {
             throw new IllegalStateException("No DCQL query found in authorization context");
@@ -429,7 +430,13 @@ public class OID4VPAuthenticator implements Authenticator {
             AuthenticationProfile authenticationProfile,
             AuthRequirements authRequirements,
             Map<String, String> presentedTokens,
-            Map<String, CredentialVerifier> credentialVerifiers) {}
+            Map<String, CredentialVerifier> credentialVerifiers) {
+
+        public Context {
+            presentedTokens = Collections.unmodifiableMap(presentedTokens);
+            credentialVerifiers = Collections.unmodifiableMap(credentialVerifiers);
+        }
+    }
 
     record AuthenticatingUser(UserModel userModel, JsonNode primaryClaims) {}
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
@@ -17,8 +17,8 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.ErrorResponseS
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.authentication.AuthenticationFlowContext;
@@ -29,6 +29,7 @@ import org.keycloak.events.Errors;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserProvider;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.sessions.AuthenticationSessionModel;
@@ -61,179 +62,271 @@ public class OID4VPAuthenticator implements Authenticator {
     }
 
     @Override
-    public void authenticate(AuthenticationFlowContext context) {
-        AuthenticationSessionModel authSession = context.getAuthenticationSession();
-        logger.info("Authenticating with OID4VPAuthenticator");
+    public void authenticate(AuthenticationFlowContext authFlowContext) {
+        Context ctx = gatherContext(authFlowContext);
+        logger.debugf("Authenticating with OID4VPAuthenticator (authSession = %s)", ctx.id());
 
-        AuthenticationProfile profile = getAuthenticationProfile(context);
-        CredentialRequirement primaryCredential = profile.getPrimaryCredential();
+        // Verify primary credential and recover authenticating user
+        AuthenticatingUser authUser;
+        try {
+            authUser = verifyPrimaryCredential(ctx);
+        } catch (VerificationException e) {
+            logger.errorf(e, "Primary credential verification failed (authSession = %s)", ctx.id());
+            return;
+        }
 
-        AuthorizationContext authContext = getAuthorizationContext(authSession);
-        AuthRequirements authRequirements = new AuthRequirements(context.getAuthenticatorConfig());
+        // Verify supporting credentials while enforcing binding to authenticating user
+        try {
+            verifySupportingCredentials(ctx, authUser);
+        } catch (VerificationException e) {
+            logger.errorf(e, "Supporting credential verification failed (authSession = %s)", ctx.id());
+            return;
+        }
+
+        // Authentication successful: attach authenticated user to context
+        UserModel user = authUser.userModel();
+        authFlowContext.setUser(user);
+        authFlowContext.success();
+        logger.debugf("User '%s' successfully authenticated", user.getUsername());
+    }
+
+    /**
+     * Builds the {@link Context} carried throughout the authentication run.
+     */
+    private Context gatherContext(AuthenticationFlowContext authFlowContext) {
+        AuthRequirements authRequirements = new AuthRequirements(authFlowContext.getAuthenticatorConfig());
+        AuthenticationSessionModel authSession = authFlowContext.getAuthenticationSession();
+        AuthorizationContext authContext = new AuthenticationSessionStore(authSession).getAuthorizationContext();
+
+        // TODO: Access the profile config reliably without full parsing on every iteration.
+        //       Issue also applies to VerifierConfig.
+        OID4VPProfileConfig profileConfig = new OID4VPProfileConfig(authFlowContext.getAuthenticatorConfig());
+        AuthenticationProfile authProfile = profileConfig.getProfile(authContext.getProfileId());
 
         Map<String, String> presentedTokens = getPresentedTokens(authSession);
-        String primaryToken = presentedTokens.get(primaryCredential.getId());
-        if (StringUtil.isBlank(primaryToken)) {
-            failRejectingPresentedCredential(
-                    context,
-                    String.format("Missing credential presentation for credential: %s", primaryCredential.getId()));
-            return;
-        }
+        Map<String, CredentialVerifier> credentialVerifiers = resolveVerifiers(authContext);
 
-        CredentialVerifier primaryVerifier = resolveVerifier(authSession, primaryCredential.getId());
+        String correlationId = ErrorResponseSanitizer.correlationIdFromAuthSession(authSession);
+        return new Context(
+                correlationId,
+                authFlowContext,
+                authSession,
+                authContext,
+                authProfile,
+                authRequirements,
+                presentedTokens,
+                credentialVerifiers);
+    }
+
+    private AuthenticatingUser verifyPrimaryCredential(Context ctx) throws VerificationException {
+        CredentialRequirement primaryCredentialReq = ctx.authenticationProfile().getPrimaryCredential();
+        CredentialVerifier primaryVerifier = ctx.credentialVerifiers().get(primaryCredentialReq.getId());
+        String primaryToken = ctx.presentedTokens().get(primaryCredentialReq.getId());
+
+        // Run credential verification and capture claims
         JsonNode primaryClaims;
-
         try {
-            primaryClaims = primaryVerifier.verifyCredential(
-                    context, authContext, authRequirements, primaryCredential, primaryToken);
-            primaryVerifier.validateTransactionData(authContext, primaryToken);
-        } catch (VerificationException e) {
-            logger.errorf(e, "Primary credential verification failed (authSession = %s)", correlationId(context));
-            failRejectingPresentedCredential(context, e.getMessage(), e);
-            return;
+            primaryClaims = primaryVerifier.verifyCredential(ctx, primaryCredentialReq, primaryToken);
+            primaryVerifier.validateTransactionData(ctx, primaryToken);
+        } catch (VerificationException | IllegalStateException e) {
+            String msg = "Primary credential verification failed";
+            failRejectingPresentedCredential(ctx, String.format("%s: %s", msg, e.getMessage()));
+            throw new VerificationException(msg, e);
         }
 
-        UserModel user =
-                recoverAuthenticatingUser(context, authContext, primaryCredential, primaryVerifier, primaryClaims);
+        // Recover authenticating user from Keycloak
+        UserModel user = recoverAuthenticatingUser(ctx, primaryClaims);
         if (user == null) {
-            return;
+            throw new VerificationException("Failure recovering authenticating user");
         }
-
-        if (!user.isEnabled()) {
-            logger.debugf("Rejecting authentication for disabled user '%s'", user.getUsername());
-            failDenyingDisabledUser(context);
-            return;
-        }
+        AuthenticatingUser authUser = new AuthenticatingUser(user, primaryClaims);
 
         // Primary-credential binding rules establish that the verified credential belongs to the
         // recovered Keycloak user. This is especially important for session-identity profiles, where
         // the user comes from the issuance session rather than from identity claims in the credential.
         try {
-            applyBindingRules(context, primaryCredential, primaryVerifier, primaryClaims, null, null, user);
+            applyBindingRules(ctx, authUser, primaryCredentialReq, primaryClaims);
         } catch (VerificationException | IllegalStateException e) {
-            logger.errorf(e, "Primary credential binding failed (authSession = %s)", correlationId(context));
-            failRejectingPresentedCredential(context, e.getMessage(), e);
-            return;
+            String msg = "Primary credential binding checks failed";
+            failRejectingPresentedCredential(ctx, String.format("%s: %s", msg, e.getMessage()));
+            throw new VerificationException(msg, e);
         }
 
-        try {
-            var supportingTokens = supportingPresentedTokens(presentedTokens, primaryCredential.getId());
-            verifySupportingCredentials(
-                    context,
-                    authContext,
-                    authSession,
-                    profile,
-                    primaryVerifier,
-                    primaryClaims,
-                    supportingTokens,
-                    user,
-                    authRequirements);
-        } catch (VerificationException | IllegalStateException e) {
-            logger.errorf(e, "Supporting credential verification failed (authSession = %s)", correlationId(context));
-            failRejectingPresentedCredential(context, e.getMessage(), e);
-            return;
-        }
-
-        context.setUser(user);
-        context.success();
-        logger.debugf("User '%s' successfully authenticated", user.getUsername());
+        return authUser;
     }
 
-    @Override
-    public void action(AuthenticationFlowContext context) {
-        // No form action is relevant for this authenticator
-    }
-
-    private CredentialVerifier resolveVerifier(AuthenticationSessionModel authSession, String credentialId) {
-        DcqlQuery dcqlQuery =
-                getAuthorizationContext(authSession).getRequestObject().getDcqlQuery();
-        if (dcqlQuery == null || dcqlQuery.getCredentials() == null) {
-            throw new IllegalStateException("No DCQL query found in authorization context");
-        }
-
-        String format = dcqlQuery.getCredentials().stream()
-                .filter(c -> credentialId.equals(c.getId()))
-                .map(Credential::getFormat)
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException(
-                        String.format("Credential '%s' not found in DCQL query", credentialId)));
-
-        CredentialVerifier verifier = handlers.get(format);
-        if (verifier == null) {
-            throw new IllegalStateException(String.format(
-                    "No registered verifier supports format '%s' for credential '%s'", format, credentialId));
-        }
-
-        return verifier;
-    }
-
-    private void verifySupportingCredentials(
-            AuthenticationFlowContext context,
-            AuthorizationContext authContext,
-            AuthenticationSessionModel authSession,
-            AuthenticationProfile profile,
-            CredentialVerifier primaryVerifier,
-            JsonNode primaryClaims,
-            Map<String, String> supportingTokens,
-            UserModel user,
-            AuthRequirements authRequirements)
-            throws VerificationException {
-
-        for (CredentialRequirement credential : profile.getCredentials()) {
+    private void verifySupportingCredentials(Context ctx, AuthenticatingUser authUser) throws VerificationException {
+        for (CredentialRequirement credential : ctx.authenticationProfile().getCredentials()) {
             if (credential.isPrimary()) {
                 continue;
             }
 
-            String token = supportingTokens.get(credential.getId());
+            String token = ctx.presentedTokens().get(credential.getId());
             if (StringUtil.isBlank(token)) {
                 throw new VerificationException(String.format(
                         "Supporting credential '%s' is missing from the presentation", credential.getId()));
             }
 
-            CredentialVerifier supportingVerifier = resolveVerifier(authSession, credential.getId());
-            JsonNode supportingClaims =
-                    supportingVerifier.verifyCredential(context, authContext, authRequirements, credential, token);
-
-            applyBindingRules(
-                    context, credential, supportingVerifier, supportingClaims, primaryVerifier, primaryClaims, user);
+            try {
+                CredentialVerifier supportingVerifier =
+                        ctx.credentialVerifiers().get(credential.getId());
+                JsonNode supportingClaims = supportingVerifier.verifyCredential(ctx, credential, token);
+                applyBindingRules(ctx, authUser, credential, supportingClaims);
+            } catch (VerificationException | IllegalStateException e) {
+                String msg = "Supporting credential verification failed";
+                failRejectingPresentedCredential(ctx, String.format("%s: %s", msg, e.getMessage()));
+                throw new VerificationException(msg, e);
+            }
         }
     }
 
     void applyBindingRules(
-            AuthenticationFlowContext context,
-            CredentialRequirement credential,
-            CredentialVerifier supportingVerifier,
-            JsonNode supportingClaims,
-            CredentialVerifier primaryVerifier,
-            JsonNode primaryClaims,
-            UserModel user)
+            Context ctx, AuthenticatingUser authUser, CredentialRequirement credentialReq, JsonNode claims)
             throws VerificationException {
+        KeycloakSession session = ctx.authenticationFlowContext().getSession();
+        CredentialRequirement primaryCredentialReq = ctx.authenticationProfile().getPrimaryCredential();
+        CredentialVerifier primaryVerifier = ctx.credentialVerifiers().get(primaryCredentialReq.getId());
 
-        for (BindingRule rule : credential.getBinding()) {
-            String supportingValue = supportingVerifier.readClaim(supportingClaims, rule.getCredentialClaim());
+        for (BindingRule rule : credentialReq.getBinding()) {
+            CredentialVerifier verifier = ctx.credentialVerifiers().get(credentialReq.getId());
+            String actualValue = verifier.readClaim(claims, rule.getCredentialClaim());
+
             String expectedValue =
                     switch (rule.getType()) {
                         case BindingRule.CLAIM_EQUALS_PRIMARY_CLAIM -> {
-                            if (primaryVerifier == null || primaryClaims == null) {
+                            if (credentialReq.isPrimary()) {
                                 throw new VerificationException(String.format(
                                         "Binding rule '%s' is not applicable to the primary credential '%s'",
-                                        rule.getType(), credential.getId()));
+                                        rule.getType(), credentialReq.getId()));
                             }
-                            yield primaryVerifier.readClaim(primaryClaims, rule.getPrimaryCredentialClaim());
+                            yield primaryVerifier.readClaim(authUser.primaryClaims(), rule.getPrimaryCredentialClaim());
                         }
                         case BindingRule.CLAIM_EQUALS_USER_ATTRIBUTE ->
-                            readUserAttribute(user, rule.getUserAttribute());
+                            readUserAttribute(authUser.userModel(), rule.getUserAttribute());
                         default ->
                             throw new IllegalStateException(
                                     String.format("Unsupported binding rule type: %s", rule.getType()));
                     };
 
-            if (!resolveComparator(context.getSession(), rule).matches(supportingValue, expectedValue)) {
+            if (!resolveComparator(session, rule).matches(actualValue, expectedValue)) {
                 throw new VerificationException(String.format(
-                        "%s credential '%s' failed binding rule '%s'",
-                        credential.isPrimary() ? "Primary" : "Supporting", credential.getId(), rule.getType()));
+                        "Credential '%s' failed binding rule '%s'", credentialReq.getId(), rule.getType()));
             }
         }
+    }
+
+    private UserModel recoverAuthenticatingUser(Context ctx, JsonNode primaryClaims) {
+        logger.infof("Recovering authenticating user (authSession = %s)", ctx.id());
+        CredentialRequirement primaryCredentialReq = ctx.authenticationProfile().getPrimaryCredential();
+
+        if (primaryCredentialReq.isSessionIdentity()) {
+            // User is to be recovered from session, not primary claims
+            return recoverPresentationDuringIssuanceUser(ctx);
+        }
+
+        CredentialVerifier verifier = ctx.credentialVerifiers().get(primaryCredentialReq.getId());
+        String subject = verifier.readClaim(primaryClaims, JsonWebToken.SUBJECT);
+        String username = verifier.readClaim(primaryClaims, OAuth2Constants.USERNAME);
+        logger.debugf("Attempting user recovery with subject '%s' and username '%s'", subject, username);
+
+        KeycloakSession session = ctx.authenticationFlowContext().getSession();
+        RealmModel realm = ctx.authenticationFlowContext().getRealm();
+        UserProvider userProvider = session.users();
+
+        UserModel user = null;
+        if (StringUtil.isNotBlank(subject)) {
+            user = userProvider.getUserById(realm, subject);
+        }
+
+        if (user == null && StringUtil.isNotBlank(username)) {
+            // TODO: Remove username-only fallback once SubjectID mapper is fixed and stable.
+            logger.warn("Subject did not resolve to a user. Falling back to username lookup");
+            user = userProvider.getUserByUsername(realm, username);
+        }
+
+        if (user == null) {
+            logger.debugf("Authentication passed but authenticating user is unknown");
+            failDenyingAuthenticatingUser(ctx);
+            return null;
+        }
+
+        logger.debugf("Recovered authenticating user has id '%s'", user.getId());
+
+        // Running additional checks on the recovered user
+
+        if (StringUtil.isNotBlank(username) && !username.equals(user.getUsername())) {
+            logger.warnf(
+                    "Username mismatch for subject '%s': credential='%s', user='%s'",
+                    subject, username, user.getUsername());
+            failRejectingPresentedCredential(ctx, "Username mismatch");
+            return null;
+        }
+
+        if (!user.isEnabled()) {
+            logger.debugf("Rejecting authentication for disabled user '%s'", user.getUsername());
+            failDenyingDisabledUser(ctx);
+            return null;
+        }
+
+        return user;
+    }
+
+    private UserModel recoverPresentationDuringIssuanceUser(Context ctx) {
+        String subjectUserId = ctx.authorizationContext().getSubjectUserId();
+        if (StringUtil.isBlank(subjectUserId)) {
+            failRejectingPresentedCredential(ctx, "Missing session-bound subject user");
+            return null;
+        }
+
+        KeycloakSession session = ctx.authenticationFlowContext().getSession();
+        RealmModel realm = ctx.authenticationFlowContext().getRealm();
+        UserModel user = session.users().getUserById(realm, subjectUserId);
+
+        if (user == null) {
+            logger.warnf("Credential offer subject '%s' did not resolve to a user", subjectUserId);
+            failDenyingAuthenticatingUser(ctx);
+            return null;
+        }
+
+        logger.debugf("Resolved presentation-during-issuance subject user id: %s", user.getId());
+        return user;
+    }
+
+    private Map<String, String> getPresentedTokens(AuthenticationSessionModel authSession) {
+        String tokensJson = authSession.getAuthNote(PRESENTED_TOKENS_KEY);
+        if (StringUtil.isBlank(tokensJson)) {
+            return Map.of();
+        }
+
+        try {
+            return JsonSerialization.readValue(tokensJson, new TypeReference<>() {});
+        } catch (IOException e) {
+            throw new IllegalStateException("Invalid OID4VP presented credentials auth note", e);
+        }
+    }
+
+    private Map<String, CredentialVerifier> resolveVerifiers(AuthorizationContext authContext) {
+        DcqlQuery dcqlQuery = authContext.getRequestObject().getDcqlQuery();
+        if (dcqlQuery == null || dcqlQuery.getCredentials() == null) {
+            throw new IllegalStateException("No DCQL query found in authorization context");
+        }
+
+        Map<String, CredentialVerifier> verifiers = new LinkedHashMap<>();
+        for (Credential credential : dcqlQuery.getCredentials()) {
+            String credentialId = credential.getId();
+            String format = credential.getFormat();
+            CredentialVerifier verifier = handlers.get(format);
+            if (verifier == null) {
+                throw new IllegalStateException(String.format(
+                        "No registered verifier supports format '%s' for credential '%s'", format, credentialId));
+            }
+            // Clone the template verifier so per-verification state (e.g. verification context held
+            // between verifyCredential and validateTransactionData) is not shared or clobbered across
+            // concurrent authentication sessions.
+            verifiers.put(credentialId, verifier.copy());
+        }
+
+        return verifiers;
     }
 
     private BindingValueComparator resolveComparator(KeycloakSession session, BindingRule rule)
@@ -257,164 +350,45 @@ public class OID4VPAuthenticator implements Authenticator {
         };
     }
 
-    private AuthorizationContext getAuthorizationContext(AuthenticationSessionModel authSession) {
-        return new AuthenticationSessionStore(authSession).getAuthorizationContext();
-    }
-
-    private AuthenticationProfile getAuthenticationProfile(AuthenticationFlowContext context) {
-        OID4VPProfileConfig profileConfig = new OID4VPProfileConfig(context.getAuthenticatorConfig());
-        AuthorizationContext authContext = getAuthorizationContext(context.getAuthenticationSession());
-        return profileConfig.getProfile(authContext.getProfileId());
-    }
-
-    private Map<String, String> getPresentedTokens(AuthenticationSessionModel authSession) {
-        String tokensJson = authSession.getAuthNote(PRESENTED_TOKENS_KEY);
-        if (StringUtil.isBlank(tokensJson)) {
-            return Map.of();
-        }
-
-        try {
-            return JsonSerialization.readValue(tokensJson, new TypeReference<>() {});
-        } catch (IOException e) {
-            throw new IllegalStateException("Invalid OID4VP presented credentials auth note", e);
-        }
-    }
-
-    private static Map<String, String> supportingPresentedTokens(
-            Map<String, String> presentedTokens, String primaryCredentialId) {
-        return presentedTokens.entrySet().stream()
-                .filter(e -> !primaryCredentialId.equals(e.getKey()))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
-
-    private UserModel recoverAuthenticatingUser(
-            AuthenticationFlowContext context,
-            AuthorizationContext authContext,
-            CredentialRequirement primaryCredential,
-            CredentialVerifier verifier,
-            JsonNode primaryClaims) {
-        logger.info("Recovering authenticating user");
-
-        if (primaryCredential.isSessionIdentity()) {
-            String subjectUserId = authContext.getSubjectUserId();
-            if (StringUtil.isBlank(subjectUserId)) {
-                failRejectingPresentedCredential(context, "Missing session-bound subject user");
-                return null;
-            }
-            return recoverPresentationSubject(context, subjectUserId);
-        }
-
-        String subject = verifier.readClaim(primaryClaims, JsonWebToken.SUBJECT);
-        if (StringUtil.isBlank(subject)) {
-            logger.warn("Presented credential is missing subject claim");
-        } else {
-            logger.debugf("Presented subject: %s", subject);
-        }
-
-        String presentedUsername = verifier.readClaim(primaryClaims, OAuth2Constants.USERNAME);
-        if (StringUtil.isBlank(presentedUsername)) {
-            logger.warn("Presented credential is missing required username claim");
-            failRejectingPresentedCredential(context, "Missing username claim");
-            return null;
-        }
-
-        UserModel user = null;
-        if (!StringUtil.isBlank(subject)) {
-            user = context.getSession().users().getUserById(context.getRealm(), subject);
-            if (user != null) {
-                logger.debugf("Resolved user id: %s", user.getId());
-            }
-        }
-
-        if (user == null) {
-            // TODO: Remove username-only fallback once SubjectID mapper is fixed and stable.
-            logger.warn("Subject did not resolve to a user. Falling back to username lookup.");
-            user = context.getSession().users().getUserByUsername(context.getRealm(), presentedUsername);
-        }
-
-        if (user == null) {
-            logger.debugf("Authentication passed but authenticating user is unknown");
-            failDenyingAuthenticatingUser(context);
-            return null;
-        }
-
-        if (!presentedUsername.equals(user.getUsername())) {
-            logger.warnf(
-                    "Username mismatch for subject '%s': credential='%s', user='%s'",
-                    subject, presentedUsername, user.getUsername());
-            failRejectingPresentedCredential(context, "Username mismatch");
-            return null;
-        }
-
-        return user;
-    }
-
-    private UserModel recoverPresentationSubject(AuthenticationFlowContext context, String subjectUserId) {
-        UserModel user = context.getSession().users().getUserById(context.getRealm(), subjectUserId);
-        if (user == null) {
-            logger.warnf("Credential offer subject '%s' did not resolve to a user", subjectUserId);
-            failDenyingAuthenticatingUser(context);
-            return null;
-        }
-        logger.debugf("Resolved presentation-during-issuance subject user id: %s", user.getId());
-        return user;
-    }
-
-    private static String correlationId(AuthenticationFlowContext context) {
-        return ErrorResponseSanitizer.correlationIdFromAuthSession(context.getAuthenticationSession());
-    }
-
-    private void failRejectingPresentedCredential(AuthenticationFlowContext context, String reason) {
-        failRejectingPresentedCredential(context, reason, null);
-    }
-
-    private void failRejectingPresentedCredential(AuthenticationFlowContext context, String reason, Throwable cause) {
-        String correlationId = ErrorResponseSanitizer.correlationIdFromAuthSession(context.getAuthenticationSession());
-        if (cause != null) {
-            logger.errorf(cause, "Presented OID4VP credential rejected (authSession = %s): %s", correlationId, reason);
-        } else {
-            logger.errorf("Presented OID4VP credential rejected (authSession = %s): %s", correlationId, reason);
-        }
-
-        String description = String.format("Invalid OID4VP credential presentation (%s)", reason);
-        var errorRep = new OAuth2ErrorRepresentation(Errors.INVALID_USER_CREDENTIALS, description);
-
-        context.failure(
+    private void failRejectingPresentedCredential(Context ctx, String reason) {
+        failAuthentication(
+                ctx,
                 AuthenticationFlowError.INVALID_CREDENTIALS,
-                Response.status(Response.Status.UNAUTHORIZED.getStatusCode())
-                        .type(MediaType.APPLICATION_JSON_TYPE)
-                        .entity(errorRep)
-                        .build());
+                Errors.INVALID_USER_CREDENTIALS,
+                String.format("Invalid OID4VP credential presentation: %s", reason));
     }
 
-    private void failDenyingAuthenticatingUser(AuthenticationFlowContext context) {
-        logger.info("Presented OID4VP credential will be rejected for associated user is unknown");
-
-        String correlationId = ErrorResponseSanitizer.correlationIdFromAuthSession(context.getAuthenticationSession());
-        logger.errorf("User with presented OID4VP credential is unknown (authSession = %s)", correlationId);
-
-        String description = "User with presented OID4VP credential is unknown";
-
-        var errorRep = new OAuth2ErrorRepresentation(Errors.USER_NOT_FOUND, description);
-
-        context.failure(
+    private void failDenyingAuthenticatingUser(Context ctx) {
+        failAuthentication(
+                ctx,
                 AuthenticationFlowError.UNKNOWN_USER,
-                Response.status(Response.Status.UNAUTHORIZED.getStatusCode())
-                        .type(MediaType.APPLICATION_JSON_TYPE)
-                        .entity(errorRep)
-                        .build());
+                Errors.USER_NOT_FOUND,
+                "User with presented OID4VP credential is unknown");
     }
 
-    private void failDenyingDisabledUser(AuthenticationFlowContext context) {
-        var errorRep = new OAuth2ErrorRepresentation(
-                Errors.USER_DISABLED, "User with presented OID4VP credential is disabled");
-
-        context.failure(
+    private void failDenyingDisabledUser(Context ctx) {
+        failAuthentication(
+                ctx,
                 AuthenticationFlowError.USER_DISABLED,
-                Response.status(Response.Status.UNAUTHORIZED.getStatusCode())
-                        .type(MediaType.APPLICATION_JSON_TYPE)
-                        .entity(errorRep)
-                        .build());
+                Errors.USER_DISABLED,
+                "User with presented OID4VP credential is disabled");
+    }
+
+    private void failAuthentication(
+            Context ctx, AuthenticationFlowError flowError, String errorCode, String description) {
+        var errorRep = new OAuth2ErrorRepresentation(errorCode, description);
+        ctx.authenticationFlowContext()
+                .failure(
+                        flowError,
+                        Response.status(Response.Status.UNAUTHORIZED.getStatusCode())
+                                .type(MediaType.APPLICATION_JSON_TYPE)
+                                .entity(errorRep)
+                                .build());
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+        // No form action is relevant for this authenticator
     }
 
     @Override
@@ -432,4 +406,16 @@ public class OID4VPAuthenticator implements Authenticator {
 
     @Override
     public void close() {}
+
+    public record Context(
+            String id,
+            AuthenticationFlowContext authenticationFlowContext,
+            AuthenticationSessionModel authenticationSession,
+            AuthorizationContext authorizationContext,
+            AuthenticationProfile authenticationProfile,
+            AuthRequirements authRequirements,
+            Map<String, String> presentedTokens,
+            Map<String, CredentialVerifier> credentialVerifiers) {}
+
+    record AuthenticatingUser(UserModel userModel, JsonNode primaryClaims) {}
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocCredentialVerifier.java
@@ -17,7 +17,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationContex
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationOpts;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.CredentialFormat;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.CredentialVerifier;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.AuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.OID4VPAuthenticator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientMetadata;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
@@ -34,10 +34,10 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.jose.jwk.JSONWebKeySet;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.sdjwt.consumer.PresentationRequirements;
 import org.keycloak.util.JWKSUtils;
 import org.keycloak.util.JsonSerialization;
@@ -58,6 +58,15 @@ public class MdocCredentialVerifier implements CredentialVerifier {
         this.tokenStatusValidator = new ReferencedTokenValidator(statusListJwtFetcher);
     }
 
+    private MdocCredentialVerifier(ReferencedTokenValidator tokenStatusValidator) {
+        this.tokenStatusValidator = tokenStatusValidator;
+    }
+
+    @Override
+    public MdocCredentialVerifier copy() {
+        return new MdocCredentialVerifier(tokenStatusValidator);
+    }
+
     @Override
     public CredentialFormat format() {
         return CredentialFormat.MSO_MDOC;
@@ -65,17 +74,14 @@ public class MdocCredentialVerifier implements CredentialVerifier {
 
     @Override
     public JsonNode verifyCredential(
-            AuthenticationFlowContext context,
-            AuthorizationContext authorizationContext,
-            AuthRequirements authRequirements,
-            CredentialRequirement credential,
-            String token)
+            OID4VPAuthenticator.Context context, CredentialRequirement credentialReq, String token)
             throws VerificationException {
 
-        MdocAuthRequirements authReqs = new MdocAuthRequirements(authRequirements, credential);
+        KeycloakSession session = context.authenticationFlowContext().getSession();
+        TrustAnchorProvider truststore = TrustedProviderResolver.resolve(session, credentialReq);
+        MdocAuthRequirements authReqs = new MdocAuthRequirements(context.authRequirements(), credentialReq);
 
-        TrustAnchorProvider truststore = TrustedProviderResolver.resolve(context.getSession(), credential);
-
+        AuthorizationContext authorizationContext = context.authorizationContext();
         RequestObject requestObject = authorizationContext.getRequestObject();
 
         byte[] jwkThumbprint = computeJwkThumbprint(requestObject);
@@ -108,7 +114,7 @@ public class MdocCredentialVerifier implements CredentialVerifier {
                 throw new VerificationException(
                         String.format(
                                 "Token status verification failed for credential to requirement '%s'",
-                                credential.getId()),
+                                credentialReq.getId()),
                         e);
             }
         }
@@ -117,12 +123,12 @@ public class MdocCredentialVerifier implements CredentialVerifier {
     }
 
     @Override
-    public void validateTransactionData(AuthorizationContext authorizationContext, String token)
+    public void validateTransactionData(OID4VPAuthenticator.Context context, String token)
             throws VerificationException {
         if (verificationContext == null) {
             throw new IllegalStateException("verifyCredential() must be called before validateTransactionData()");
         }
-        validateTransactionData(authorizationContext, verificationContext);
+        validateTransactionData(context.authorizationContext(), verificationContext);
     }
 
     /**
@@ -229,7 +235,7 @@ public class MdocCredentialVerifier implements CredentialVerifier {
         }
         if (value instanceof CBORItemList list
                 && list.getItems().size() == 1
-                && list.getItems().get(0) instanceof CBORString s) {
+                && list.getItems().getFirst() instanceof CBORString s) {
             return s.getValue();
         }
         throw new VerificationException("transaction_data_hashes_alg must be a string");

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/sdjwt/SdJwtCredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/sdjwt/SdJwtCredentialVerifier.java
@@ -37,14 +37,14 @@ public class SdJwtCredentialVerifier implements CredentialVerifier {
         this.tokenStatusValidator = new ReferencedTokenValidator(statusListJwtFetcher);
     }
 
-    private SdJwtCredentialVerifier(SdJwtPresentationConsumer consumer, ReferencedTokenValidator tokenStatusValidator) {
-        this.consumer = consumer;
+    private SdJwtCredentialVerifier(ReferencedTokenValidator tokenStatusValidator) {
+        this.consumer = new SdJwtPresentationConsumer();
         this.tokenStatusValidator = tokenStatusValidator;
     }
 
     @Override
     public SdJwtCredentialVerifier copy() {
-        return new SdJwtCredentialVerifier(consumer, tokenStatusValidator);
+        return new SdJwtCredentialVerifier(tokenStatusValidator);
     }
 
     @Override
@@ -54,14 +54,14 @@ public class SdJwtCredentialVerifier implements CredentialVerifier {
 
     @Override
     public JsonNode verifyCredential(
-            OID4VPAuthenticator.Context context, CredentialRequirement credential, String token)
+            OID4VPAuthenticator.Context context, CredentialRequirement credentialReq, String token)
             throws VerificationException {
 
         KeycloakSession session = context.authenticationFlowContext().getSession();
         AuthorizationContext authorizationContext = context.authorizationContext();
         RequestObject requestObject = authorizationContext.getRequestObject();
         SdJwtAuthRequirements authReqs =
-                new SdJwtAuthRequirements(session.getContext(), context.authRequirements(), credential);
+                new SdJwtAuthRequirements(session.getContext(), context.authRequirements(), credentialReq);
 
         SdJwtVP sdJwt = parseSdJwt(token);
 
@@ -74,7 +74,7 @@ public class SdJwtCredentialVerifier implements CredentialVerifier {
         consumer.verifySdJwtPresentation(
                 sdJwt,
                 requirements,
-                SdJwtTrustedIssuerResolver.resolve(session, credential),
+                SdJwtTrustedIssuerResolver.resolve(session, credentialReq),
                 authReqs.getIssuerSignedJwtVerificationOpts(),
                 authReqs.getKeyBindingJwtVerificationOpts(
                         requestObject.getNonce(),
@@ -88,7 +88,7 @@ public class SdJwtCredentialVerifier implements CredentialVerifier {
                 throw new VerificationException(
                         String.format(
                                 "Token status verification failed for credential to requirement '%s'",
-                                credential.getId()),
+                                credentialReq.getId()),
                         e);
             }
         }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/sdjwt/SdJwtCredentialVerifier.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/sdjwt/SdJwtCredentialVerifier.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.CredentialFormat;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.CredentialVerifier;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.AuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.OID4VPAuthenticator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
@@ -15,9 +15,8 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusList
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-import org.jboss.logging.Logger;
-import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.common.VerificationException;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.sdjwt.consumer.PresentationRequirements;
 import org.keycloak.sdjwt.consumer.SdJwtPresentationConsumer;
 import org.keycloak.sdjwt.vp.KeyBindingJWT;
@@ -30,14 +29,22 @@ import org.keycloak.utils.StringUtil;
  */
 public class SdJwtCredentialVerifier implements CredentialVerifier {
 
-    private static final Logger logger = Logger.getLogger(SdJwtCredentialVerifier.class);
-
     private final SdJwtPresentationConsumer consumer;
     private final ReferencedTokenValidator tokenStatusValidator;
 
     public SdJwtCredentialVerifier(StatusListJwtFetcher statusListJwtFetcher) {
         this.consumer = new SdJwtPresentationConsumer();
         this.tokenStatusValidator = new ReferencedTokenValidator(statusListJwtFetcher);
+    }
+
+    private SdJwtCredentialVerifier(SdJwtPresentationConsumer consumer, ReferencedTokenValidator tokenStatusValidator) {
+        this.consumer = consumer;
+        this.tokenStatusValidator = tokenStatusValidator;
+    }
+
+    @Override
+    public SdJwtCredentialVerifier copy() {
+        return new SdJwtCredentialVerifier(consumer, tokenStatusValidator);
     }
 
     @Override
@@ -47,21 +54,16 @@ public class SdJwtCredentialVerifier implements CredentialVerifier {
 
     @Override
     public JsonNode verifyCredential(
-            AuthenticationFlowContext context,
-            AuthorizationContext authorizationContext,
-            AuthRequirements authRequirements,
-            CredentialRequirement credential,
-            String token)
+            OID4VPAuthenticator.Context context, CredentialRequirement credential, String token)
             throws VerificationException {
 
+        KeycloakSession session = context.authenticationFlowContext().getSession();
+        AuthorizationContext authorizationContext = context.authorizationContext();
         RequestObject requestObject = authorizationContext.getRequestObject();
-        String nonce = requestObject.getNonce();
-        String audience = requestObject.getClientId();
+        SdJwtAuthRequirements authReqs =
+                new SdJwtAuthRequirements(session.getContext(), context.authRequirements(), credential);
 
         SdJwtVP sdJwt = parseSdJwt(token);
-
-        SdJwtAuthRequirements authReqs =
-                new SdJwtAuthRequirements(context.getSession().getContext(), authRequirements, credential);
 
         AtomicReference<JsonNode> payloadRef = new AtomicReference<>();
         PresentationRequirements requirements = payload -> {
@@ -72,10 +74,12 @@ public class SdJwtCredentialVerifier implements CredentialVerifier {
         consumer.verifySdJwtPresentation(
                 sdJwt,
                 requirements,
-                SdJwtTrustedIssuerResolver.resolve(context.getSession(), credential),
+                SdJwtTrustedIssuerResolver.resolve(session, credential),
                 authReqs.getIssuerSignedJwtVerificationOpts(),
                 authReqs.getKeyBindingJwtVerificationOpts(
-                        nonce, audience, authReqs.shouldRequireCryptographicHolderBinding()));
+                        requestObject.getNonce(),
+                        requestObject.getClientId(),
+                        authReqs.shouldRequireCryptographicHolderBinding()));
 
         if (authReqs.shouldEnforceRevocationStatus()) {
             try {
@@ -93,14 +97,9 @@ public class SdJwtCredentialVerifier implements CredentialVerifier {
     }
 
     @Override
-    public String readClaim(JsonNode claims, String claimName) {
-        return Optional.ofNullable(claims.get(claimName)).map(JsonNode::asText).orElse(null);
-    }
-
-    @Override
-    public void validateTransactionData(AuthorizationContext authorizationContext, String presentedToken) {
+    public void validateTransactionData(OID4VPAuthenticator.Context context, String presentedToken) {
         List<String> transactionDataWire =
-                authorizationContext.getRequestObject().getTransactionData();
+                context.authorizationContext().getRequestObject().getTransactionData();
         if (transactionDataWire == null || transactionDataWire.isEmpty()) {
             return;
         }
@@ -113,6 +112,11 @@ public class SdJwtCredentialVerifier implements CredentialVerifier {
 
         ObjectNode kbPayload = keyBindingJwt.get().getPayload();
         TransactionDataValidator.validate(transactionDataWire, kbPayload);
+    }
+
+    @Override
+    public String readClaim(JsonNode claims, String claimName) {
+        return Optional.ofNullable(claims.get(claimName)).map(JsonNode::asText).orElse(null);
     }
 
     private static SdJwtVP parseSdJwt(String presentedToken) {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/AuthenticationProfile.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/AuthenticationProfile.java
@@ -102,7 +102,7 @@ public class AuthenticationProfile {
         return credentials.stream()
                 .filter(credential -> credential.getId().equals(credentialId))
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException(
+                .orElseThrow(() -> new IllegalArgumentException(
                         "Profile does not define credential '%s': %s".formatted(credentialId, id)));
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/utils/ErrorResponseSanitizer.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/utils/ErrorResponseSanitizer.java
@@ -3,6 +3,7 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPUserAuthEndpointBase;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.OID4VPConfig;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
@@ -35,18 +36,9 @@ public final class ErrorResponseSanitizer {
     }
 
     public static String correlationIdFromAuthSession(AuthenticationSessionModel authSession) {
-        if (authSession == null) {
-            return newCorrelationId();
-        }
-        return OID4VPUserAuthEndpointBase.getAuthSessionId(authSession);
-    }
-
-    public static String correlationIdFromState(String state) {
-        try {
-            return OID4VPUserAuthEndpointBase.pruneAuthSessionId(state);
-        } catch (IllegalArgumentException e) {
-            return newCorrelationId();
-        }
+        return Optional.ofNullable(authSession)
+                .map(OID4VPUserAuthEndpointBase::getAuthSessionId)
+                .orElseGet(ErrorResponseSanitizer::newCorrelationId);
     }
 
     public static String clientDescription(String generic, String detailed, String correlationId) {

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -695,7 +695,7 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
                 TestOpts.getDefault(),
                 HttpStatus.SC_UNAUTHORIZED,
                 ProcessingError.VP_TOKEN_AUTH_ERROR.getErrorString(),
-                "Invalid OID4VP credential presentation (Token status verification failed for credential to requirement 'identity')");
+                "Invalid OID4VP credential presentation: Primary credential verification failed: Token status verification failed for credential to requirement 'identity'");
     }
 
     @Test
@@ -820,7 +820,7 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
                     opts,
                     HttpStatus.SC_UNAUTHORIZED,
                     ProcessingError.VP_TOKEN_AUTH_ERROR.getErrorString(),
-                    "Supporting credential 'supporting' failed binding rule 'claim_equals_primary_claim'");
+                    "Invalid OID4VP credential presentation: Supporting credential verification failed: Credential 'supporting' failed binding rule 'claim_equals_primary_claim'");
         });
     }
 

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/ContextBuilder.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/ContextBuilder.java
@@ -1,0 +1,76 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.AuthRequirements;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.AuthenticationProfile;
+import java.util.HashMap;
+import java.util.Map;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+/**
+ * Test-only builder for {@link OID4VPAuthenticator.Context}.
+ */
+public class ContextBuilder {
+
+    private String id;
+    private AuthenticationFlowContext authenticationFlowContext;
+    private AuthenticationSessionModel authenticationSession;
+    private AuthorizationContext authorizationContext;
+    private AuthenticationProfile authenticationProfile;
+    private AuthRequirements authRequirements;
+    private final Map<String, String> presentedTokens = new HashMap<>();
+    private final Map<String, CredentialVerifier> credentialVerifiers = new HashMap<>();
+
+    public ContextBuilder id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public ContextBuilder authenticationFlowContext(AuthenticationFlowContext authenticationFlowContext) {
+        this.authenticationFlowContext = authenticationFlowContext;
+        return this;
+    }
+
+    public ContextBuilder authenticationSession(AuthenticationSessionModel authenticationSession) {
+        this.authenticationSession = authenticationSession;
+        return this;
+    }
+
+    public ContextBuilder authorizationContext(AuthorizationContext authorizationContext) {
+        this.authorizationContext = authorizationContext;
+        return this;
+    }
+
+    public ContextBuilder authenticationProfile(AuthenticationProfile authenticationProfile) {
+        this.authenticationProfile = authenticationProfile;
+        return this;
+    }
+
+    public ContextBuilder authRequirements(AuthRequirements authRequirements) {
+        this.authRequirements = authRequirements;
+        return this;
+    }
+
+    public ContextBuilder presentedToken(String credentialId, String token) {
+        this.presentedTokens.put(credentialId, token);
+        return this;
+    }
+
+    public ContextBuilder credentialVerifier(String credentialId, CredentialVerifier verifier) {
+        this.credentialVerifiers.put(credentialId, verifier);
+        return this;
+    }
+
+    public OID4VPAuthenticator.Context build() {
+        return new OID4VPAuthenticator.Context(
+                id,
+                authenticationFlowContext,
+                authenticationSession,
+                authorizationContext,
+                authenticationProfile,
+                authRequirements,
+                presentedTokens,
+                credentialVerifiers);
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/CredentialVerifierIsolationTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/CredentialVerifierIsolationTest.java
@@ -1,0 +1,109 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationContext;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.mdoc.MdocCredentialVerifier;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.sdjwt.SdJwtCredentialVerifier;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusListJwtFetcher;
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the per-session verifier isolation introduced through {@link CredentialVerifier#copy()}.
+ *
+ * <p>{@code OID4VPAuthenticator#resolveVerifiers} clones the registered template verifier for each
+ * credential so that mutable per-verification state is never shared across concurrent sessions.
+ */
+class CredentialVerifierIsolationTest {
+
+    private static SdJwtCredentialVerifier sdJwtTemplate;
+    private static MdocCredentialVerifier mdocTemplate;
+    private static OID4VPAuthenticator authenticator;
+    private static AuthorizationContext authContext;
+
+    @BeforeAll
+    static void setUp() {
+        StatusListJwtFetcher statusListJwtFetcher = mock(StatusListJwtFetcher.class);
+        sdJwtTemplate = new SdJwtCredentialVerifier(statusListJwtFetcher);
+        mdocTemplate = new MdocCredentialVerifier(statusListJwtFetcher);
+        Map<String, CredentialVerifier> handlers = Map.of(
+                CredentialFormat.SD_JWT_VC.getValue(), sdJwtTemplate,
+                CredentialFormat.MSO_MDOC.getValue(), mdocTemplate);
+        authenticator = new OID4VPAuthenticator(handlers);
+
+        var credentialReqs = (List.of(
+                credential("sdjwt-a", CredentialFormat.SD_JWT_VC.getValue()),
+                credential("sdjwt-b", CredentialFormat.SD_JWT_VC.getValue()),
+                credential("mdoc-a", CredentialFormat.MSO_MDOC.getValue()),
+                credential("mdoc-b", CredentialFormat.MSO_MDOC.getValue())));
+
+        DcqlQuery query = new DcqlQuery();
+        query.setCredentials(credentialReqs);
+
+        RequestObject requestObject = mock(RequestObject.class);
+        when(requestObject.getDcqlQuery()).thenReturn(query);
+
+        authContext = mock(AuthorizationContext.class);
+        when(authContext.getRequestObject()).thenReturn(requestObject);
+    }
+
+    private static Credential credential(String id, String format) {
+        Credential credential = new Credential();
+        credential.setId(id);
+        credential.setFormat(format);
+        return credential;
+    }
+
+    @Test
+    void resolveVerifiers_isolatesInstancePerCredential() {
+        Map<String, CredentialVerifier> verifiers = authenticator.resolveVerifiers(authContext);
+
+        Set<CredentialVerifier> resolved = new HashSet<>(List.of(
+                sdJwtTemplate,
+                mdocTemplate,
+                verifiers.get("sdjwt-a"),
+                verifiers.get("sdjwt-b"),
+                verifiers.get("mdoc-a"),
+                verifiers.get("mdoc-b")));
+
+        assertEquals(6, resolved.size(), "Each resolved verifier must be distinct from the templates and one another");
+    }
+
+    @Test
+    void copy_DropsCachedVerificationContext() throws Exception {
+        MdocCredentialVerifier verifier1 = mdocTemplate.copy();
+
+        MdocVerificationContext cached = mock(MdocVerificationContext.class);
+        field("verificationContext").set(verifier1, cached);
+
+        MdocCredentialVerifier verifier2 = verifier1.copy();
+
+        assertSame(cached, field("verificationContext").get(verifier1), "verifier1 keeps its cached state");
+        assertNull(field("verificationContext").get(verifier2), "a copy must not carry over the cached state");
+
+        assertSame(
+                field("tokenStatusValidator").get(mdocTemplate),
+                field("tokenStatusValidator").get(verifier2),
+                "the configuration-only token status validator is preserved across copies");
+    }
+
+    private static Field field(String name) throws Exception {
+        Field field = MdocCredentialVerifier.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field;
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtPrimaryBindingTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtPrimaryBindingTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.binding.BindingValueComparator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.binding.ExactBindingValueComparator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.binding.ExactBindingValueComparatorFactory;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.AuthenticationProfile;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.BindingRule;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRole;
@@ -53,7 +54,7 @@ class SdJwtPrimaryBindingTest {
         when(user.getUsername()).thenReturn("someone-else");
         VerificationException error =
                 assertThrows(VerificationException.class, () -> apply(primaryWithUserAttributeBinding()));
-        assertEquals("Primary credential 'pid' failed binding rule 'claim_equals_user_attribute'", error.getMessage());
+        assertEquals("Credential 'pid' failed binding rule 'claim_equals_user_attribute'", error.getMessage());
     }
 
     @Test
@@ -81,7 +82,19 @@ class SdJwtPrimaryBindingTest {
     }
 
     private void apply(CredentialRequirement primary) throws VerificationException {
-        authenticator.applyBindingRules(context, primary, verifier, claims, null, null, user);
+        AuthenticationProfile profile =
+                new AuthenticationProfile().setId("default").setCredentials(List.of(primary));
+
+        OID4VPAuthenticator.Context ctx = new ContextBuilder()
+                .id("id")
+                .authenticationFlowContext(context)
+                .authenticationProfile(profile)
+                .credentialVerifier(primary.getId(), verifier)
+                .build();
+
+        OID4VPAuthenticator.AuthenticatingUser authenticatingUser =
+                new OID4VPAuthenticator.AuthenticatingUser(user, claims);
+        authenticator.applyBindingRules(ctx, authenticatingUser, primary, claims);
     }
 
     private static CredentialRequirement primaryWithUserAttributeBinding() {

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/mdoc/MdocRevocationStatusTest.java
@@ -23,6 +23,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocBaseTest;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocVerificationOpts;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.TestTruststoreProvider;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.ContextBuilder;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.AuthRequirements;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
@@ -134,12 +135,17 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
                 .build();
 
         String validMdoc = buildMdocWithStatus(1, optsFromRequest);
-        assertDoesNotThrow(() -> verifier.verifyCredential(context, authCtx, authReqs, credential, validMdoc));
+        var ctx = new ContextBuilder()
+                .authenticationFlowContext(context)
+                .authorizationContext(authCtx)
+                .authRequirements(authReqs)
+                .build();
+
+        assertDoesNotThrow(() -> verifier.verifyCredential(ctx, credential, validMdoc));
 
         String revokedMdoc = buildMdocWithStatus(0, optsFromRequest);
         VerificationException exception = assertThrows(
-                VerificationException.class,
-                () -> verifier.verifyCredential(context, authCtx, authReqs, credential, revokedMdoc));
+                VerificationException.class, () -> verifier.verifyCredential(ctx, credential, revokedMdoc));
         assertTrue(exception.getMessage().contains("Token status verification failed"));
     }
 
@@ -208,7 +214,13 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
         DeviceResponse withStatus = withModifiedMso(dr, mso -> getCborPairList(1, mso));
         String validMdoc = withStatus.encodeToBase64Url();
 
-        assertDoesNotThrow(() -> verifier.verifyCredential(context, authCtx, authReqs, credential, validMdoc));
+        var ctx = new ContextBuilder()
+                .authenticationFlowContext(context)
+                .authorizationContext(authCtx)
+                .authRequirements(authReqs)
+                .build();
+
+        assertDoesNotThrow(() -> verifier.verifyCredential(ctx, credential, validMdoc));
 
         // Build mDoc with revoked status (idx 0) + matching transaction_data_hashes
         DeviceResponse revokedDr =
@@ -217,8 +229,7 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
         String revokedMdoc = withRevokedStatus.encodeToBase64Url();
 
         VerificationException exception = assertThrows(
-                VerificationException.class,
-                () -> verifier.verifyCredential(context, authCtx, authReqs, credential, revokedMdoc));
+                VerificationException.class, () -> verifier.verifyCredential(ctx, credential, revokedMdoc));
         assertTrue(exception.getMessage().contains("Token status verification failed"));
 
         // Build mDoc with matching hashes but unauthorized namespace (DOC_TYPE not in KeyAuthorizations)
@@ -233,9 +244,9 @@ public class MdocRevocationStatusTest extends MdocBaseTest {
         DeviceResponse unauthorizedWithStatus = withModifiedMso(unauthorizedDr, mso -> getCborPairList(1, mso));
         String unauthorizedMdoc = unauthorizedWithStatus.encodeToBase64Url();
 
-        assertDoesNotThrow(() -> verifier.verifyCredential(context, authCtx, authReqs, credential, unauthorizedMdoc));
+        assertDoesNotThrow(() -> verifier.verifyCredential(ctx, credential, unauthorizedMdoc));
         VerificationException unauthorizedException = assertThrows(
-                VerificationException.class, () -> verifier.validateTransactionData(authCtx, unauthorizedMdoc));
+                VerificationException.class, () -> verifier.validateTransactionData(ctx, unauthorizedMdoc));
         assertTrue(unauthorizedException.getMessage().contains("not authorized"));
     }
 

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/sdjwt/SdJwtCredentialVerifierTransactionDataTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/sdjwt/SdJwtCredentialVerifierTransactionDataTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.ContextBuilder;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.OID4VPAuthenticator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestObject;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.ECTestUtils;
@@ -16,6 +18,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http.StatusList
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.util.Time;
 import org.keycloak.crypto.AsymmetricSignatureSignerContext;
@@ -45,10 +48,10 @@ class SdJwtCredentialVerifierTransactionDataTest {
         String hash = hashForWire(wire);
         String presentedSdJwt = presentationWithHashes(List.of(hash));
 
-        AuthorizationContext authContext = authContextWithWire(List.of(wire));
+        var ctx = ctxWithWire(List.of(wire));
         SdJwtCredentialVerifier handler = new SdJwtCredentialVerifier(mock(StatusListJwtFetcher.class));
 
-        assertDoesNotThrow(() -> handler.validateTransactionData(authContext, presentedSdJwt));
+        assertDoesNotThrow(() -> handler.validateTransactionData(ctx, presentedSdJwt));
     }
 
     @Test
@@ -56,21 +59,26 @@ class SdJwtCredentialVerifierTransactionDataTest {
         String wire = wireEntry("payment");
         String presentedSdJwt = presentationWithHashes(List.of("invalid-hash"));
 
-        AuthorizationContext authContext = authContextWithWire(List.of(wire));
+        var ctx = ctxWithWire(List.of(wire));
         SdJwtCredentialVerifier handler = new SdJwtCredentialVerifier(mock(StatusListJwtFetcher.class));
 
-        assertThrows(
-                IllegalArgumentException.class, () -> handler.validateTransactionData(authContext, presentedSdJwt));
+        assertThrows(IllegalArgumentException.class, () -> handler.validateTransactionData(ctx, presentedSdJwt));
     }
 
     @Test
     void skipsValidationWhenNoTransactionDataInRequest() throws Exception {
         String presentedSdJwt = presentationWithHashes(List.of("any"));
-        AuthorizationContext authContext = authContextWithWire(null);
+        var ctx = ctxWithWire(null);
 
         SdJwtCredentialVerifier handler = new SdJwtCredentialVerifier(mock(StatusListJwtFetcher.class));
+        assertDoesNotThrow(() -> handler.validateTransactionData(ctx, presentedSdJwt));
+    }
 
-        assertDoesNotThrow(() -> handler.validateTransactionData(authContext, presentedSdJwt));
+    private static OID4VPAuthenticator.Context ctxWithWire(List<String> wireEntries) {
+        return new ContextBuilder()
+                .authenticationFlowContext(mock(AuthenticationFlowContext.class))
+                .authorizationContext(authContextWithWire(wireEntries))
+                .build();
     }
 
     private static AuthorizationContext authContextWithWire(List<String> wireEntries) {


### PR DESCRIPTION
Closes #121 

Highlights:
- Authenticator readability refactor: split the monolithic authenticate() into focused steps (verifyPrimaryCredential, verifySupportingCredentials, recoverAuthenticatingUser, applyBindingRules), centralize per-run state in an immutable Context record via gatherContext.
- Verifier interface simplification: verifyCredential/validateTransactionData take a single Context instead of many parameters.
- Per-session verifier isolation (fix): added CredentialVerifier.copy(); resolveVerifiers stores verifier.copy() per credential so mutable per-verification state (mDoc MdocVerificationContext) isn't shared across concurrent sessions.