### PR TITLE
Implement DCQL presentation pre-validation for mDoc credential queries

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlClaimSelectionValidator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlClaimSelectionValidator.java
@@ -1,0 +1,58 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql;
+
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.keycloak.common.VerificationException;
+
+/** Applies the format-neutral DCQL {@code claims}/{@code claim_sets} selection rules. */
+final class DcqlClaimSelectionValidator {
+
+    private DcqlClaimSelectionValidator() {}
+
+    static void validate(
+            Credential credential,
+            Function<Claim, ClaimValidationResult> claimEvaluator,
+            String unsatisfiedClaimSetsMessage)
+            throws VerificationException {
+        List<Claim> claims = credential.getClaims();
+        if (claims == null || claims.isEmpty()) {
+            return;
+        }
+
+        List<List<String>> claimSets = credential.getClaimSets();
+        if (claimSets == null || claimSets.isEmpty()) {
+            for (Claim claim : claims) {
+                ClaimValidationResult result = claimEvaluator.apply(claim);
+                if (!result.satisfied()) {
+                    throw new VerificationException(result.errorMessage());
+                }
+            }
+            return;
+        }
+
+        Map<String, Boolean> claimSatisfactionById = new HashMap<>();
+        for (Claim claim : claims) {
+            claimSatisfactionById.put(claim.getId(), claimEvaluator.apply(claim).satisfied());
+        }
+
+        boolean satisfiesAnyClaimSet = claimSets.stream().anyMatch(option -> option.stream()
+                .allMatch(claimId -> Boolean.TRUE.equals(claimSatisfactionById.get(claimId))));
+        if (!satisfiesAnyClaimSet) {
+            throw new VerificationException(unsatisfiedClaimSetsMessage);
+        }
+    }
+
+    record ClaimValidationResult(boolean satisfied, String errorMessage) {
+        static ClaimValidationResult ok() {
+            return new ClaimValidationResult(true, null);
+        }
+
+        static ClaimValidationResult failed(String errorMessage) {
+            return new ClaimValidationResult(false, errorMessage);
+        }
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapability.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapability.java
@@ -1,15 +1,32 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql;
 
+import com.authlete.cbor.CBORItem;
+import com.authlete.cbor.CBORItemList;
+import com.authlete.cbor.CBORPair;
+import com.authlete.cbor.CBORPairList;
+import com.authlete.cbor.CBORString;
 import com.authlete.cose.constants.COSEAlgorithms;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.CborUtil;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocEncodingException;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocParser;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.CredentialFormat;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientMetadata;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.MdocGenericFormat;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import org.keycloak.common.VerificationException;
 
 /**
  * DCQL capability for {@code mso_mdoc} (ISO/IEC 18013-5) credentials.
+ *
+ * <p>Pre-validates the presented DeviceResponse document type and the presence of requested
+ * namespace/data-element paths. Cryptographic, digest, validity, trust, and device-binding checks remain in the
+ * mDoc credential verifier.
  *
  * <p>Contributes VP format metadata with COSE algorithm identifiers for
  * issuer authentication and device authentication per OpenID4VP Final 1.0
@@ -24,13 +41,24 @@ public final class MdocDcqlCredentialCapability implements DcqlCredentialCapabil
 
     @Override
     public boolean supportsPresentationPreValidation() {
-        return false;
+        return true;
     }
 
     @Override
     public void validatePresentation(Credential credential, String presentedToken) throws VerificationException {
-        throw new UnsupportedOperationException(
-                "DCQL presentation validation is not yet supported for mso_mdoc credentials");
+        if (!format().equals(credential.getFormat())) {
+            throw new VerificationException(
+                    "Unsupported dcql_query credential format for presentation validation: " + credential.getFormat());
+        }
+
+        PresentedMdoc presentation = parsePresentation(presentedToken);
+        String expectedDocType = credential.getMeta().getDoctypeValue();
+        if (!Objects.equals(expectedDocType, presentation.docType())) {
+            throw new VerificationException(
+                    "Presented mDoc docType does not match meta.doctype_value: " + presentation.docType());
+        }
+
+        validateRequestedClaims(credential, presentation.claimPaths());
     }
 
     @Override
@@ -46,4 +74,96 @@ public final class MdocDcqlCredentialCapability implements DcqlCredentialCapabil
         format.setDeviceAuthAlgValues(coseAlgorithms);
         vpFormat.setMsoMdoc(format);
     }
+
+    private static PresentedMdoc parsePresentation(String presentedToken) throws VerificationException {
+        CBORPairList deviceResponse;
+        try {
+            deviceResponse = MdocParser.parseBase64Url(presentedToken);
+        } catch (MdocEncodingException e) {
+            throw new IllegalArgumentException("Failed to parse presented mDoc device response", e);
+        }
+
+        CBORPair documentsEntry = deviceResponse.findByKey(MdocConstants.L_DOCUMENTS);
+        if (documentsEntry == null) {
+            throw new VerificationException("Presented mDoc response is missing the documents field");
+        }
+
+        CBORItemList documents = (CBORItemList) documentsEntry.getValue();
+        if (documents.getItems().size() != 1) {
+            throw new VerificationException("Presented mDoc response must contain exactly one document, but contained "
+                    + documents.getItems().size());
+        }
+
+        CBORPairList document = (CBORPairList) documents.getItems().getFirst();
+        String docType =
+                ((CBORString) document.findByKey(MdocConstants.L_DOC_TYPE).getValue()).getValue();
+        return new PresentedMdoc(docType, extractClaimPaths(document));
+    }
+
+    private static Set<ClaimPath> extractClaimPaths(CBORPairList document) {
+        CBORPairList issuerSigned =
+                (CBORPairList) document.findByKey(MdocConstants.L_ISSUER_SIGNED).getValue();
+        CBORPair namespacesEntry = issuerSigned.findByKey(MdocConstants.L_NAME_SPACES);
+        if (namespacesEntry == null) {
+            return Set.of();
+        }
+
+        Set<ClaimPath> claimPaths = new HashSet<>();
+        CBORPairList namespaces = (CBORPairList) namespacesEntry.getValue();
+        for (CBORPair namespace : namespaces.getPairs()) {
+            String namespaceIdentifier = CborUtil.asString(namespace.getKey());
+            CBORItemList issuerSignedItems = (CBORItemList) namespace.getValue();
+            for (CBORItem issuerSignedItem : issuerSignedItems.getItems()) {
+                CBORPairList item = (CBORPairList) CborUtil.unwrap(issuerSignedItem);
+                String elementIdentifier = ((CBORString) item.findByKey(MdocConstants.L_ELEMENT_IDENTIFIER)
+                                .getValue())
+                        .getValue();
+                claimPaths.add(new ClaimPath(namespaceIdentifier, elementIdentifier));
+            }
+        }
+        return Set.copyOf(claimPaths);
+    }
+
+    /**
+     * Validates claim-path presence and claim-set alternatives. Claim {@code values} are intentionally not enforced:
+     * OpenID4VP Final 1.0 defines them as a best-effort wallet privacy hint that verifiers must not treat as a
+     * security control.
+     */
+    private static void validateRequestedClaims(Credential credential, Set<ClaimPath> presentedClaimPaths)
+            throws VerificationException {
+        List<Claim> claims = credential.getClaims();
+        if (claims == null || claims.isEmpty()) {
+            return;
+        }
+
+        List<List<String>> claimSets = credential.getClaimSets();
+        if (claimSets == null || claimSets.isEmpty()) {
+            for (Claim claim : claims) {
+                if (!isPresented(claim, presentedClaimPaths)) {
+                    throw new VerificationException(
+                            "Presented mDoc does not satisfy DCQL claim path: " + claim.getPath());
+                }
+            }
+            return;
+        }
+
+        boolean satisfiesAnyClaimSet = claimSets.stream()
+                .anyMatch(option -> option.stream().allMatch(claimId -> claims.stream()
+                        .filter(claim -> Objects.equals(claimId, claim.getId()))
+                        .anyMatch(claim -> isPresented(claim, presentedClaimPaths))));
+        if (!satisfiesAnyClaimSet) {
+            throw new VerificationException("Presented mDoc does not satisfy any DCQL claim_sets option");
+        }
+    }
+
+    private static boolean isPresented(Claim claim, Set<ClaimPath> presentedClaimPaths) {
+        List<String> path = claim.getPath();
+        return path != null
+                && path.size() == 2
+                && presentedClaimPaths.contains(new ClaimPath(path.getFirst(), path.get(1)));
+    }
+
+    private record PresentedMdoc(String docType, Set<ClaimPath> claimPaths) {}
+
+    private record ClaimPath(String namespace, String elementIdentifier) {}
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapability.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapability.java
@@ -54,8 +54,11 @@ public final class MdocDcqlCredentialCapability implements DcqlCredentialCapabil
         PresentedMdoc presentation = parsePresentation(presentedToken);
         String expectedDocType = credential.getMeta().getDoctypeValue();
         if (!Objects.equals(expectedDocType, presentation.docType())) {
-            throw new VerificationException(
-                    "Presented mDoc docType does not match meta.doctype_value: " + presentation.docType());
+            throw new VerificationException("Presented mDoc docType does not match meta.doctype_value: expected '"
+                    + expectedDocType
+                    + "' but got '"
+                    + presentation.docType()
+                    + "'");
         }
 
         validateRequestedClaims(credential, presentation.claimPaths());
@@ -121,7 +124,7 @@ public final class MdocDcqlCredentialCapability implements DcqlCredentialCapabil
                 claimPaths.add(new ClaimPath(namespaceIdentifier, elementIdentifier));
             }
         }
