### PR TITLE
Relocate jar build and shade to maven phase process-classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Confirmed support for OpenID4VP 1.0 is pending further updates, review, and test
 
 ## Build the Plugin
 
-To compile the plugin without running tests (recommended for a first-time build), run:
+To compile the plugin without running tests, run:
 
 ```sh
 ./mvnw clean package -DskipTests
@@ -53,6 +53,11 @@ If you want to run the tests, make sure **Docker is installed and running** beca
 ```sh
 ./mvnw clean verify
 ```
+
+Running the tests from an IDE such as IntelliJ may fail if the JAR has not been built first. By default,
+the IDE does not delegate the build to Maven and therefore does not produce the JAR that the tests deploy
+into the Keycloak container. Build the JAR explicitly (as described above) before running the tests from
+the IDE.
 
 ## Deploying the Plugin
 

--- a/pom.xml
+++ b/pom.xml
@@ -223,12 +223,31 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.12.0</version>
+                <configuration>
+                    <doclint>none</doclint>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.4.2</version>
                 <executions>
                     <execution>
                         <id>default-jar</id>
-                        <phase>process-test-classes</phase>
+                        <!-- Bound to process-classes so the (shaded) fat JAR is produced before tests run: the
+                             integration tests deploy this JAR into a Keycloak container. The fat JAR is also
+                             the released artifact for convenience. -->
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>
@@ -241,7 +260,7 @@
                 <version>3.6.2</version>
                 <executions>
                     <execution>
-                        <phase>process-test-classes</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
@@ -261,29 +280,18 @@
                                 <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.12.0</version>
-                <configuration>
-                    <doclint>none</doclint>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Closes #125 

**Requirement:** the plugin must produce a fat jar before running tests, because integration tests deploy that jar into a Keycloak container. A previous PR silently addressed this by binding the JAR and shade goals to process-test-classes. Also, the final release JAR was already made a fat jar by #132.                                                                 
                                                                                                               
**This PR moves that relocation one phase earlier:**                          
- maven-jar-plugin (default-jar) and maven-shade-plugin (shade) now bind to `process-classes` instead of `process-test-classes`.                                                                                         
- The fat jar is built immediately after main classes are compiled, no longer coupled to the `test-compile` lifecycle.                                                                                                  
- This makes the intent explicit: the fat jar is required even when tests are skipped (-DskipTests), and it now covers builds that stop short of `process-test-classes`.                   
                                                                                                               
Manifest handling (minor but important):                                                                        
                                                                                                               
- Exclude META-INF/MANIFEST.MF from shaded dependencies (prevents an arbitrary dependency manifest from winning).                                                                                                     
- Add ManifestResourceTransformer so the shaded jar carries a single, correct manifest (preserving the project's).
- Add ServicesResourceTransformer so META-INF/services provider files from shaded dependencies are merged rather than overridden -- relevant for Keycloak SPI/provider discovery.

**Testing:** `./mvnw clean package` completes successfully.

Note for IDE users: Running tests directly from IntelliJ will not automatically produce this fat jar, since the IDE compiles without the Maven lifecycle by default. To get the jar, either delegate build/run to Maven or run mvn package manually first. This should be okay.