### PR TITLE
Add credential requirement groups for alternative OpenID4VP credentials

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
@@ -66,12 +66,19 @@ public class OID4VPAuthenticator implements Authenticator {
         logger.info("Authenticating with OID4VPAuthenticator");
 
         AuthenticationProfile profile = getAuthenticationProfile(context);
-        CredentialRequirement primaryCredential = profile.getPrimaryCredential();
 
         AuthorizationContext authContext = getAuthorizationContext(authSession);
         AuthRequirements authRequirements = new AuthRequirements(context.getAuthenticatorConfig());
 
         Map<String, String> presentedTokens = getPresentedTokens(authSession);
+        CredentialRequirement primaryCredential;
+        try {
+            primaryCredential = profile.getPresentedPrimaryCredential(presentedTokens.keySet());
+        } catch (IllegalStateException e) {
+            failRejectingPresentedCredential(context, e.getMessage(), e);
+            return;
+        }
+
         String primaryToken = presentedTokens.get(primaryCredential.getId());
         if (StringUtil.isBlank(primaryToken)) {
             failRejectingPresentedCredential(
@@ -186,8 +193,7 @@ public class OID4VPAuthenticator implements Authenticator {
 
             String token = supportingTokens.get(credential.getId());
             if (StringUtil.isBlank(token)) {
-                throw new VerificationException(String.format(
-                        "Supporting credential '%s' is missing from the presentation", credential.getId()));
+                continue;
             }
 
             CredentialVerifier supportingVerifier = resolveVerifier(authSession, credential.getId());

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
@@ -14,6 +14,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRe
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.OID4VPProfileConfig;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.AuthenticationSessionStore;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.ErrorResponseSanitizer;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.TransactionDataSupport;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
@@ -133,8 +134,10 @@ public class OID4VPAuthenticator implements Authenticator {
         JsonNode primaryClaims;
         try {
             primaryClaims = primaryVerifier.verifyCredential(ctx, primaryCredentialReq, primaryToken);
+            TransactionDataSupport.requireCredentialIdInAllEntries(
+                    ctx.authorizationContext().getRequestObject().getTransactionData(), primaryCredentialReq.getId());
             primaryVerifier.validateTransactionData(ctx, primaryToken);
-        } catch (VerificationException | IllegalStateException e) {
+        } catch (VerificationException | IllegalArgumentException | IllegalStateException e) {
             String msg = "Primary credential verification failed";
             failRejectingPresentedCredential(ctx, String.format("%s: %s", msg, e.getMessage()));
             throw new VerificationException(msg, e);
@@ -189,8 +192,6 @@ public class OID4VPAuthenticator implements Authenticator {
             Context ctx, AuthenticatingUser authUser, CredentialRequirement credentialReq, JsonNode claims)
             throws VerificationException {
         KeycloakSession session = ctx.authenticationFlowContext().getSession();
-        CredentialRequirement primaryCredentialReq = getPresentedPrimaryCredential(ctx);
-        CredentialVerifier primaryVerifier = ctx.credentialVerifiers().get(primaryCredentialReq.getId());
 
         for (BindingRule rule : credentialReq.getBinding()) {
             CredentialVerifier verifier = ctx.credentialVerifiers().get(credentialReq.getId());
@@ -204,6 +205,9 @@ public class OID4VPAuthenticator implements Authenticator {
                                         "Binding rule '%s' is not applicable to the primary credential '%s'",
                                         rule.getType(), credentialReq.getId()));
                             }
+                            CredentialRequirement primaryCredentialReq = getPresentedPrimaryCredential(ctx);
+                            CredentialVerifier primaryVerifier =
+                                    ctx.credentialVerifiers().get(primaryCredentialReq.getId());
                             yield primaryVerifier.readClaim(authUser.primaryClaims(), rule.getPrimaryCredentialClaim());
                         }
                         case BindingRule.CLAIM_EQUALS_USER_ATTRIBUTE ->

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryGenerator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryGenerator.java
@@ -9,6 +9,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.AuthenticationProfile;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement.ClaimReference;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirementGroup;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -17,8 +18,9 @@ import org.keycloak.utils.StringUtil;
 /**
  * Builds a DCQL query from an {@link AuthenticationProfile}.
  *
- * <p>Each {@link CredentialRequirement} becomes one DCQL credential query. All credentials
- * are required and grouped into a single {@link CredentialSet}.
+ * <p>Each {@link CredentialRequirement} becomes one DCQL credential query. The profile's
+ * credential groups become DCQL credential sets. Profiles without explicit groups keep the
+ * legacy behavior where all configured credentials are required together.
  */
 public final class DcqlQueryGenerator {
 
@@ -33,16 +35,19 @@ public final class DcqlQueryGenerator {
             credentials.add(buildCredential(requirement, requireCryptographicHolderBinding));
         }
 
-        // All credentials are required → one CredentialSet with a single option listing all ids.
-        List<String> allIds = credentials.stream().map(Credential::getId).toList();
-        CredentialSet credentialSet = new CredentialSet();
-        credentialSet.setRequired(true);
-        credentialSet.setOptions(List.of(allIds));
-
         DcqlQuery query = new DcqlQuery();
         query.setCredentials(credentials);
-        query.setCredentialSets(List.of(credentialSet));
+        query.setCredentialSets(profile.getEffectiveCredentialGroups().stream()
+                .map(DcqlQueryGenerator::buildCredentialSet)
+                .toList());
         return query;
+    }
+
+    private static CredentialSet buildCredentialSet(CredentialRequirementGroup group) {
+        CredentialSet credentialSet = new CredentialSet();
+        credentialSet.setRequired(group.isRequired());
+        credentialSet.setOptions(group.getOptions());
+        return credentialSet;
     }
 
     /** Wraps a single credential into a DcqlQuery with its own credential_set, for validators. */

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlResponseCredentialSelector.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlResponseCredentialSelector.java
@@ -1,0 +1,113 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.CredentialSet;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Validates that the credential IDs returned in a vp_token satisfy the signed DCQL query.
+ */
+public final class DcqlResponseCredentialSelector {
+
+    private DcqlResponseCredentialSelector() {}
+
+    public static Set<String> selectPresentedCredentialIds(DcqlQuery dcqlQuery, Set<String> presentedCredentialIds) {
+        Set<String> credentialQueryIds = credentialQueryIds(dcqlQuery);
+        Set<String> unknownCredentialIds = new HashSet<>(presentedCredentialIds);
+        unknownCredentialIds.removeAll(credentialQueryIds);
+        if (!unknownCredentialIds.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Presented vp_token map contains unknown credential(s): " + unknownCredentialIds);
+        }
+
+        List<CredentialSet> credentialSets = effectiveCredentialSets(dcqlQuery);
+        if (!matchesCredentialSets(
+                credentialSets, credentialQueryIds, presentedCredentialIds, 0, new LinkedHashSet<>())) {
+            throw new IllegalArgumentException("Presented vp_token map does not satisfy DCQL credential_sets");
+        }
+
+        return Set.copyOf(presentedCredentialIds);
+    }
+
+    private static Set<String> credentialQueryIds(DcqlQuery dcqlQuery) {
+        if (dcqlQuery == null
+                || dcqlQuery.getCredentials() == null
+                || dcqlQuery.getCredentials().isEmpty()) {
+            throw new IllegalArgumentException("DCQL query must contain at least one credential query");
+        }
+        return dcqlQuery.getCredentials().stream().map(Credential::getId).collect(java.util.stream.Collectors.toSet());
+    }
+
+    private static List<CredentialSet> effectiveCredentialSets(DcqlQuery dcqlQuery) {
+        if (dcqlQuery.getCredentialSets() != null
+                && !dcqlQuery.getCredentialSets().isEmpty()) {
+            return dcqlQuery.getCredentialSets();
+        }
+
+        CredentialSet allCredentials = new CredentialSet();
+        allCredentials.setRequired(Boolean.TRUE);
+        allCredentials.setOptions(List.of(
+                dcqlQuery.getCredentials().stream().map(Credential::getId).toList()));
+        return List.of(allCredentials);
+    }
+
+    private static boolean matchesCredentialSets(
+            List<CredentialSet> credentialSets,
+            Set<String> credentialQueryIds,
+            Set<String> presentedCredentialIds,
+            int index,
+            Set<String> coveredCredentialIds) {
+        if (index == credentialSets.size()) {
+            return coveredCredentialIds.equals(presentedCredentialIds);
+        }
+
+        CredentialSet credentialSet = credentialSets.get(index);
+        if (!isRequired(credentialSet)
+                && matchesCredentialSets(
+                        credentialSets, credentialQueryIds, presentedCredentialIds, index + 1, coveredCredentialIds)) {
+            return true;
+        }
+
+        List<List<String>> options = credentialSet.getOptions();
+        if (options == null || options.isEmpty()) {
+            throw new IllegalArgumentException("DCQL credential_set options must be non-empty");
+        }
+
+        for (List<String> option : options) {
+            Set<String> optionIds = optionIds(credentialSet, option, credentialQueryIds);
+            if (!presentedCredentialIds.containsAll(optionIds)) {
+                continue;
+            }
+
+            Set<String> nextCoveredCredentialIds = new LinkedHashSet<>(coveredCredentialIds);
+            nextCoveredCredentialIds.addAll(optionIds);
+            if (matchesCredentialSets(
+                    credentialSets, credentialQueryIds, presentedCredentialIds, index + 1, nextCoveredCredentialIds)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean isRequired(CredentialSet credentialSet) {
+        return !Boolean.FALSE.equals(credentialSet.getRequired());
+    }
+
+    private static Set<String> optionIds(
+            CredentialSet credentialSet, List<String> option, Set<String> credentialQueryIds) {
+        if (option == null || option.isEmpty()) {
+            throw new IllegalArgumentException("DCQL credential_set options must be non-empty");
+        }
+
+        Set<String> optionIds = new LinkedHashSet<>(option);
+        if (!credentialQueryIds.containsAll(optionIds)) {
+            throw new IllegalArgumentException("DCQL credential_set references unknown credential query id");
+        }
+        return optionIds;
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/AuthenticationProfile.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/AuthenticationProfile.java
@@ -1,6 +1,7 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -10,11 +11,6 @@ public class AuthenticationProfile {
 
     public static final String DEFAULT_PROFILE_ID = "default";
     public static final String DEFAULT_CTA = "Sign in with a wallet";
-
-    // TODO: support groups of credential requirements so the wallet only has to satisfy one
-    //  member per group (e.g. accept a passport OR a national-ID as primary). Today every
-    //  requirement is its own required CredentialSet in the DCQL query, so the wallet must
-    //  present all of them.
 
     @JsonProperty("id")
     private String id;
@@ -30,6 +26,9 @@ public class AuthenticationProfile {
 
     @JsonProperty("credentials")
     private List<CredentialRequirement> credentials;
+
+    @JsonProperty("credentialGroups")
+    private List<CredentialRequirementGroup> credentialGroups;
 
     public String getId() {
         return id;
@@ -76,6 +75,27 @@ public class AuthenticationProfile {
         return this;
     }
 
+    public List<CredentialRequirementGroup> getCredentialGroups() {
+        return credentialGroups;
+    }
+
+    public AuthenticationProfile setCredentialGroups(List<CredentialRequirementGroup> credentialGroups) {
+        this.credentialGroups = credentialGroups;
+        return this;
+    }
+
+    public List<CredentialRequirementGroup> getEffectiveCredentialGroups() {
+        if (credentialGroups != null && !credentialGroups.isEmpty()) {
+            return credentialGroups;
+        }
+
+        return List.of(new CredentialRequirementGroup()
+                .setId("all")
+                .setRequired(Boolean.TRUE)
+                .setOptions(List.of(
+                        credentials.stream().map(CredentialRequirement::getId).toList())));
+    }
+
     public String getDisplayCta(Locale locale) {
         if (displayCta == null || displayCta.isEmpty()) {
             return DEFAULT_CTA;
@@ -92,10 +112,25 @@ public class AuthenticationProfile {
     }
 
     public CredentialRequirement getPrimaryCredential() {
-        return credentials.stream()
-                .filter(CredentialRequirement::isPrimary)
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("Profile has no primary credential: " + id));
+        List<CredentialRequirement> primaryCredentials = getPrimaryCredentials();
+        if (primaryCredentials.size() != 1) {
+            throw new IllegalStateException("Profile must resolve exactly one primary credential: " + id);
+        }
+        return primaryCredentials.getFirst();
+    }
+
+    public List<CredentialRequirement> getPrimaryCredentials() {
+        return credentials.stream().filter(CredentialRequirement::isPrimary).toList();
+    }
+
+    public CredentialRequirement getPresentedPrimaryCredential(Collection<String> presentedCredentialIds) {
+        List<CredentialRequirement> primaryCredentials = getPrimaryCredentials().stream()
+                .filter(credential -> presentedCredentialIds.contains(credential.getId()))
+                .toList();
+        if (primaryCredentials.size() != 1) {
+            throw new IllegalStateException("Presentation must contain exactly one primary credential: " + id);
+        }
+        return primaryCredentials.getFirst();
     }
 
     public CredentialRequirement getCredential(String credentialId) {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/CredentialRequirementGroup.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/CredentialRequirementGroup.java
@@ -1,0 +1,47 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class CredentialRequirementGroup {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("required")
+    private Boolean required = Boolean.TRUE;
+
+    @JsonProperty("options")
+    private List<List<String>> options;
+
+    public String getId() {
+        return id;
+    }
+
+    public CredentialRequirementGroup setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public Boolean getRequired() {
+        return required;
+    }
+
+    public CredentialRequirementGroup setRequired(Boolean required) {
+        this.required = required;
+        return this;
+    }
+
+    public boolean isRequired() {
+        return !Boolean.FALSE.equals(required);
+    }
+
+    public List<List<String>> getOptions() {
+        return options;
+    }
+
+    public CredentialRequirementGroup setOptions(List<List<String>> options) {
+        this.options = options;
+        return this;
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfig.java
@@ -7,10 +7,12 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.AuthRequireme
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement.ClaimReference;
 import java.io.IOException;
 import java.security.cert.X509Certificate;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.representations.JsonWebToken;
@@ -104,12 +106,14 @@ public class OID4VPProfileConfig {
                         String.format("OpenID4VP profile must request at least one credential: %s", profileId));
             }
 
-            long primaryCount = profile.getCredentials().stream()
-                    .filter(CredentialRequirement::isPrimary)
-                    .count();
-            if (primaryCount != 1) {
-                throw new IllegalStateException(
-                        String.format("OpenID4VP profile must have exactly one primary credential: %s", profileId));
+            boolean hasCredentialGroups = profile.getCredentialGroups() != null
+                    && !profile.getCredentialGroups().isEmpty();
+            long primaryCount = profile.getPrimaryCredentials().size();
+            if (primaryCount == 0 || (!hasCredentialGroups && primaryCount != 1)) {
+                String message = !hasCredentialGroups
+                        ? "OpenID4VP profile must have exactly one primary credential: %s"
+                        : "OpenID4VP profile must have at least one primary credential: %s";
+                throw new IllegalStateException(String.format(message, profileId));
             }
 
             for (CredentialRequirement credential : profile.getCredentials()) {
@@ -162,7 +166,92 @@ public class OID4VPProfileConfig {
                         String.format("OpenID4VP credential ids must be unique in profile: %s", profileId));
             }
 
+            validateCredentialGroups(profile);
             validateBindingRules(profile);
+        }
+    }
+
+    private static void validateCredentialGroups(AuthenticationProfile profile) {
+        if (profile.getCredentialGroups() == null
+                || profile.getCredentialGroups().isEmpty()) {
+            return;
+        }
+
+        String profileId = profile.getId();
+        Map<String, CredentialRequirement> credentialsById = profile.getCredentials().stream()
+                .collect(Collectors.toMap(CredentialRequirement::getId, credential -> credential));
+        Set<String> groupIds = new HashSet<>();
+        int primarySelectionGroups = 0;
+
+        for (CredentialRequirementGroup group : profile.getCredentialGroups()) {
+            if (StringUtil.isBlank(group.getId())) {
+                throw new IllegalStateException(
+                        String.format("OpenID4VP credential group id must not be blank in profile: %s", profileId));
+            }
+            if (!groupIds.add(group.getId())) {
+                throw new IllegalStateException(
+                        String.format("OpenID4VP credential group ids must be unique in profile: %s", profileId));
+            }
+            if (group.getOptions() == null || group.getOptions().isEmpty()) {
+                throw new IllegalStateException(String.format(
+                        "OpenID4VP credential group must define at least one option: %s/%s", profileId, group.getId()));
+            }
+
+            Boolean groupSelectsPrimary = null;
+            for (List<String> option : group.getOptions()) {
+                if (option == null || option.isEmpty()) {
+                    throw new IllegalStateException(String.format(
+                            "OpenID4VP credential group option must not be empty: %s/%s", profileId, group.getId()));
+                }
+
+                Set<String> optionIds = new HashSet<>();
+                int primaryCount = 0;
+                for (String credentialId : option) {
+                    CredentialRequirement credential = credentialsById.get(credentialId);
+                    if (credential == null) {
+                        throw new IllegalStateException(String.format(
+                                "OpenID4VP credential group references unknown credential '%s': %s/%s",
+                                credentialId, profileId, group.getId()));
+                    }
+                    if (!optionIds.add(credentialId)) {
+                        throw new IllegalStateException(String.format(
+                                "OpenID4VP credential group option contains duplicate credential '%s': %s/%s",
+                                credentialId, profileId, group.getId()));
+                    }
+                    if (credential.isPrimary()) {
+                        primaryCount++;
+                    }
+                }
+
+                if (primaryCount > 1) {
+                    throw new IllegalStateException(String.format(
+                            "OpenID4VP credential group option must contain at most one primary credential: %s/%s",
+                            profileId, group.getId()));
+                }
+
+                boolean optionSelectsPrimary = primaryCount == 1;
+                if (groupSelectsPrimary == null) {
+                    groupSelectsPrimary = optionSelectsPrimary;
+                } else if (groupSelectsPrimary != optionSelectsPrimary) {
+                    throw new IllegalStateException(String.format(
+                            "OpenID4VP credential group options must consistently select a primary credential: %s/%s",
+                            profileId, group.getId()));
+                }
+            }
+
+            if (Boolean.TRUE.equals(groupSelectsPrimary)) {
+                if (!group.isRequired()) {
+                    throw new IllegalStateException(String.format(
+                            "OpenID4VP primary credential group must be required: %s/%s", profileId, group.getId()));
+                }
+                primarySelectionGroups++;
+            }
+        }
+
+        if (primarySelectionGroups != 1) {
+            throw new IllegalStateException(String.format(
+                    "OpenID4VP profile must have exactly one credential group selecting a primary credential: %s",
+                    profileId));
         }
     }
 
@@ -205,8 +294,7 @@ public class OID4VPProfileConfig {
 
     private static void validateBindingRules(AuthenticationProfile profile) {
         String profileId = profile.getId();
-        CredentialRequirement primary = profile.getPrimaryCredential();
-        Set<String> primaryClaimNames = Set.copyOf(primary.getClaims());
+        List<CredentialRequirement> primaryCredentials = profile.getPrimaryCredentials();
 
         for (CredentialRequirement credential : profile.getCredentials()) {
             if (credential.isPrimary()) {
@@ -249,11 +337,19 @@ public class OID4VPProfileConfig {
                                 profileId, credential.getId()));
                     }
 
-                    if (!primaryClaimNames.contains(rule.getPrimaryCredentialClaim())) {
-                        throw new IllegalStateException(String.format(
-                                "OpenID4VP binding rule primaryCredentialClaim '%s' must be among the"
-                                        + " primary credential's requested claims: %s/%s",
-                                rule.getPrimaryCredentialClaim(), profileId, credential.getId()));
+                    for (CredentialRequirement primary : primaryCredentials) {
+                        if (!Set.copyOf(primary.getClaims()).contains(rule.getPrimaryCredentialClaim())) {
+                            String primaryCredentialLabel = primaryCredentials.size() == 1
+                                    ? "the primary credential's"
+                                    : "every possible primary credential's";
+                            throw new IllegalStateException(String.format(
+                                    "OpenID4VP binding rule primaryCredentialClaim '%s' must be among %s"
+                                            + " requested claims: %s/%s",
+                                    rule.getPrimaryCredentialClaim(),
+                                    primaryCredentialLabel,
+                                    profileId,
+                                    credential.getId()));
+                        }
                     }
                 }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -20,6 +20,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContextStatus;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.AuthenticationProfile;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.SpacephobicJwsBuilder;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.TransactionDataSupport;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.VerifierInfoSupport;
@@ -267,17 +268,16 @@ public class AuthorizationRequestService {
         DcqlQuery dcqlQuery =
                 DcqlQueryGenerator.create().buildQuery(profile, config.shouldRequireCryptographicHolderBinding());
 
-        // transaction_data and verifier_info currently reference the primary DCQL
-        // credential id. Multi-credential profile support keeps the selected
-        // profile's first credential as the verifier-scoped credential id.
-        String dcqlCredentialId = dcqlQuery.getCredentials().getFirst().getId();
+        List<String> primaryCredentialIds = profile.getPrimaryCredentials().stream()
+                .map(CredentialRequirement::getId)
+                .toList();
 
         List<String> transactionData = config.getTransactionDataRaw().isEmpty()
                 ? null
-                : TransactionDataSupport.prepareWireEntries(config.getTransactionDataRaw(), dcqlCredentialId);
+                : TransactionDataSupport.prepareWireEntries(config.getTransactionDataRaw(), primaryCredentialIds);
 
         var verifierInfo = VerifierInfoSupport.build(
-                config.getRegistrationCertificate(), config.getVerifierInfoConfig(), dcqlCredentialId);
+                config.getRegistrationCertificate(), config.getVerifierInfoConfig(), primaryCredentialIds);
 
         // Aggregate properties
         RequestObject requestObject = new RequestObject()

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationResponseService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationResponseService.java
@@ -7,6 +7,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.Creden
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.OID4VPAuthenticator;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql.DcqlCredentialCapabilities;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql.DcqlCredentialCapability;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql.DcqlResponseCredentialSelector;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ResponseObject;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
@@ -15,7 +16,6 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.Authorizat
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.ProcessingError;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.AuthenticationProfile;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirementGroup;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.ErrorResponseSanitizer;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.OpenId4VpConstants;
 import jakarta.ws.rs.WebApplicationException;
@@ -23,8 +23,6 @@ import jakarta.ws.rs.core.Response;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -162,8 +160,13 @@ public class AuthorizationResponseService {
 
         Map<String, CredentialRequirement> credentialsById = profile.getCredentials().stream()
                 .collect(Collectors.toMap(CredentialRequirement::getId, credential -> credential));
-        Set<String> selectedCredentialIds =
-                selectPresentedCredentialIds(vpTokenMap.keySet(), profile, authContext, store);
+        Set<String> selectedCredentialIds;
+        try {
+            selectedCredentialIds = DcqlResponseCredentialSelector.selectPresentedCredentialIds(
+                    authContext.getRequestObject().getDcqlQuery(), vpTokenMap.keySet());
+        } catch (IllegalArgumentException e) {
+            throw failInvalidVpToken(e.getMessage(), authContext, store);
+        }
 
         for (String credentialId : vpTokenMap.keySet()) {
             if (!credentialsById.containsKey(credentialId)) {
@@ -204,54 +207,6 @@ public class AuthorizationResponseService {
         }
 
         return tokens;
-    }
-
-    private Set<String> selectPresentedCredentialIds(
-            Set<String> presentedCredentialIds,
-            AuthenticationProfile profile,
-            AuthorizationContext authContext,
-            AuthenticationSessionStore store) {
-        Set<String> selectedCredentialIds = new HashSet<>();
-
-        for (CredentialRequirementGroup group : profile.getEffectiveCredentialGroups()) {
-            List<List<String>> selectedOptions = group.getOptions().stream()
-                    .filter(option -> presentedCredentialIds.containsAll(option))
-                    .toList();
-
-            if (group.isRequired() && selectedOptions.size() != 1) {
-                if (selectedOptions.isEmpty() && group.getOptions().size() == 1) {
-                    for (String credentialId : group.getOptions().getFirst()) {
-                        if (!presentedCredentialIds.contains(credentialId)) {
-                            throw failInvalidVpToken(
-                                    String.format(
-                                            "Presented vp_token map must contain exactly one token for credential '%s'. Found: 0",
-                                            credentialId),
-                                    authContext,
-                                    store);
-                        }
-                    }
-                }
-                throw failInvalidVpToken(
-                        String.format(
-                                "Presented vp_token map must satisfy exactly one option for required credential group '%s'. Found: %d",
-                                group.getId(), selectedOptions.size()),
-                        authContext,
-                        store);
-            }
-
-            if (!group.isRequired() && selectedOptions.size() > 1) {
-                throw failInvalidVpToken(
-                        String.format(
-                                "Presented vp_token map must satisfy at most one option for optional credential group '%s'. Found: %d",
-                                group.getId(), selectedOptions.size()),
-                        authContext,
-                        store);
-            }
-
-            selectedOptions.stream().findFirst().ifPresent(selectedCredentialIds::addAll);
-        }
-
-        return selectedCredentialIds;
     }
 
     /**

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationResponseService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationResponseService.java
@@ -15,6 +15,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.Authorizat
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.ProcessingError;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.AuthenticationProfile;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirementGroup;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.ErrorResponseSanitizer;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils.OpenId4VpConstants;
 import jakarta.ws.rs.WebApplicationException;
@@ -22,7 +23,12 @@ import jakarta.ws.rs.core.Response;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.authentication.AuthenticationProcessor;
@@ -135,12 +141,12 @@ public class AuthorizationResponseService {
     }
 
     /**
-     * Extracts exactly one decoded credential token per configured DCQL credential ID.
+     * Extracts exactly one decoded credential token per selected DCQL credential ID.
      *
      * <p>The response object keeps the wire-level vp_token shape, where each DCQL
      * credential ID maps to a list. The authenticator needs a normalized lookup map
-     * so it can verify the primary credential and all supporting credentials inside
-     * the same Keycloak authentication execution before marking the flow successful.
+     * so it can verify the selected primary credential and supporting credentials
+     * inside the same Keycloak authentication execution before marking the flow successful.
      */
     private HashMap<String, String> extractPresentedTokens(
             ResponseObject responseObject,
@@ -154,12 +160,32 @@ public class AuthorizationResponseService {
             throw failInvalidVpToken("Presented vp_token map is missing", authContext, store);
         }
 
-        for (CredentialRequirement credential : profile.getCredentials()) {
-            var credentialTokens = vpTokenMap.get(credential.getId());
+        Map<String, CredentialRequirement> credentialsById = profile.getCredentials().stream()
+                .collect(Collectors.toMap(CredentialRequirement::getId, credential -> credential));
+        Set<String> selectedCredentialIds =
+                selectPresentedCredentialIds(vpTokenMap.keySet(), profile, authContext, store);
+
+        for (String credentialId : vpTokenMap.keySet()) {
+            if (!credentialsById.containsKey(credentialId)) {
+                throw failInvalidVpToken(
+                        "Presented vp_token map contains unknown credential: " + credentialId, authContext, store);
+            }
+            if (!selectedCredentialIds.contains(credentialId)) {
+                throw failInvalidVpToken(
+                        "Presented vp_token map contains credential outside the selected group options: "
+                                + credentialId,
+                        authContext,
+                        store);
+            }
+        }
+
+        for (String credentialId : selectedCredentialIds) {
+            CredentialRequirement credential = credentialsById.get(credentialId);
+            var credentialTokens = vpTokenMap.get(credentialId);
             if (credentialTokens == null || credentialTokens.size() != 1) {
                 String errorMsg = String.format(
                         "Presented vp_token map must contain exactly one token for credential '%s'. Found: %d",
-                        credential.getId(), credentialTokens == null ? 0 : credentialTokens.size());
+                        credentialId, credentialTokens == null ? 0 : credentialTokens.size());
                 throw failInvalidVpToken(errorMsg, authContext, store);
             }
 
@@ -173,11 +199,59 @@ public class AuthorizationResponseService {
                         case MSO_MDOC -> rawToken;
                     };
 
-            validatePresentedToken(presentedToken, credential.getId(), authContext, store);
-            tokens.put(credential.getId(), presentedToken);
+            validatePresentedToken(presentedToken, credentialId, authContext, store);
+            tokens.put(credentialId, presentedToken);
         }
 
         return tokens;
+    }
+
+    private Set<String> selectPresentedCredentialIds(
+            Set<String> presentedCredentialIds,
+            AuthenticationProfile profile,
+            AuthorizationContext authContext,
+            AuthenticationSessionStore store) {
+        Set<String> selectedCredentialIds = new HashSet<>();
+
+        for (CredentialRequirementGroup group : profile.getEffectiveCredentialGroups()) {
+            List<List<String>> selectedOptions = group.getOptions().stream()
+                    .filter(option -> presentedCredentialIds.containsAll(option))
+                    .toList();
+
+            if (group.isRequired() && selectedOptions.size() != 1) {
+                if (selectedOptions.isEmpty() && group.getOptions().size() == 1) {
+                    for (String credentialId : group.getOptions().getFirst()) {
+                        if (!presentedCredentialIds.contains(credentialId)) {
+                            throw failInvalidVpToken(
+                                    String.format(
+                                            "Presented vp_token map must contain exactly one token for credential '%s'. Found: 0",
+                                            credentialId),
+                                    authContext,
+                                    store);
+                        }
+                    }
+                }
+                throw failInvalidVpToken(
+                        String.format(
+                                "Presented vp_token map must satisfy exactly one option for required credential group '%s'. Found: %d",
+                                group.getId(), selectedOptions.size()),
+                        authContext,
+                        store);
+            }
+
+            if (!group.isRequired() && selectedOptions.size() > 1) {
+                throw failInvalidVpToken(
+                        String.format(
+                                "Presented vp_token map must satisfy at most one option for optional credential group '%s'. Found: %d",
+                                group.getId(), selectedOptions.size()),
+                        authContext,
+                        store);
+            }
+
+            selectedOptions.stream().findFirst().ifPresent(selectedCredentialIds::addAll);
+        }
+
+        return selectedCredentialIds;
     }
 
     /**

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/utils/TransactionDataSupport.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/utils/TransactionDataSupport.java
@@ -53,14 +53,30 @@ public final class TransactionDataSupport {
      * Returns the wire strings as they must appear on the signed request (re-encoded when normalized).
      */
     public static List<String> prepareWireEntries(List<String> rawWireStrings, String dcqlCredentialId) {
+        return prepareWireEntries(rawWireStrings, List.of(dcqlCredentialId));
+    }
+
+    /**
+     * Validates each entry and ensures {@code credential_ids} references all permitted DCQL credential ids.
+     * Returns the wire strings as they must appear on the signed request (re-encoded when normalized).
+     */
+    public static List<String> prepareWireEntries(List<String> rawWireStrings, List<String> dcqlCredentialIds) {
         List<String> prepared = new ArrayList<>();
         for (String raw : rawWireStrings) {
-            prepared.add(prepareWireEntry(raw, dcqlCredentialId));
+            prepared.add(prepareWireEntry(raw, dcqlCredentialIds));
         }
         return prepared;
     }
 
     public static String prepareWireEntry(String rawWire, String dcqlCredentialId) {
+        return prepareWireEntry(rawWire, List.of(dcqlCredentialId));
+    }
+
+    public static String prepareWireEntry(String rawWire, List<String> dcqlCredentialIds) {
+        if (dcqlCredentialIds == null || dcqlCredentialIds.isEmpty()) {
+            throw new IllegalArgumentException("transaction_data requires at least one DCQL credential id");
+        }
+
         ObjectNode object = decodeWireObject(rawWire);
         if (!object.hasNonNull(TYPE_CLAIM)
                 || StringUtil.isBlank(object.get(TYPE_CLAIM).asText())) {
@@ -70,11 +86,34 @@ public final class TransactionDataSupport {
         if (!object.has(CREDENTIAL_IDS_CLAIM)
                 || !object.get(CREDENTIAL_IDS_CLAIM).isArray()) {
             ArrayNode credentialIds = JsonSerialization.mapper.createArrayNode();
-            credentialIds.add(dcqlCredentialId);
+            dcqlCredentialIds.forEach(credentialIds::add);
             object.set(CREDENTIAL_IDS_CLAIM, credentialIds);
         } else {
             ArrayNode credentialIds = (ArrayNode) object.get(CREDENTIAL_IDS_CLAIM);
             if (credentialIds.isEmpty()) {
+                throw new IllegalArgumentException("transaction_data credential_ids must be a non-empty array");
+            }
+            Set<String> configuredIds = Set.copyOf(dcqlCredentialIds);
+            Set<String> wireIds = new java.util.HashSet<>();
+            credentialIds.forEach(id -> wireIds.add(id.asText()));
+            if (!wireIds.containsAll(configuredIds)) {
+                throw new IllegalArgumentException(String.format(
+                        "transaction_data credential_ids must reference DCQL credential ids %s", configuredIds));
+            }
+        }
+
+        return encodeWireObject(object);
+    }
+
+    public static void requireCredentialIdInAllEntries(List<String> transactionDataWire, String dcqlCredentialId) {
+        if (transactionDataWire == null || transactionDataWire.isEmpty()) {
+            return;
+        }
+
+        for (String wire : transactionDataWire) {
+            ObjectNode object = decodeWireObject(wire);
+            JsonNode credentialIds = object.get(CREDENTIAL_IDS_CLAIM);
+            if (credentialIds == null || !credentialIds.isArray() || credentialIds.isEmpty()) {
                 throw new IllegalArgumentException("transaction_data credential_ids must be a non-empty array");
             }
             boolean matches = false;
@@ -86,11 +125,10 @@ public final class TransactionDataSupport {
             }
             if (!matches) {
                 throw new IllegalArgumentException(String.format(
-                        "transaction_data credential_ids must reference DCQL credential id '%s'", dcqlCredentialId));
+                        "transaction_data credential_ids must reference selected DCQL credential id '%s'",
+                        dcqlCredentialId));
             }
         }
-
-        return encodeWireObject(object);
     }
 
     public static ObjectNode decodeWireObject(String wire) {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/utils/VerifierInfoSupport.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/utils/VerifierInfoSupport.java
@@ -18,13 +18,18 @@ public final class VerifierInfoSupport {
 
     public static List<VerifierInfo> build(
             String registrationCertificate, String verifierInfoConfigJson, String dcqlCredentialId) {
+        return build(registrationCertificate, verifierInfoConfigJson, List.of(dcqlCredentialId));
+    }
+
+    public static List<VerifierInfo> build(
+            String registrationCertificate, String verifierInfoConfigJson, List<String> dcqlCredentialIds) {
         List<VerifierInfo> entries = new ArrayList<>();
 
         if (!StringUtil.isBlank(registrationCertificate)) {
             entries.add(new VerifierInfo()
                     .setFormat(REGISTRATION_CERT_FORMAT)
                     .setData(registrationCertificate)
-                    .setCredentialIds(List.of(dcqlCredentialId)));
+                    .setCredentialIds(dcqlCredentialIds));
         }
 
         entries.addAll(parseConfigEntries(verifierInfoConfigJson));
@@ -33,7 +38,7 @@ public final class VerifierInfoSupport {
             return null;
         }
 
-        validate(entries, dcqlCredentialId);
+        validate(entries, dcqlCredentialIds);
         return entries;
     }
 
@@ -52,6 +57,14 @@ public final class VerifierInfoSupport {
     }
 
     public static void validate(List<VerifierInfo> entries, String dcqlCredentialId) {
+        validate(entries, List.of(dcqlCredentialId));
+    }
+
+    public static void validate(List<VerifierInfo> entries, List<String> dcqlCredentialIds) {
+        if (dcqlCredentialIds == null || dcqlCredentialIds.isEmpty()) {
+            throw new IllegalArgumentException("verifier_info requires at least one DCQL credential id");
+        }
+
         for (VerifierInfo entry : entries) {
             if (StringUtil.isBlank(entry.getFormat())) {
                 throw new IllegalArgumentException("verifier_info format must not be blank");
@@ -64,10 +77,11 @@ public final class VerifierInfoSupport {
                 if (credentialIds.isEmpty()) {
                     throw new IllegalArgumentException("verifier_info credential_ids must be non-empty when present");
                 }
-                boolean matches = credentialIds.stream().anyMatch(dcqlCredentialId::equals);
+                boolean matches = credentialIds.stream().anyMatch(dcqlCredentialIds::contains);
                 if (!matches) {
                     throw new IllegalArgumentException(String.format(
-                            "verifier_info credential_ids must reference DCQL credential id '%s'", dcqlCredentialId));
+                            "verifier_info credential_ids must reference one of DCQL credential ids %s",
+                            dcqlCredentialIds));
                 }
             }
         }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/AuthenticationProfileSamples.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/AuthenticationProfileSamples.java
@@ -16,12 +16,15 @@ public final class AuthenticationProfileSamples {
     public static final String DUAL_PROFILE_ID = "dual";
     public static final String MDOC_PRIMARY_PROFILE_ID = "mdoc-primary";
     public static final String SDJWT_MDOC_DUAL_PROFILE_ID = "sdjwt-mdoc-dual";
+    public static final String ALTERNATIVE_PRIMARY_PROFILE_ID = "alternative-primary";
 
     /** Credential id used for the primary credential in multi-credential profiles and VP token maps. */
     public static final String PRIMARY_CREDENTIAL_ID = "primary";
 
     /** Credential id used for the supporting credential in dual-credential profiles and VP token maps. */
     public static final String SUPPORTING_CREDENTIAL_ID = "supporting";
+
+    public static final String ALTERNATIVE_PRIMARY_CREDENTIAL_ID = "national-id";
 
     /**
      * Bundles a profile's JSON configuration with its identifier, so callers of
@@ -170,5 +173,45 @@ public final class AuthenticationProfileSamples {
                 .replace("{namespace}", MdocBaseTest.NAMESPACE)
                 .replace("{issuerCertBase64}", MdocBaseTest.getIssuerCertBase64());
         return new ProfileSample(json, SDJWT_MDOC_DUAL_PROFILE_ID);
+    }
+
+    /** Profile where either one of two SD-JWT credentials can act as the primary credential. */
+    public static ProfileSample alternativePrimary() {
+        String json = """
+                [
+                  {
+                    "id": "{profileId}",
+                    "displayCta": { "en": "Sign in with an identity credential" },
+                    "credentials": [
+                      {
+                        "id": "{primaryCredentialId}",
+                        "role": "primary",
+                        "credentialTypes": ["{defaultVct}"],
+                        "claims": ["sub", "username"]
+                      },
+                      {
+                        "id": "{alternativeCredentialId}",
+                        "role": "primary",
+                        "credentialTypes": ["{defaultVct}"],
+                        "claims": ["sub", "username"]
+                      }
+                    ],
+                    "credentialGroups": [
+                      {
+                        "id": "primary-identity",
+                        "required": true,
+                        "options": [
+                          ["{primaryCredentialId}"],
+                          ["{alternativeCredentialId}"]
+                        ]
+                      }
+                    ]
+                  }
+                ]
+                """.replace("{profileId}", ALTERNATIVE_PRIMARY_PROFILE_ID)
+                .replace("{primaryCredentialId}", PRIMARY_CREDENTIAL_ID)
+                .replace("{alternativeCredentialId}", ALTERNATIVE_PRIMARY_CREDENTIAL_ID)
+                .replace("{defaultVct}", CREDENTIAL_TYPES_CONFIG_DEFAULT);
+        return new ProfileSample(json, ALTERNATIVE_PRIMARY_PROFILE_ID);
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -1,5 +1,6 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp;
 
+import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.AuthenticationProfileSamples.ALTERNATIVE_PRIMARY_CREDENTIAL_ID;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.AuthenticationProfileSamples.PRIMARY_CREDENTIAL_ID;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.AuthenticationProfileSamples.SUPPORTING_CREDENTIAL_ID;
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPUserAuthEndpoint.REQUEST_JWT_PATH;
@@ -338,6 +339,22 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
                     TestOpts.getDefault().setAuthContext(apiFlow.authContext()).setCodeVerifier(apiFlow.codeVerifier());
 
             testSuccessfulAuthentication(sdJwt, opts);
+        });
+    }
+
+    @Test
+    public void shouldAuthenticateSuccessfully_WithAlternativePrimaryCredentialGroup() throws Exception {
+        withAuthenticationProfile(AuthenticationProfileSamples.alternativePrimary(), (apiFlow, requestObject) -> {
+            assertEquals(2, requestObject.getDcqlQuery().getCredentials().size());
+            assertEquals(
+                    List.of(List.of(PRIMARY_CREDENTIAL_ID), List.of(ALTERNATIVE_PRIMARY_CREDENTIAL_ID)),
+                    requestObject.getDcqlQuery().getCredentialSets().getFirst().getOptions());
+
+            String sdJwtVpToken = presentSdJwt(requestObject);
+            TestOpts opts =
+                    TestOpts.getDefault().setAuthContext(apiFlow.authContext()).setCodeVerifier(apiFlow.codeVerifier());
+
+            testSuccessfulAuthenticationWithVPTokenMap(Map.of(ALTERNATIVE_PRIMARY_CREDENTIAL_ID, sdJwtVpToken), opts);
         });
     }
 

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -587,7 +587,7 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
                 authContext.getTransactionId(),
                 HttpStatus.SC_BAD_REQUEST,
                 ProcessingError.INVALID_VP_TOKEN.getErrorString(),
-                "Presented vp_token map must contain exactly one token for credential");
+                "Presented vp_token map contains unknown credential(s): [non-matching-dcql-credential-id]");
     }
 
     @Test
@@ -784,7 +784,7 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
                     opts,
                     HttpStatus.SC_BAD_REQUEST,
                     ProcessingError.INVALID_VP_TOKEN.getErrorString(),
-                    "Presented vp_token map must contain exactly one token for credential 'supporting'");
+                    "Presented vp_token map does not satisfy DCQL credential_sets");
         });
     }
 

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryGeneratorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlQueryGeneratorTest.java
@@ -9,6 +9,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credentia
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.AuthenticationProfile;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirementGroup;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRole;
 import java.util.HashSet;
 import java.util.List;
@@ -61,6 +62,42 @@ public class DcqlQueryGeneratorTest {
         assertEquals(
                 List.of("main", "supporting"),
                 query.getCredentialSets().getFirst().getOptions().getFirst());
+    }
+
+    @Test
+    void testGenerateGroupedAlternativeCredentialDcqlQuery() {
+        AuthenticationProfile profile = new AuthenticationProfile()
+                .setId("grouped")
+                .setCredentials(List.of(
+                        new CredentialRequirement()
+                                .setId("passport")
+                                .setRole(CredentialRole.PRIMARY)
+                                .setCredentialTypes(List.of("passport-vct"))
+                                .setClaims(List.of("sub", "username")),
+                        new CredentialRequirement()
+                                .setId("national-id")
+                                .setRole(CredentialRole.PRIMARY)
+                                .setCredentialTypes(List.of("national-id-vct"))
+                                .setClaims(List.of("sub", "username")),
+                        new CredentialRequirement()
+                                .setId("pid")
+                                .setRole(CredentialRole.SUPPORTING)
+                                .setCredentialTypes(List.of("pid-vct"))
+                                .setClaims(List.of("given_name"))))
+                .setCredentialGroups(List.of(
+                        new CredentialRequirementGroup()
+                                .setId("primary-identity")
+                                .setOptions(List.of(List.of("passport"), List.of("national-id"))),
+                        new CredentialRequirementGroup().setId("pid").setOptions(List.of(List.of("pid")))));
+
+        DcqlQuery query = generator.buildQuery(profile, true);
+
+        assertEquals(3, query.getCredentials().size());
+        assertEquals(2, query.getCredentialSets().size());
+        assertEquals(
+                List.of(List.of("passport"), List.of("national-id")),
+                query.getCredentialSets().getFirst().getOptions());
+        assertEquals(List.of(List.of("pid")), query.getCredentialSets().get(1).getOptions());
     }
 
     @Test

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlResponseCredentialSelectorTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlResponseCredentialSelectorTest.java
@@ -1,0 +1,110 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.CredentialSet;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.DcqlQuery;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class DcqlResponseCredentialSelectorTest {
+
+    @Test
+    void acceptsCompleteRequiredCombination() {
+        DcqlQuery query = query(List.of("pid", "residence"), List.of(required(List.of(List.of("pid", "residence")))));
+
+        assertEquals(
+                Set.of("pid", "residence"),
+                DcqlResponseCredentialSelector.selectPresentedCredentialIds(query, Set.of("pid", "residence")));
+    }
+
+    @Test
+    void acceptsSubsetOptionWhenCompleteResponseMatchesLargerOption() {
+        DcqlQuery query = query(
+                List.of("pid", "residence"), List.of(required(List.of(List.of("pid"), List.of("pid", "residence")))));
+
+        assertEquals(
+                Set.of("pid", "residence"),
+                DcqlResponseCredentialSelector.selectPresentedCredentialIds(query, Set.of("pid", "residence")));
+    }
+
+    @Test
+    void acceptsOptionalCredentialSetWhenItAccountsForPresentedCredential() {
+        DcqlQuery query = query(
+                List.of("pid", "residence"),
+                List.of(required(List.of(List.of("pid"))), optional(List.of(List.of("residence")))));
+
+        assertEquals(
+                Set.of("pid", "residence"),
+                DcqlResponseCredentialSelector.selectPresentedCredentialIds(query, Set.of("pid", "residence")));
+    }
+
+    @Test
+    void acceptsCredentialSharedByMultipleSets() {
+        DcqlQuery query =
+                query(List.of("pid"), List.of(required(List.of(List.of("pid"))), required(List.of(List.of("pid")))));
+
+        assertEquals(Set.of("pid"), DcqlResponseCredentialSelector.selectPresentedCredentialIds(query, Set.of("pid")));
+    }
+
+    @Test
+    void rejectsPresentedCredentialNotCoveredBySelectedOptions() {
+        DcqlQuery query = query(List.of("pid", "residence"), List.of(required(List.of(List.of("pid")))));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlResponseCredentialSelector.selectPresentedCredentialIds(query, Set.of("pid", "residence")));
+    }
+
+    @Test
+    void rejectsCredentialSetWithoutOptions() {
+        DcqlQuery query = query(List.of("pid"), List.of(required(null)));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlResponseCredentialSelector.selectPresentedCredentialIds(query, Set.of("pid")));
+    }
+
+    @Test
+    void fallsBackToAllCredentialsRequiredWhenCredentialSetsAreMissing() {
+        DcqlQuery query = query(List.of("pid", "residence"), null);
+
+        assertDoesNotThrow(
+                () -> DcqlResponseCredentialSelector.selectPresentedCredentialIds(query, Set.of("pid", "residence")));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DcqlResponseCredentialSelector.selectPresentedCredentialIds(query, Set.of("pid")));
+    }
+
+    private static DcqlQuery query(List<String> credentialIds, List<CredentialSet> credentialSets) {
+        DcqlQuery query = new DcqlQuery();
+        query.setCredentials(credentialIds.stream()
+                .map(DcqlResponseCredentialSelectorTest::credential)
+                .toList());
+        query.setCredentialSets(credentialSets);
+        return query;
+    }
+
+    private static Credential credential(String id) {
+        Credential credential = new Credential();
+        credential.setId(id);
+        return credential;
+    }
+
+    private static CredentialSet required(List<List<String>> options) {
+        CredentialSet credentialSet = new CredentialSet();
+        credentialSet.setRequired(Boolean.TRUE);
+        credentialSet.setOptions(options);
+        return credentialSet;
+    }
+
+    private static CredentialSet optional(List<List<String>> options) {
+        CredentialSet credentialSet = required(options);
+        credentialSet.setRequired(Boolean.FALSE);
+        return credentialSet;
+    }
+}

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocBaseTest;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.VerifierConfig;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.keycloak.models.AuthenticatorConfigModel;
@@ -57,6 +58,40 @@ public class OID4VPProfileConfigTest {
         assertEquals(2, profile.getCredentials().size());
         assertEquals(
                 "main-vct", profile.getPrimaryCredential().getCredentialTypes().getFirst());
+    }
+
+    @Test
+    void shouldParseCredentialGroups() {
+        AuthenticatorConfigModel config = new AuthenticatorConfigModel();
+        config.setConfig(Map.of(PROFILES_CONFIG, """
+                [
+                  {
+                    "id": "grouped",
+                    "credentials": [
+                      { "id": "passport", "role": "primary", "credentialTypes": ["passport-vct"], "claims": ["sub", "username"] },
+                      { "id": "national-id", "role": "primary", "credentialTypes": ["national-id-vct"], "claims": ["sub", "username"] },
+                      { "id": "pid", "role": "supporting", "credentialTypes": ["pid-vct"], "claims": ["given_name"] }
+                    ],
+                    "credentialGroups": [
+                      {
+                        "id": "primary-identity",
+                        "options": [["passport"], ["national-id"]]
+                      },
+                      {
+                        "id": "pid-support",
+                        "options": [["pid"]]
+                      }
+                    ]
+                  }
+                ]
+                """));
+
+        AuthenticationProfile profile = new OID4VPProfileConfig(config).getProfile("grouped");
+
+        assertEquals(2, profile.getCredentialGroups().size());
+        assertEquals(
+                List.of(List.of("passport"), List.of("national-id")),
+                profile.getCredentialGroups().getFirst().getOptions());
     }
 
     @Test
@@ -180,6 +215,33 @@ public class OID4VPProfileConfigTest {
 
         IllegalStateException error = assertThrows(IllegalStateException.class, () -> new OID4VPProfileConfig(config));
         assertEquals("OpenID4VP profile must have exactly one primary credential: broken", error.getMessage());
+    }
+
+    @Test
+    void shouldRejectCredentialGroupWithoutConsistentPrimarySelection() {
+        AuthenticatorConfigModel config = new AuthenticatorConfigModel();
+        config.setConfig(Map.of(PROFILES_CONFIG, """
+                [
+                  {
+                    "id": "broken",
+                    "credentials": [
+                      { "id": "passport", "role": "primary", "credentialTypes": ["passport-vct"], "claims": ["sub", "username"] },
+                      { "id": "pid", "role": "supporting", "credentialTypes": ["pid-vct"], "claims": ["given_name"] }
+                    ],
+                    "credentialGroups": [
+                      {
+                        "id": "primary-identity",
+                        "options": [["passport"], ["pid"]]
+                      }
+                    ]
+                  }
+                ]
+                """));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, () -> new OID4VPProfileConfig(config));
+        assertEquals(
+                "OpenID4VP credential group options must consistently select a primary credential: broken/primary-identity",
+                error.getMessage());
     }
 
     @Test

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/utils/TransactionDataSupportTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/utils/TransactionDataSupportTest.java
@@ -3,6 +3,7 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,34 @@ class TransactionDataSupportTest {
         assertEquals(
                 "my-credential",
                 decoded.get(TransactionDataSupport.CREDENTIAL_IDS_CLAIM).get(0).asText());
+    }
+
+    @Test
+    void prepareWireEntryInjectsAllPrimaryCredentialIds() {
+        ObjectNode tx = JsonSerialization.mapper.createObjectNode();
+        tx.put(TransactionDataSupport.TYPE_CLAIM, "payment");
+        String raw = TransactionDataSupport.encodeWireObject(tx);
+
+        String prepared = TransactionDataSupport.prepareWireEntry(raw, List.of("passport", "national-id"));
+
+        ObjectNode decoded = TransactionDataSupport.decodeWireObject(prepared);
+        assertEquals(
+                List.of("passport", "national-id"),
+                JsonSerialization.mapper.convertValue(
+                        decoded.get(TransactionDataSupport.CREDENTIAL_IDS_CLAIM),
+                        new TypeReference<List<String>>() {}));
+    }
+
+    @Test
+    void rejectsTransactionDataWhenSelectedPrimaryIsNotReferenced() {
+        ObjectNode tx = JsonSerialization.mapper.createObjectNode();
+        tx.put(TransactionDataSupport.TYPE_CLAIM, "payment");
+        tx.putArray(TransactionDataSupport.CREDENTIAL_IDS_CLAIM).add("passport");
+        String wire = TransactionDataSupport.encodeWireObject(tx);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> TransactionDataSupport.requireCredentialIdInAllEntries(List.of(wire), "national-id"));
     }
 
     @Test


### PR DESCRIPTION
This adds `credentialGroups` to authentication profiles so a verifier can request alternatives like passport OR national ID while keeping the existing flat credential configuration valid. The DCQL query, authorization response validation, and authenticator flow now resolve the selected option per group and authenticate with the credential actually presented by the wallet.