-        return Set.copyOf(claimPaths);
+        return claimPaths;
     }
 
     /**
@@ -131,36 +134,29 @@ public final class MdocDcqlCredentialCapability implements DcqlCredentialCapabil
      */
     private static void validateRequestedClaims(Credential credential, Set<ClaimPath> presentedClaimPaths)
             throws VerificationException {
-        List<Claim> claims = credential.getClaims();
-        if (claims == null || claims.isEmpty()) {
-            return;
-        }
-
-        List<List<String>> claimSets = credential.getClaimSets();
-        if (claimSets == null || claimSets.isEmpty()) {
-            for (Claim claim : claims) {
-                if (!isPresented(claim, presentedClaimPaths)) {
-                    throw new VerificationException(
-                            "Presented mDoc does not satisfy DCQL claim path: " + claim.getPath());
-                }
-            }
-            return;
-        }
-
-        boolean satisfiesAnyClaimSet = claimSets.stream()
-                .anyMatch(option -> option.stream().allMatch(claimId -> claims.stream()
-                        .filter(claim -> Objects.equals(claimId, claim.getId()))
-                        .anyMatch(claim -> isPresented(claim, presentedClaimPaths))));
-        if (!satisfiesAnyClaimSet) {
-            throw new VerificationException("Presented mDoc does not satisfy any DCQL claim_sets option");
-        }
+        DcqlClaimSelectionValidator.validate(
+                credential,
+                claim -> {
+                    try {
+                        return isPresented(claim, presentedClaimPaths)
+                                ? DcqlClaimSelectionValidator.ClaimValidationResult.ok()
+                                : DcqlClaimSelectionValidator.ClaimValidationResult.failed(
+                                        "Presented mDoc does not satisfy DCQL claim path: " + claim.getPath());
+                    } catch (VerificationException e) {
+                        return DcqlClaimSelectionValidator.ClaimValidationResult.failed(e.getMessage());
+                    }
+                },
+                "Presented mDoc does not satisfy any DCQL claim_sets option");
     }
 
-    private static boolean isPresented(Claim claim, Set<ClaimPath> presentedClaimPaths) {
+    private static boolean isPresented(Claim claim, Set<ClaimPath> presentedClaimPaths) throws VerificationException {
         List<String> path = claim.getPath();
-        return path != null
-                && path.size() == 2
-                && presentedClaimPaths.contains(new ClaimPath(path.getFirst(), path.get(1)));
+        if (path == null || path.size() != 2) {
+            throw new VerificationException(
+                    "Invalid mDoc claim path: mDoc claims must be [namespace, elementIdentifier], but got: "
+                            + (path == null ? "null" : path));
+        }
+        return presentedClaimPaths.contains(new ClaimPath(path.getFirst(), path.get(1)));
     }
 
     private record PresentedMdoc(String docType, Set<ClaimPath> claimPaths) {}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/SdJwtDcqlCredentialCapability.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/SdJwtDcqlCredentialCapability.java
@@ -8,9 +8,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.prex.SdGenericFormat;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.keycloak.VCFormat;
 import org.keycloak.common.VerificationException;
 import org.keycloak.sdjwt.vp.SdJwtVP;
@@ -76,55 +74,23 @@ public final class SdJwtDcqlCredentialCapability implements DcqlCredentialCapabi
 
     private static void validateRequestedClaims(Credential credential, SdJwtVP presentation)
             throws VerificationException {
-        if (credential.getClaims() == null || credential.getClaims().isEmpty()) {
-            return;
-        }
-
-        Map<String, ClaimValidationResult> claimResults = evaluateClaims(credential.getClaims(), presentation);
-
-        List<List<String>> claimSets = credential.getClaimSets();
-        if (claimSets == null || claimSets.isEmpty()) {
-            for (Claim claim : credential.getClaims()) {
-                ClaimValidationResult result = evaluateClaim(claim, presentation);
-                if (!result.satisfied()) {
-                    throw new VerificationException(result.errorMessage());
-                }
-            }
-            return;
-        }
-
-        if (satisfiesAnyClaimSet(claimSets, claimResults)) {
-            return;
-        }
-        throw new VerificationException("Presented SD-JWT does not satisfy any DCQL claim_sets option");
+        DcqlClaimSelectionValidator.validate(
+                credential,
+                claim -> evaluateClaim(claim, presentation),
+                "Presented SD-JWT does not satisfy any DCQL claim_sets option");
     }
 
-    private static Map<String, ClaimValidationResult> evaluateClaims(List<Claim> claims, SdJwtVP presentation) {
-        Map<String, ClaimValidationResult> claimResults = new HashMap<>();
-        for (Claim claim : claims) {
-            claimResults.put(claim.getId(), evaluateClaim(claim, presentation));
-        }
-        return claimResults;
-    }
-
-    private static boolean satisfiesAnyClaimSet(
-            List<List<String>> claimSets, Map<String, ClaimValidationResult> claimResults) {
-        return claimSets.stream().anyMatch(option -> option.stream()
-                .allMatch(claimId -> claimResults.containsKey(claimId)
-                        && claimResults.get(claimId).satisfied()));
-    }
-
-    private static ClaimValidationResult evaluateClaim(Claim claim, SdJwtVP presentation) {
+    private static DcqlClaimSelectionValidator.ClaimValidationResult evaluateClaim(Claim claim, SdJwtVP presentation) {
         List<JsonNode> selectedClaimValues = ClaimPathResolver.resolveInSdJwt(presentation, claim.getPath());
         if (selectedClaimValues.isEmpty()) {
-            return ClaimValidationResult.failed(
+            return DcqlClaimSelectionValidator.ClaimValidationResult.failed(
                     "Presented SD-JWT does not satisfy DCQL claim path: " + claim.getPath());
         }
         try {
             validateRequestedClaimValues(claim, selectedClaimValues);
-            return ClaimValidationResult.ok();
+            return DcqlClaimSelectionValidator.ClaimValidationResult.ok();
         } catch (VerificationException e) {
-            return ClaimValidationResult.failed(e.getMessage());
+            return DcqlClaimSelectionValidator.ClaimValidationResult.failed(e.getMessage());
         }
     }
 
@@ -141,16 +107,6 @@ public final class SdJwtDcqlCredentialCapability implements DcqlCredentialCapabi
         if (!hasAnyExpectedMatch) {
             throw new VerificationException(
                     "Presented SD-JWT does not satisfy DCQL claim values for path: " + claim.getPath());
-        }
-    }
-
-    private record ClaimValidationResult(boolean satisfied, String errorMessage) {
-        private static ClaimValidationResult ok() {
-            return new ClaimValidationResult(true, null);
-        }
-
-        private static ClaimValidationResult failed(String errorMessage) {
-            return new ClaimValidationResult(false, errorMessage);
         }
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -773,19 +773,25 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
 
     @Test
     public void shouldFailAuthentication_IfMdocRequiredClaimsMissingOrBlank() throws Exception {
-        Map<Map<String, Object>, String> cases = Map.of(
-                Map.of(MdocBaseTest.NAMESPACE, Map.of()),
-                "Missing required claim: com.example.namespace1/username",
-                Map.of(MdocBaseTest.NAMESPACE, Map.of(OAuth2Constants.USERNAME, "")),
-                "Required claim is blank: com.example.namespace1/username");
+        record FailureCase(
+                Map<String, Object> claims, int httpStatus, ProcessingError error, String errorDescription) {}
 
-        for (var entry : cases.entrySet()) {
-            Map<String, Object> mdocClaims = entry.getKey();
-            String expectedError = entry.getValue();
+        List<FailureCase> cases = List.of(
+                new FailureCase(
+                        Map.of(MdocBaseTest.NAMESPACE, Map.of()),
+                        HttpStatus.SC_BAD_REQUEST,
+                        ProcessingError.INVALID_VP_TOKEN,
+                        "Presented mDoc does not satisfy DCQL claim path: [com.example.namespace1, username]"),
+                new FailureCase(
+                        Map.of(MdocBaseTest.NAMESPACE, Map.of(OAuth2Constants.USERNAME, "")),
+                        HttpStatus.SC_UNAUTHORIZED,
+                        ProcessingError.VP_TOKEN_AUTH_ERROR,
+                        "Required claim is blank: com.example.namespace1/username"));
 
+        for (FailureCase failureCase : cases) {
             withAuthenticationProfile(AuthenticationProfileSamples.sdjwtMdocDual(), (apiFlow, requestObject) -> {
                 String sdJwtVpToken = presentSdJwt(requestObject);
-                String mdocToken = presentMdoc(requestObject, mdocClaims);
+                String mdocToken = presentMdoc(requestObject, failureCase.claims());
 
                 TestOpts opts = TestOpts.getDefault()
                         .setAuthContext(apiFlow.authContext())
@@ -795,9 +801,9 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
                 testFailingAuthenticationWithVPTokenMap(
                         Map.of(PRIMARY_CREDENTIAL_ID, sdJwtVpToken, SUPPORTING_CREDENTIAL_ID, mdocToken),
                         opts,
-                        HttpStatus.SC_UNAUTHORIZED,
-                        ProcessingError.VP_TOKEN_AUTH_ERROR.getErrorString(),
-                        expectedError);
+                        failureCase.httpStatus(),
+                        failureCase.error().getErrorString(),
+                        failureCase.errorDescription());
             });
         }
     }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlCredentialCapabilitiesTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/DcqlCredentialCapabilitiesTest.java
@@ -1,7 +1,6 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -79,6 +78,6 @@ class DcqlCredentialCapabilitiesTest {
         DcqlCredentialCapabilities capabilities = DcqlCredentialCapabilities.createDefault();
 
         assertTrue(capabilities.resolve(VCFormat.SD_JWT_VC).supportsPresentationPreValidation());
-        assertFalse(capabilities.resolve("mso_mdoc").supportsPresentationPreValidation());
+        assertTrue(capabilities.resolve("mso_mdoc").supportsPresentationPreValidation());
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
@@ -160,11 +160,14 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
 
     @Test
     void rejectsValidCborButMissingDocType() throws Exception {
-        CBORPairList issuerSigned =
-                new CBORPairList(new CBORPair(new CBORString(MdocConstants.L_NAME_SPACES), new CBORPairList()));
-
-        CBORPairList document =
-                new CBORPairList(new CBORPair(new CBORString(MdocConstants.L_ISSUER_SIGNED), issuerSigned));
+        Document validDocument = extractDocument(buildDeviceResponse());
+        CBORPairList document = new CBORPairList(
+                new CBORPair(
+                        new CBORString(MdocConstants.L_ISSUER_SIGNED),
+                        validDocument.findByKey(MdocConstants.L_ISSUER_SIGNED).getValue()),
+                new CBORPair(
+                        new CBORString(MdocConstants.L_DEVICE_SIGNED),
+                        validDocument.findByKey(MdocConstants.L_DEVICE_SIGNED).getValue()));
 
         CBORItemList documents = new CBORItemList(List.of(document));
         CBORPairList deviceResponse = new CBORPairList(
@@ -181,6 +184,7 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
                 IllegalArgumentException.class,
                 () -> capability.validatePresentation(credential, validCborButInvalidMdoc));
         assertTrue(error.getMessage().contains("Failed to parse"));
+        assertTrue(error.getCause().getMessage().contains("docType"));
     }
 
     @Test
@@ -254,8 +258,15 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
 
     @Test
     void handlesPresentationWithMissingNamespaces() throws Exception {
-        assertDoesNotThrow(
-                () -> capability.validatePresentation(credentialWithClaims(), buildDeviceResponseWithoutNamespaces()));
+        String token = buildDeviceResponseWithoutNamespaces();
+        assertDoesNotThrow(() -> capability.validatePresentation(credentialWithClaims(), token));
+
+        Credential credential = credentialWithClaims(claim("given-name", NAMESPACE, "given_name"));
+        VerificationException error =
+                assertThrows(VerificationException.class, () -> capability.validatePresentation(credential, token));
+        assertEquals(
+                "Presented mDoc does not satisfy DCQL claim path: [com.example.namespace1, given_name]",
+                error.getMessage());
     }
 
     @Test

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
@@ -1,19 +1,148 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.dcql;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocBaseTest;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientMetadata;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.keycloak.VCFormat;
+import org.keycloak.common.VerificationException;
 
-class MdocDcqlCredentialCapabilityTest {
+class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
 
     private final MdocDcqlCredentialCapability capability = new MdocDcqlCredentialCapability();
 
     @Test
     void formatReturnsMsoMdoc() {
         assertEquals("mso_mdoc", capability.format());
+    }
+
+    @Test
+    void reportsPresentationPreValidationSupport() {
+        assertTrue(capability.supportsPresentationPreValidation());
+    }
+
+    @Test
+    void validatesMatchingDocTypeAndRequestedClaims() throws Exception {
+        String token = mdocToken(Map.of(NAMESPACE, Map.of("given_name", "Alice", "family_name", "Smith")), DOC_TYPE);
+        Credential credential = credentialWithClaims(
+                claim("given-name", NAMESPACE, "given_name"), claim("family-name", NAMESPACE, "family_name"));
+
+        assertDoesNotThrow(() -> capability.validatePresentation(credential, token));
+    }
+
+    @Test
+    void validatesIsoSpecSample() {
+        String token = readResource("/mdoc/spec-sample.txt");
+        Credential credential = credentialWithDocTypeAndClaims(
+                "org.iso.18013.5.1.mDL", claim("given-name", "org.iso.18013.5.1", "given_name"));
+
+        assertDoesNotThrow(() -> capability.validatePresentation(credential, token));
+    }
+
+    @Test
+    void validatesPresentationWithNoRequestedClaims() throws Exception {
+        String token = mdocToken(Map.of(NAMESPACE, Map.of("given_name", "Alice")), DOC_TYPE);
+        Credential credential = credentialWithClaims();
+
+        assertDoesNotThrow(() -> capability.validatePresentation(credential, token));
+    }
+
+    @Test
+    void rejectsUnsupportedCredentialFormat() throws Exception {
+        String token = mdocToken(Map.of(NAMESPACE, Map.of("given_name", "Alice")), DOC_TYPE);
+        Credential credential = credentialWithClaims(claim("given-name", NAMESPACE, "given_name"));
+        credential.setFormat(VCFormat.SD_JWT_VC);
+
+        VerificationException error =
+                assertThrows(VerificationException.class, () -> capability.validatePresentation(credential, token));
+        assertEquals(
+                "Unsupported dcql_query credential format for presentation validation: " + VCFormat.SD_JWT_VC,
+                error.getMessage());
+    }
+
+    @Test
+    void rejectsMismatchedDocType() throws Exception {
+        String token = mdocToken(Map.of(NAMESPACE, Map.of("given_name", "Alice")), "com.example.other");
+        Credential credential = credentialWithClaims(claim("given-name", NAMESPACE, "given_name"));
+
+        VerificationException error =
+                assertThrows(VerificationException.class, () -> capability.validatePresentation(credential, token));
+        assertEquals("Presented mDoc docType does not match meta.doctype_value: com.example.other", error.getMessage());
+    }
+
+    @Test
+    void rejectsMissingRequestedClaim() throws Exception {
+        String token = mdocToken(Map.of(NAMESPACE, Map.of("given_name", "Alice")), DOC_TYPE);
+        Credential credential = credentialWithClaims(claim("family-name", NAMESPACE, "family_name"));
+
+        VerificationException error =
+                assertThrows(VerificationException.class, () -> capability.validatePresentation(credential, token));
+        assertEquals(
+                "Presented mDoc does not satisfy DCQL claim path: [com.example.namespace1, family_name]",
+                error.getMessage());
+    }
+
+    @Test
+    void rejectsRequestedClaimFromDifferentNamespace() throws Exception {
+        String token = mdocToken(Map.of(NAMESPACE, Map.of("given_name", "Alice")), DOC_TYPE);
+        Credential credential = credentialWithClaims(claim("given-name", "com.example.other-namespace", "given_name"));
+
+        VerificationException error =
+                assertThrows(VerificationException.class, () -> capability.validatePresentation(credential, token));
+        assertEquals(
+                "Presented mDoc does not satisfy DCQL claim path: [com.example.other-namespace, given_name]",
+                error.getMessage());
+    }
+
+    @Test
+    void validatesClaimSetsWhenOneOptionIsSatisfied() throws Exception {
+        String token = mdocToken(Map.of(NAMESPACE, Map.of("given_name", "Alice")), DOC_TYPE);
+        Claim givenName = claim("given-name", NAMESPACE, "given_name");
+        Claim familyName = claim("family-name", NAMESPACE, "family_name");
+        Credential credential = credentialWithClaims(givenName, familyName);
+        credential.setClaimSets(List.of(List.of("given-name", "family-name"), List.of("given-name")));
+
+        assertDoesNotThrow(() -> capability.validatePresentation(credential, token));
+    }
+
+    @Test
+    void rejectsClaimSetsWhenNoOptionIsSatisfied() throws Exception {
+        String token = mdocToken(Map.of(NAMESPACE, Map.of("given_name", "Alice")), DOC_TYPE);
+        Claim givenName = claim("given-name", NAMESPACE, "given_name");
+        Claim familyName = claim("family-name", NAMESPACE, "family_name");
+        Credential credential = credentialWithClaims(givenName, familyName);
+        credential.setClaimSets(List.of(List.of("given-name", "family-name")));
+
+        VerificationException error =
+                assertThrows(VerificationException.class, () -> capability.validatePresentation(credential, token));
+        assertEquals("Presented mDoc does not satisfy any DCQL claim_sets option", error.getMessage());
+    }
+
+    @Test
+    void doesNotTreatClaimValuesAsSecurityConstraint() throws Exception {
+        String token = mdocToken(Map.of(NAMESPACE, Map.of("given_name", "Alice")), DOC_TYPE);
+        Claim givenName = claim("given-name", NAMESPACE, "given_name");
+        givenName.setValues(List.of("Bob"));
+        Credential credential = credentialWithClaims(givenName);
+
+        assertDoesNotThrow(() -> capability.validatePresentation(credential, token));
+    }
+
+    @Test
+    void rejectsMalformedPresentation() {
+        Credential credential = credentialWithClaims(claim("given-name", NAMESPACE, "given_name"));
+
+        assertThrows(IllegalArgumentException.class, () -> capability.validatePresentation(credential, "not-cbor"));
     }
 
     @Test
@@ -54,5 +183,33 @@ class MdocDcqlCredentialCapabilityTest {
         assertNotNull(vpFormat.getMsoMdoc());
         assertEquals(List.of(-8), vpFormat.getMsoMdoc().getIssuerAuthAlgValues());
         assertEquals(List.of(-8), vpFormat.getMsoMdoc().getDeviceAuthAlgValues());
+    }
+
+    private static String mdocToken(Map<String, Object> claims, String docType) throws Exception {
+        return buildDeviceResponse(getDefaultMdocVerificationOpts().build(), claims, docType)
+                .encodeToBase64Url();
+    }
+
+    private static Credential credentialWithClaims(Claim... claims) {
+        return credentialWithDocTypeAndClaims(DOC_TYPE, claims);
+    }
+
+    private static Credential credentialWithDocTypeAndClaims(String docType, Claim... claims) {
+        Meta meta = new Meta();
+        meta.setDoctypeValue(docType);
+
+        Credential credential = new Credential();
+        credential.setId("mdoc-credential");
+        credential.setFormat("mso_mdoc");
+        credential.setMeta(meta);
+        credential.setClaims(List.of(claims));
+        return credential;
+    }
+
+    private static Claim claim(String id, String namespace, String elementIdentifier) {
+        Claim claim = new Claim();
+        claim.setId(id);
+        claim.setPath(List.of(namespace, elementIdentifier));
+        return claim;
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
@@ -6,6 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.authlete.cbor.CBORInteger;
+import com.authlete.cbor.CBORItem;
+import com.authlete.mdoc.DeviceResponse;
+import com.authlete.mdoc.Document;
+import com.authlete.mdoc.IssuerSigned;
 import com.authlete.cbor.CBORItemList;
 import com.authlete.cbor.CBORPair;
 import com.authlete.cbor.CBORPairList;
@@ -16,6 +21,8 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientMetadata
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Meta;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -160,11 +167,13 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
                 new CBORPairList(new CBORPair(new CBORString(MdocConstants.L_ISSUER_SIGNED), issuerSigned));
 
         CBORItemList documents = new CBORItemList(List.of(document));
-        CBORPairList deviceResponse =
-                new CBORPairList(new CBORPair(new CBORString(MdocConstants.L_DOCUMENTS), documents));
+        CBORPairList deviceResponse = new CBORPairList(
+                new CBORPair(new CBORString("version"), new CBORString("1.0")),
+                new CBORPair(new CBORString(MdocConstants.L_STATUS), new CBORInteger(MdocConstants.V_STATUS_OK)),
+                new CBORPair(new CBORString(MdocConstants.L_DOCUMENTS), documents));
 
         String validCborButInvalidMdoc =
-                java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(deviceResponse.encode());
+                Base64.getUrlEncoder().withoutPadding().encodeToString(deviceResponse.encode());
 
         Credential credential = credentialWithClaims(claim("given-name", NAMESPACE, "given_name"));
 
@@ -217,34 +226,35 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
     @Test
     void rejectsPresentationWithMissingDocumentsField() throws Exception {
         Credential credential = credentialWithClaims();
-        String invalidToken = "omdvY3VtZW50c4A";
-        IllegalArgumentException error = assertThrows(
-                IllegalArgumentException.class, () -> capability.validatePresentation(credential, invalidToken));
-        assertTrue(error.getMessage().contains("Failed to parse"));
+        CBORPairList deviceResponse = new CBORPairList(
+                new CBORPair(new CBORString("version"), new CBORString("1.0")),
+                new CBORPair(new CBORString(MdocConstants.L_STATUS), new CBORInteger(MdocConstants.V_STATUS_OK)));
+        String invalidToken = Base64.getUrlEncoder().withoutPadding().encodeToString(deviceResponse.encode());
+
+        VerificationException error = assertThrows(
+                VerificationException.class, () -> capability.validatePresentation(credential, invalidToken));
+        assertTrue(error.getMessage().contains("missing the documents field"));
     }
 
     @Test
     void rejectsPresentationWithZeroDocuments() throws Exception {
-        IllegalArgumentException error = assertThrows(
-                IllegalArgumentException.class,
+        VerificationException error = assertThrows(
+                VerificationException.class,
                 () -> capability.validatePresentation(credentialWithClaims(), buildDeviceResponseWithDocumentCount(0)));
-        assertTrue(error.getMessage().contains("Failed to parse"));
+        assertTrue(error.getMessage().contains("exactly one document"));
     }
 
     @Test
     void rejectsPresentationWithMultipleDocuments() throws Exception {
-        IllegalArgumentException error = assertThrows(
-                IllegalArgumentException.class,
+        VerificationException error = assertThrows(
+                VerificationException.class,
                 () -> capability.validatePresentation(credentialWithClaims(), buildDeviceResponseWithDocumentCount(2)));
-        assertTrue(error.getMessage().contains("Failed to parse"));
+        assertTrue(error.getMessage().contains("exactly one document"));
     }
 
     @Test
     void handlesPresentationWithMissingNamespaces() throws Exception {
-        IllegalArgumentException error = assertThrows(
-                IllegalArgumentException.class,
-                () -> capability.validatePresentation(credentialWithClaims(), buildDeviceResponseWithoutNamespaces()));
-        assertTrue(error.getMessage().contains("Failed to parse"));
+        assertDoesNotThrow(() -> capability.validatePresentation(credentialWithClaims(), buildDeviceResponseWithoutNamespaces()));
     }
 
     @Test
@@ -317,39 +327,46 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
         return claim;
     }
 
-    private static String buildDeviceResponseWithDocumentCount(int documentCount) throws Exception {
-        List<CBORPairList> documentList = new java.util.ArrayList<>();
+    private String buildDeviceResponseWithDocumentCount(int documentCount) throws Exception {
+        DeviceResponse validDr = buildDeviceResponse();
+        Document validDoc = extractDocument(validDr);
 
+        List<CBORItem> documentList = new ArrayList<>();
         for (int i = 0; i < documentCount; i++) {
-            CBORPairList issuerSigned =
-                    new CBORPairList(new CBORPair(new CBORString(MdocConstants.L_NAME_SPACES), new CBORPairList()));
-
-            CBORPairList document = new CBORPairList(
-                    new CBORPair(new CBORString(MdocConstants.L_DOC_TYPE), new CBORString(DOC_TYPE)),
-                    new CBORPair(new CBORString(MdocConstants.L_ISSUER_SIGNED), issuerSigned));
-
-            documentList.add(document);
+            documentList.add(validDoc);
         }
 
         CBORItemList documents = new CBORItemList(documentList);
-        CBORPairList deviceResponse =
-                new CBORPairList(new CBORPair(new CBORString(MdocConstants.L_DOCUMENTS), documents));
+        CBORPairList deviceResponse = new CBORPairList(
+                new CBORPair(new CBORString("version"), new CBORString("1.0")),
+                new CBORPair(new CBORString(MdocConstants.L_STATUS), new CBORInteger(MdocConstants.V_STATUS_OK)),
+                new CBORPair(new CBORString(MdocConstants.L_DOCUMENTS), documents));
 
-        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(deviceResponse.encode());
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(deviceResponse.encode());
     }
 
-    private static String buildDeviceResponseWithoutNamespaces() throws Exception {
-        CBORPairList issuerSigned = new CBORPairList();
+    private String buildDeviceResponseWithoutNamespaces() throws Exception {
+        DeviceResponse validDr = buildDeviceResponse();
+        Document validDoc = extractDocument(validDr);
 
-        CBORPairList document = new CBORPairList(
-                new CBORPair(new CBORString(MdocConstants.L_DOC_TYPE), new CBORString(DOC_TYPE)),
-                new CBORPair(new CBORString(MdocConstants.L_ISSUER_SIGNED), issuerSigned));
+        IssuerSigned issuerSigned = (IssuerSigned) validDoc.findByKey(MdocConstants.L_ISSUER_SIGNED).getValue();
+        
+        CBORPairList newIssuerSigned = new CBORPairList(
+            new CBORPair(new CBORString(MdocConstants.L_ISSUER_AUTH), issuerSigned.findByKey(MdocConstants.L_ISSUER_AUTH).getValue())
+        );
 
-        CBORItemList documents = new CBORItemList(List.of(document));
+        CBORPairList newDocument = new CBORPairList(
+                new CBORPair(new CBORString(MdocConstants.L_DOC_TYPE), validDoc.findByKey(MdocConstants.L_DOC_TYPE).getValue()),
+                new CBORPair(new CBORString(MdocConstants.L_ISSUER_SIGNED), newIssuerSigned),
+                new CBORPair(new CBORString(MdocConstants.L_DEVICE_SIGNED), validDoc.findByKey(MdocConstants.L_DEVICE_SIGNED).getValue()));
 
-        CBORPairList deviceResponse =
-                new CBORPairList(new CBORPair(new CBORString(MdocConstants.L_DOCUMENTS), documents));
+        CBORItemList documents = new CBORItemList(List.of(newDocument));
 
-        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(deviceResponse.encode());
+        CBORPairList deviceResponse = new CBORPairList(
+                new CBORPair(new CBORString("version"), new CBORString("1.0")),
+                new CBORPair(new CBORString(MdocConstants.L_STATUS), new CBORInteger(MdocConstants.V_STATUS_OK)),
+                new CBORPair(new CBORString(MdocConstants.L_DOCUMENTS), documents));
+
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(deviceResponse.encode());
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
@@ -6,7 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.authlete.cbor.CBORItemList;
+import com.authlete.cbor.CBORPair;
+import com.authlete.cbor.CBORPairList;
+import com.authlete.cbor.CBORString;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocBaseTest;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientMetadata;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Claim;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dcql.Credential;
@@ -66,8 +71,7 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
         VerificationException error =
                 assertThrows(VerificationException.class, () -> capability.validatePresentation(credential, token));
         assertEquals(
-                "Unsupported dcql_query credential format for presentation validation: " + VCFormat.SD_JWT_VC,
-                error.getMessage());
+                "Unsupported dcql_query credential format for presentation validation: dc+sd-jwt", error.getMessage());
     }
 
     @Test
@@ -77,7 +81,9 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
 
         VerificationException error =
                 assertThrows(VerificationException.class, () -> capability.validatePresentation(credential, token));
-        assertEquals("Presented mDoc docType does not match meta.doctype_value: com.example.other", error.getMessage());
+        assertEquals(
+                "Presented mDoc docType does not match meta.doctype_value: expected 'com.example.doctype' but got 'com.example.other'",
+                error.getMessage());
     }
 
     @Test
@@ -146,6 +152,29 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
     }
 
     @Test
+    void rejectsValidCborButMissingDocType() throws Exception {
+        CBORPairList issuerSigned =
+                new CBORPairList(new CBORPair(new CBORString(MdocConstants.L_NAME_SPACES), new CBORPairList()));
+
+        CBORPairList document =
+                new CBORPairList(new CBORPair(new CBORString(MdocConstants.L_ISSUER_SIGNED), issuerSigned));
+
+        CBORItemList documents = new CBORItemList(List.of(document));
+        CBORPairList deviceResponse =
+                new CBORPairList(new CBORPair(new CBORString(MdocConstants.L_DOCUMENTS), documents));
+
+        String validCborButInvalidMdoc =
+                java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(deviceResponse.encode());
+
+        Credential credential = credentialWithClaims(claim("given-name", NAMESPACE, "given_name"));
+
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> capability.validatePresentation(credential, validCborButInvalidMdoc));
+        assertTrue(error.getMessage().contains("Failed to parse"));
+    }
+
+    @Test
     void contributeVpFormatsSupportedConvertsJoseToCoseAlgorithms() {
         ClientMetadata.VpFormat vpFormat = new ClientMetadata.VpFormat();
         capability.contributeVpFormatsSupported(vpFormat, List.of("ES256", "ES384"));
@@ -185,6 +214,81 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
         assertEquals(List.of(-8), vpFormat.getMsoMdoc().getDeviceAuthAlgValues());
     }
 
+    @Test
+    void rejectsPresentationWithMissingDocumentsField() throws Exception {
+        Credential credential = credentialWithClaims();
+        String invalidToken = "omdvY3VtZW50c4A";
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class, () -> capability.validatePresentation(credential, invalidToken));
+        assertTrue(error.getMessage().contains("Failed to parse"));
+    }
+
+    @Test
+    void rejectsPresentationWithZeroDocuments() throws Exception {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> capability.validatePresentation(credentialWithClaims(), buildDeviceResponseWithDocumentCount(0)));
+        assertTrue(error.getMessage().contains("Failed to parse"));
+    }
+
+    @Test
+    void rejectsPresentationWithMultipleDocuments() throws Exception {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> capability.validatePresentation(credentialWithClaims(), buildDeviceResponseWithDocumentCount(2)));
+        assertTrue(error.getMessage().contains("Failed to parse"));
+    }
+
+    @Test
+    void handlesPresentationWithMissingNamespaces() throws Exception {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> capability.validatePresentation(credentialWithClaims(), buildDeviceResponseWithoutNamespaces()));
+        assertTrue(error.getMessage().contains("Failed to parse"));
+    }
+
+    @Test
+    void rejectsClaimPathWithNullPath() throws Exception {
+        Claim claimWithNullPath = new Claim();
+        claimWithNullPath.setId("test-claim");
+        claimWithNullPath.setPath(null);
+        Credential credential = credentialWithClaims(claimWithNullPath);
+        String token = mdocToken(Map.of(), DOC_TYPE);
+
+        VerificationException error =
+                assertThrows(VerificationException.class, () -> capability.validatePresentation(credential, token));
+        assertTrue(error.getMessage().contains("Invalid mDoc claim path"));
+        assertTrue(error.getMessage().contains("null"));
+    }
+
+    @Test
+    void rejectsClaimPathWithSingleElement() throws Exception {
+        String token = mdocToken(Map.of(NAMESPACE, Map.of("given_name", "Alice")), DOC_TYPE);
+        Claim claimWithSingleElement = new Claim();
+        claimWithSingleElement.setId("test-claim");
+        claimWithSingleElement.setPath(List.of("only-one-element"));
+        Credential credential = credentialWithClaims(claimWithSingleElement);
+
+        VerificationException error =
+                assertThrows(VerificationException.class, () -> capability.validatePresentation(credential, token));
+        assertTrue(error.getMessage().contains("Invalid mDoc claim path"));
+        assertTrue(error.getMessage().contains("[only-one-element]"));
+    }
+
+    @Test
+    void rejectsClaimPathWithThreeElements() throws Exception {
+        String token = mdocToken(Map.of(NAMESPACE, Map.of("given_name", "Alice")), DOC_TYPE);
+        Claim claimWithThreeElements = new Claim();
+        claimWithThreeElements.setId("test-claim");
+        claimWithThreeElements.setPath(List.of("one", "two", "three"));
+        Credential credential = credentialWithClaims(claimWithThreeElements);
+
+        VerificationException error =
+                assertThrows(VerificationException.class, () -> capability.validatePresentation(credential, token));
+        assertTrue(error.getMessage().contains("Invalid mDoc claim path"));
+        assertTrue(error.getMessage().contains("[one, two, three]"));
+    }
+
     private static String mdocToken(Map<String, Object> claims, String docType) throws Exception {
         return buildDeviceResponse(getDefaultMdocVerificationOpts().build(), claims, docType)
                 .encodeToBase64Url();
@@ -211,5 +315,41 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
         claim.setId(id);
         claim.setPath(List.of(namespace, elementIdentifier));
         return claim;
+    }
+
+    private static String buildDeviceResponseWithDocumentCount(int documentCount) throws Exception {
+        List<CBORPairList> documentList = new java.util.ArrayList<>();
+
+        for (int i = 0; i < documentCount; i++) {
+            CBORPairList issuerSigned =
+                    new CBORPairList(new CBORPair(new CBORString(MdocConstants.L_NAME_SPACES), new CBORPairList()));
+
+            CBORPairList document = new CBORPairList(
+                    new CBORPair(new CBORString(MdocConstants.L_DOC_TYPE), new CBORString(DOC_TYPE)),
+                    new CBORPair(new CBORString(MdocConstants.L_ISSUER_SIGNED), issuerSigned));
+
+            documentList.add(document);
+        }
+
+        CBORItemList documents = new CBORItemList(documentList);
+        CBORPairList deviceResponse =
+                new CBORPairList(new CBORPair(new CBORString(MdocConstants.L_DOCUMENTS), documents));
+
+        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(deviceResponse.encode());
+    }
+
+    private static String buildDeviceResponseWithoutNamespaces() throws Exception {
+        CBORPairList issuerSigned = new CBORPairList();
+
+        CBORPairList document = new CBORPairList(
+                new CBORPair(new CBORString(MdocConstants.L_DOC_TYPE), new CBORString(DOC_TYPE)),
+                new CBORPair(new CBORString(MdocConstants.L_ISSUER_SIGNED), issuerSigned));
+
+        CBORItemList documents = new CBORItemList(List.of(document));
+
+        CBORPairList deviceResponse =
+                new CBORPairList(new CBORPair(new CBORString(MdocConstants.L_DOCUMENTS), documents));
+
+        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(deviceResponse.encode());
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
@@ -8,13 +8,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.authlete.cbor.CBORInteger;
 import com.authlete.cbor.CBORItem;
-import com.authlete.mdoc.DeviceResponse;
-import com.authlete.mdoc.Document;
-import com.authlete.mdoc.IssuerSigned;
 import com.authlete.cbor.CBORItemList;
 import com.authlete.cbor.CBORPair;
 import com.authlete.cbor.CBORPairList;
 import com.authlete.cbor.CBORString;
+import com.authlete.mdoc.DeviceResponse;
+import com.authlete.mdoc.Document;
+import com.authlete.mdoc.IssuerSigned;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocBaseTest;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocConstants;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientMetadata;
@@ -254,7 +254,8 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
 
     @Test
     void handlesPresentationWithMissingNamespaces() throws Exception {
-        assertDoesNotThrow(() -> capability.validatePresentation(credentialWithClaims(), buildDeviceResponseWithoutNamespaces()));
+        assertDoesNotThrow(
+                () -> capability.validatePresentation(credentialWithClaims(), buildDeviceResponseWithoutNamespaces()));
     }
 
     @Test
@@ -349,16 +350,21 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
         DeviceResponse validDr = buildDeviceResponse();
         Document validDoc = extractDocument(validDr);
 
-        IssuerSigned issuerSigned = (IssuerSigned) validDoc.findByKey(MdocConstants.L_ISSUER_SIGNED).getValue();
-        
-        CBORPairList newIssuerSigned = new CBORPairList(
-            new CBORPair(new CBORString(MdocConstants.L_ISSUER_AUTH), issuerSigned.findByKey(MdocConstants.L_ISSUER_AUTH).getValue())
-        );
+        IssuerSigned issuerSigned =
+                (IssuerSigned) validDoc.findByKey(MdocConstants.L_ISSUER_SIGNED).getValue();
+
+        CBORPairList newIssuerSigned = new CBORPairList(new CBORPair(
+                new CBORString(MdocConstants.L_ISSUER_AUTH),
+                issuerSigned.findByKey(MdocConstants.L_ISSUER_AUTH).getValue()));
 
         CBORPairList newDocument = new CBORPairList(
-                new CBORPair(new CBORString(MdocConstants.L_DOC_TYPE), validDoc.findByKey(MdocConstants.L_DOC_TYPE).getValue()),
+                new CBORPair(
+                        new CBORString(MdocConstants.L_DOC_TYPE),
+                        validDoc.findByKey(MdocConstants.L_DOC_TYPE).getValue()),
                 new CBORPair(new CBORString(MdocConstants.L_ISSUER_SIGNED), newIssuerSigned),
-                new CBORPair(new CBORString(MdocConstants.L_DEVICE_SIGNED), validDoc.findByKey(MdocConstants.L_DEVICE_SIGNED).getValue()));
+                new CBORPair(
+                        new CBORString(MdocConstants.L_DEVICE_SIGNED),
+                        validDoc.findByKey(MdocConstants.L_DEVICE_SIGNED).getValue()));
 
         CBORItemList documents = new CBORItemList(List.of(newDocument));
 


### PR DESCRIPTION
Add format-specific DCQL presentation pre-validation for `mso_mdoc` credential queries using the capability architecture introduced in #134.

The verifier now rejects mDoc presentations early when the presented `DeviceResponse` does not satisfy the corresponding DCQL credential query.

## Implementation

- Enable presentation pre-validation for the mDoc DCQL capability.
- Decode the base64url-encoded mDoc `DeviceResponse`.
- Require exactly one presented Document for each DCQL credential response.
- Validate the presented Document `docType` against `meta.doctype_value`.
- Extract issuer-signed data-element paths from `IssuerSigned.nameSpaces`.
- Validate exact `[namespace, elementIdentifier]` claim paths.
- Require every requested claim when `claim_sets` is absent.
- Accept any complete alternative when `claim_sets` is present.
- Treat claim `values` as a best-effort privacy hint rather than a security constraint, as required by OpenID4VP Final 1.0.
- Preserve cryptographic verification, digest validation, trust validation, validity checks, and device binding in the existing mDoc credential verifier.

closes #117
