### PR TITLE
 fix(oid4vp): make primary credential identity claims configurable

### DIFF
--- a/docs/modules/ROOT/pages/german-wallet-pid-verification-configuration.adoc
+++ b/docs/modules/ROOT/pages/german-wallet-pid-verification-configuration.adoc
@@ -181,55 +181,9 @@ Use a single-credential profile when only a self-issued primary credential is re
 
 == Primary credential identity claim configuration
 
-A primary credential must carry at least one claim that identifies the Keycloak user.
-Two optional properties control which claims are used for user resolution:
+When a primary mDoc credential identifies the Keycloak user, use a namespaced `subjectClaim` (e.g. `eu.europa.ec.eudi.pid.1/personal_administrative_number`) rather than a bare element like `document_number`, which may not be globally unique across issuers.
 
-`subjectClaim`::
-  The claim used to resolve the Keycloak user by *user id*.
-  Defaults to `sub`.
-
-`usernameClaim`::
-  An optional fallback claim used to resolve the Keycloak user by *username* when `subjectClaim` does not match a Keycloak user id.
-  Defaults to `username`.
-  Omit or set to blank to skip the username fallback.
-
-For mDoc credentials, claims are namespaced using the `namespace/element` format defined by ISO 18013-5.
-For example, a PID mDoc identifies a person by:
-
-[source,text]
-----
-namespace: eu.europa.ec.eudi.pid.1
-element:   given_name
-Namespaced form: eu.europa.ec.eudi.pid.1/given_name
-----
-
-When configuring a primary mDoc credential for authentication, set `subjectClaim` to a namespaced claim that uniquely identifies the user (e.g. `eu.europa.ec.eudi.pid.1/personal_administrative_number`).
-Do *not* set `subjectClaim` to a bare element like `document_number` unless it is globally unique across issuers.
-
-The following example shows the identity claim configuration for a primary mDoc credential.
-The `trust` configuration is omitted for brevity — refer to the x5c trust or EUDI PID trust-list sections above.
-
-[source,json]
-----
-{
-  "id": "main",
-  "role": "primary",
-  "format": "mso_mdoc",
-  "credentialTypes": [
-    "eu.europa.ec.eudi.pid.1"
-  ],
-  "subjectClaim": "eu.europa.ec.eudi.pid.1/personal_administrative_number",
-  "usernameClaim": "eu.europa.ec.eudi.pid.1/given_name",
-  "claims": [
-    "eu.europa.ec.eudi.pid.1/personal_administrative_number",
-    "eu.europa.ec.eudi.pid.1/given_name",
-    "eu.europa.ec.eudi.pid.1/family_name"
-  ],
-  "trust": [ ... ]
-}
-----
-
-For SD-JWT VC credentials, use standard claim names such as `sub` and `username` — no namespace is needed.
+For full details on `subjectClaim`, `usernameClaim`, and the namespace/element format, see xref:oid4vp-deployment-configuration.adoc#oid4vp-deployment-configuration[OpenID4VP deployment configuration reference — Configuring primary credential identity claims].
 
 == Authentication flow
 

--- a/docs/modules/ROOT/pages/german-wallet-pid-verification-configuration.adoc
+++ b/docs/modules/ROOT/pages/german-wallet-pid-verification-configuration.adoc
@@ -179,6 +179,58 @@ Use a single-credential profile when only a self-issued primary credential is re
 ]
 ----
 
+== Primary credential identity claim configuration
+
+A primary credential must carry at least one claim that identifies the Keycloak user.
+Two optional properties control which claims are used for user resolution:
+
+`subjectClaim`::
+  The claim used to resolve the Keycloak user by *user id*.
+  Defaults to `sub`.
+
+`usernameClaim`::
+  An optional fallback claim used to resolve the Keycloak user by *username* when `subjectClaim` does not match a Keycloak user id.
+  Defaults to `username`.
+  Omit or set to blank to skip the username fallback.
+
+For mDoc credentials, claims are namespaced using the `namespace/element` format defined by ISO 18013-5.
+For example, a PID mDoc identifies a person by:
+
+[source,text]
+----
+namespace: eu.europa.ec.eudi.pid.1
+element:   given_name
+Namespaced form: eu.europa.ec.eudi.pid.1/given_name
+----
+
+When configuring a primary mDoc credential for authentication, set `subjectClaim` to a namespaced claim that uniquely identifies the user (e.g. `eu.europa.ec.eudi.pid.1/personal_administrative_number`).
+Do *not* set `subjectClaim` to a bare element like `document_number` unless it is globally unique across issuers.
+
+The following example shows the identity claim configuration for a primary mDoc credential.
+The `trust` configuration is omitted for brevity — refer to the x5c trust or EUDI PID trust-list sections above.
+
+[source,json]
+----
+{
+  "id": "main",
+  "role": "primary",
+  "format": "mso_mdoc",
+  "credentialTypes": [
+    "eu.europa.ec.eudi.pid.1"
+  ],
+  "subjectClaim": "eu.europa.ec.eudi.pid.1/personal_administrative_number",
+  "usernameClaim": "eu.europa.ec.eudi.pid.1/given_name",
+  "claims": [
+    "eu.europa.ec.eudi.pid.1/personal_administrative_number",
+    "eu.europa.ec.eudi.pid.1/given_name",
+    "eu.europa.ec.eudi.pid.1/family_name"
+  ],
+  "trust": [ ... ]
+}
+----
+
+For SD-JWT VC credentials, use standard claim names such as `sub` and `username` — no namespace is needed.
+
 == Authentication flow
 
 At runtime:

--- a/docs/modules/ROOT/pages/oid4vp-deployment-configuration.adoc
+++ b/docs/modules/ROOT/pages/oid4vp-deployment-configuration.adoc
@@ -66,6 +66,57 @@ Generic example authenticator configuration (realm JSON import format):
 If you provision Keycloak using Terraform or similar tooling, map these settings to your own
 module/input variable names according to your deployment conventions.
 
+=== Configuring primary credential identity claims
+
+When the primary credential is used to identify the Keycloak user, two optional properties control which claims are used for user resolution.
+
+`subjectClaim`::
+  The claim used to resolve the Keycloak user by *user id*.
+  Defaults to `sub`.
+
+`usernameClaim`::
+  An optional fallback claim used to resolve the Keycloak user by *username* when `subjectClaim` does not match a Keycloak user id.
+  Defaults to `username`.
+  Omit or set to blank to skip the username fallback.
+
+For mDoc credentials, claims are namespaced using the `namespace/element` format defined by ISO 18013-5.
+For example, a PID mDoc identifies a person by:
+
+[source,text]
+----
+namespace: eu.europa.ec.eudi.pid.1
+element:   given_name
+Namespaced form: eu.europa.ec.eudi.pid.1/given_name
+----
+
+When configuring a primary mDoc credential for authentication, set `subjectClaim` to a namespaced claim that uniquely identifies the user (e.g. `eu.europa.ec.eudi.pid.1/personal_administrative_number`).
+Do *not* set `subjectClaim` to a bare element like `document_number` unless it is globally unique across issuers.
+
+The following example shows the identity claim configuration for a primary mDoc credential.
+The `trust` configuration is omitted for brevity — refer to the trust configuration sections above.
+
+[source,json]
+----
+{
+  "id": "main",
+  "role": "primary",
+  "format": "mso_mdoc",
+  "credentialTypes": [
+    "eu.europa.ec.eudi.pid.1"
+  ],
+  "subjectClaim": "eu.europa.ec.eudi.pid.1/personal_administrative_number",
+  "usernameClaim": "eu.europa.ec.eudi.pid.1/given_name",
+  "claims": [
+    "eu.europa.ec.eudi.pid.1/personal_administrative_number",
+    "eu.europa.ec.eudi.pid.1/given_name",
+    "eu.europa.ec.eudi.pid.1/family_name"
+  ],
+  "trust": [ ... ]
+}
+----
+
+For SD-JWT VC credentials, use standard claim names such as `sub` and `username` — no namespace is needed.
+
 === SPRIN-D wallet sandbox profile (example)
 
 For the German wallet ecosystem profile (HAIP/OpenID4VP PID presentation), use the

--- a/docs/modules/ROOT/pages/oid4vp-user-authentication.adoc
+++ b/docs/modules/ROOT/pages/oid4vp-user-authentication.adoc
@@ -110,31 +110,9 @@ For detailed deployment options (`x509_hash`, `direct_post.jwt`, injected certif
 
 === Configuring primary credential identity claims
 
-When the primary credential is used to identify the Keycloak user, two optional properties control which claims are used for user resolution.
+When a primary credential is used to identify the Keycloak user, use `subjectClaim` and `usernameClaim` to control which claims are read from the presented credential.
 
-`subjectClaim`::
-  The claim used to resolve the Keycloak user by *user id*.
-  Defaults to `sub`.
-
-`usernameClaim`::
-  An optional fallback claim used to resolve the Keycloak user by *username* when `subjectClaim` does not match a Keycloak user id.
-  Defaults to `username`.
-  Omit or set to blank to skip the username fallback.
-
-For mDoc credentials, claims are namespaced using the `namespace/element` format defined by ISO 18013-5.
-For example, a PID mDoc identifies a person by:
-
-[source,text]
-----
-namespace: eu.europa.ec.eudi.pid.1
-element:   given_name
-Namespaced form: eu.europa.ec.eudi.pid.1/given_name
-----
-
-When setting `subjectClaim` for an mDoc primary credential, use a namespaced claim that uniquely identifies the user (e.g. `eu.europa.ec.eudi.pid.1/personal_administrative_number`).
-Do *not* set `subjectClaim` to a bare element like `document_number` unless it is globally unique across issuers.
-
-For SD-JWT VC credentials, use standard claim names such as `sub` and `username` — no namespace is needed.
+For the full configuration reference — including the mDoc namespace/element format, defaults, and examples — see link:oid4vp-deployment-configuration.adoc[OpenID4VP deployment configuration reference — Configuring primary credential identity claims].
 
 === Technical Configuration (Performance & Security)
 

--- a/docs/modules/ROOT/pages/oid4vp-user-authentication.adoc
+++ b/docs/modules/ROOT/pages/oid4vp-user-authentication.adoc
@@ -108,6 +108,34 @@ The single SdJwt authenticator in the flow is pre-configured with sensible defau
 These policy settings are deployed through the same authenticator configuration surface.
 For detailed deployment options (`x509_hash`, `direct_post.jwt`, injected certificates, and infrastructure-as-code mapping guidance), see link:oid4vp-deployment-configuration.adoc[OpenID4VP deployment configuration reference].
 
+=== Configuring primary credential identity claims
+
+When the primary credential is used to identify the Keycloak user, two optional properties control which claims are used for user resolution.
+
+`subjectClaim`::
+  The claim used to resolve the Keycloak user by *user id*.
+  Defaults to `sub`.
+
+`usernameClaim`::
+  An optional fallback claim used to resolve the Keycloak user by *username* when `subjectClaim` does not match a Keycloak user id.
+  Defaults to `username`.
+  Omit or set to blank to skip the username fallback.
+
+For mDoc credentials, claims are namespaced using the `namespace/element` format defined by ISO 18013-5.
+For example, a PID mDoc identifies a person by:
+
+[source,text]
+----
+namespace: eu.europa.ec.eudi.pid.1
+element:   given_name
+Namespaced form: eu.europa.ec.eudi.pid.1/given_name
+----
+
+When setting `subjectClaim` for an mDoc primary credential, use a namespaced claim that uniquely identifies the user (e.g. `eu.europa.ec.eudi.pid.1/personal_administrative_number`).
+Do *not* set `subjectClaim` to a bare element like `document_number` unless it is globally unique across issuers.
+
+For SD-JWT VC credentials, use standard claim names such as `sub` and `username` — no namespace is needed.
+
 === Technical Configuration (Performance & Security)
 
 For details on certificate caching, lifespan, and other performance/security configurations, see link:non-functional-requirements.adoc[Non-Functional Requirements & Technical Configuration].

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.jboss.logging.Logger;
-import org.keycloak.OAuth2Constants;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.Authenticator;
@@ -33,7 +32,6 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
-import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.JsonSerialization;
@@ -255,8 +253,8 @@ public class OID4VPAuthenticator implements Authenticator {
     private UserModel recoverUserFromClaims(
             Context ctx, CredentialRequirement primaryCredentialReq, JsonNode primaryClaims) {
         CredentialVerifier verifier = ctx.credentialVerifiers().get(primaryCredentialReq.getId());
-        String subject = verifier.readClaim(primaryClaims, JsonWebToken.SUBJECT);
-        String username = verifier.readClaim(primaryClaims, OAuth2Constants.USERNAME);
+        String subject = verifier.readClaim(primaryClaims, primaryCredentialReq.getSubjectClaim());
+        String username = verifier.readClaim(primaryClaims, primaryCredentialReq.getUsernameClaim());
         logger.debugf("Attempting user recovery with subject '%s' and username '%s'", subject, username);
 
         KeycloakSession session = ctx.authenticationFlowContext().getSession();

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/CredentialRequirement.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/CredentialRequirement.java
@@ -2,7 +2,9 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import org.keycloak.OAuth2Constants;
 import org.keycloak.VCFormat;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.utils.StringUtil;
 
 public class CredentialRequirement {
@@ -33,6 +35,20 @@ public class CredentialRequirement {
 
     @JsonProperty("claims")
     private List<String> claims;
+
+    /**
+     * Claim (optionally namespaced, e.g. {@code "org.iso.18013.5.1/document_number"}) carrying the
+     * credential subject used to resolve the Keycloak user by user id. Defaults to {@code sub}.
+     */
+    @JsonProperty("subjectClaim")
+    private String subjectClaim = JsonWebToken.SUBJECT;
+
+    /**
+     * Claim (optionally namespaced, e.g. {@code "org.iso.18013.5.1/document_number"}) carrying the
+     * credential subject used to resolve the Keycloak user by username. Defaults to {@code username}.
+     */
+    @JsonProperty("usernameClaim")
+    private String usernameClaim = OAuth2Constants.USERNAME;
 
     @JsonProperty("trust")
     private List<TrustPolicy> trust = List.of(new TrustPolicy());
@@ -95,6 +111,24 @@ public class CredentialRequirement {
 
     public CredentialRequirement setClaims(List<String> claims) {
         this.claims = claims;
+        return this;
+    }
+
+    public String getSubjectClaim() {
+        return subjectClaim;
+    }
+
+    public CredentialRequirement setSubjectClaim(String subjectClaim) {
+        this.subjectClaim = subjectClaim;
+        return this;
+    }
+
+    public String getUsernameClaim() {
+        return usernameClaim;
+    }
+
+    public CredentialRequirement setUsernameClaim(String usernameClaim) {
+        this.usernameClaim = usernameClaim;
         return this;
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/CredentialRequirement.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/CredentialRequirement.java
@@ -39,13 +39,16 @@ public class CredentialRequirement {
     /**
      * Claim (optionally namespaced, e.g. {@code "org.iso.18013.5.1/document_number"}) carrying the
      * credential subject used to resolve the Keycloak user by user id. Defaults to {@code sub}.
+     * Required for login credentials.
      */
     @JsonProperty("subjectClaim")
     private String subjectClaim = JsonWebToken.SUBJECT;
 
     /**
-     * Claim (optionally namespaced, e.g. {@code "org.iso.18013.5.1/document_number"}) carrying the
-     * credential subject used to resolve the Keycloak user by username. Defaults to {@code username}.
+     * Optional claim (optionally namespaced) used as a fallback to resolve the Keycloak user by
+     * username when {@code subjectClaim} does not match a user ID. Defaults to {@code username}.
+     * Set to blank or omit to skip the username fallback (subjectClaim alone is sufficient).
+     * Temporary workaround until the SubjectID mapper is in place.
      */
     @JsonProperty("usernameClaim")
     private String usernameClaim = OAuth2Constants.USERNAME;

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfig.java
@@ -382,7 +382,8 @@ public class OID4VPProfileConfig {
      *
      * <ul>
      *   <li>{@code credential} (login): the identity is derived from the presented credential, so it must
-     *       request {@code sub} and {@code username}.
+     *       request the configured identity claims ({@link CredentialRequirement#getSubjectClaim()} and
+     *       {@link CredentialRequirement#getUsernameClaim()}, defaulting to {@code sub} and {@code username}).
      *   <li>{@code session} (presentation during issuance): the identity comes from the brokered offer
      *       user, so {@code sub}/{@code username} are not required; instead binding rules are mandatory so
      *       the presented credential is actually matched against the user (otherwise the presentation
@@ -398,12 +399,39 @@ public class OID4VPProfileConfig {
             }
             return;
         }
-        List<ClaimReference> primaryRefs = credential.getClaimReferences();
-        boolean hasSubject = primaryRefs.stream().anyMatch(ref -> JsonWebToken.SUBJECT.equals(ref.name()));
-        boolean hasUsername = primaryRefs.stream().anyMatch(ref -> OAuth2Constants.USERNAME.equals(ref.name()));
-        if (!hasSubject || !hasUsername) {
-            throw new IllegalStateException("OpenID4VP primary credential must request sub and username: "
-                    + profile.getId() + "/" + credential.getId());
+        if (StringUtil.isBlank(credential.getSubjectClaim()) || StringUtil.isBlank(credential.getUsernameClaim())) {
+            throw new IllegalStateException(
+                    "OpenID4VP primary credential subjectClaim and usernameClaim must not be blank: " + profile.getId()
+                            + "/" + credential.getId());
         }
+        List<ClaimReference> primaryRefs = credential.getClaimReferences();
+        ClaimReference subjectRef = ClaimReference.parse(credential.getSubjectClaim());
+        ClaimReference usernameRef = ClaimReference.parse(credential.getUsernameClaim());
+        boolean hasSubject = containsIdentityClaim(primaryRefs, subjectRef);
+        boolean hasUsername = containsIdentityClaim(primaryRefs, usernameRef);
+        if (!hasSubject || !hasUsername) {
+            String message = isDefaultIdentityClaims(credential)
+                    ? "OpenID4VP primary credential must request sub and username"
+                    : "OpenID4VP primary credential must request identity claims " + subjectRef + " and " + usernameRef;
+            throw new IllegalStateException(message + ": " + profile.getId() + "/" + credential.getId());
+        }
+    }
+
+    private static boolean isDefaultIdentityClaims(CredentialRequirement credential) {
+        return JsonWebToken.SUBJECT.equals(credential.getSubjectClaim())
+                && OAuth2Constants.USERNAME.equals(credential.getUsernameClaim());
+    }
+
+    /**
+     * Whether {@code refs} contains the configured identity claim. An un-namespaced configured claim
+     * matches by name under any namespace (so mDoc profiles requesting e.g.
+     * {@code org.iso.18013.5.1/sub} still satisfy the default {@code sub}); a namespaced configured
+     * claim must match the exact namespace/name pair.
+     */
+    private static boolean containsIdentityClaim(List<ClaimReference> refs, ClaimReference configured) {
+        if (configured.isNamespaced()) {
+            return refs.contains(configured);
+        }
+        return refs.stream().anyMatch(ref -> configured.name().equals(ref.name()));
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfig.java
@@ -399,27 +399,43 @@ public class OID4VPProfileConfig {
             }
             return;
         }
-        if (StringUtil.isBlank(credential.getSubjectClaim()) || StringUtil.isBlank(credential.getUsernameClaim())) {
-            throw new IllegalStateException(
-                    "OpenID4VP primary credential subjectClaim and usernameClaim must not be blank: " + profile.getId()
-                            + "/" + credential.getId());
+        if (StringUtil.isBlank(credential.getSubjectClaim())) {
+            throw new IllegalStateException("OpenID4VP primary credential subjectClaim must not be blank: "
+                    + profile.getId() + "/" + credential.getId());
         }
-        List<ClaimReference> primaryRefs = credential.getClaimReferences();
-        ClaimReference subjectRef = ClaimReference.parse(credential.getSubjectClaim());
-        ClaimReference usernameRef = ClaimReference.parse(credential.getUsernameClaim());
-        boolean hasSubject = containsIdentityClaim(primaryRefs, subjectRef);
-        boolean hasUsername = containsIdentityClaim(primaryRefs, usernameRef);
-        if (!hasSubject || !hasUsername) {
-            String message = isDefaultIdentityClaims(credential)
-                    ? "OpenID4VP primary credential must request sub and username"
-                    : "OpenID4VP primary credential must request identity claims " + subjectRef + " and " + usernameRef;
-            throw new IllegalStateException(message + ": " + profile.getId() + "/" + credential.getId());
-        }
-    }
 
-    private static boolean isDefaultIdentityClaims(CredentialRequirement credential) {
-        return JsonWebToken.SUBJECT.equals(credential.getSubjectClaim())
-                && OAuth2Constants.USERNAME.equals(credential.getUsernameClaim());
+        boolean isMdoc = CredentialFormat.MSO_MDOC.getValue().equals(credential.getFormat());
+
+        ClaimReference subjectRef = ClaimReference.parse(credential.getSubjectClaim());
+        if (isMdoc && !subjectRef.isNamespaced()) {
+            throw new IllegalStateException(
+                    "mDoc primary credential subjectClaim must be namespace-qualified (\"namespace/name\")," + " got: "
+                            + subjectRef + ": " + profile.getId() + "/" + credential.getId());
+        }
+
+        ClaimReference usernameRef = null;
+        if (StringUtil.isNotBlank(credential.getUsernameClaim())) {
+            usernameRef = ClaimReference.parse(credential.getUsernameClaim());
+            if (isMdoc && !usernameRef.isNamespaced()) {
+                throw new IllegalStateException(
+                        "mDoc primary credential usernameClaim must be namespace-qualified (\"namespace/name\"),"
+                                + " got: " + usernameRef + ": " + profile.getId() + "/" + credential.getId());
+            }
+        }
+
+        List<ClaimReference> primaryRefs = credential.getClaimReferences();
+        boolean hasSubject = containsIdentityClaim(primaryRefs, subjectRef);
+        boolean hasUsername = true;
+        if (usernameRef != null) {
+            hasUsername = containsIdentityClaim(primaryRefs, usernameRef);
+        }
+        if (!hasSubject || !hasUsername) {
+            String required = usernameRef != null
+                    ? "subjectClaim='" + subjectRef + "' and usernameClaim='" + usernameRef + "'"
+                    : "subjectClaim='" + subjectRef + "'";
+            throw new IllegalStateException("OpenID4VP primary credential must request identity claims " + required
+                    + ": " + profile.getId() + "/" + credential.getId());
+        }
     }
 
     /**

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/AuthenticationProfileSamples.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/AuthenticationProfileSamples.java
@@ -107,6 +107,8 @@ public final class AuthenticationProfileSamples {
                         "format": "mso_mdoc",
                         "credentialTypes": ["{docType}"],
                         "claims": ["{namespace}/sub", "{namespace}/username"],
+                        "subjectClaim": "{namespace}/sub",
+                        "usernameClaim": "{namespace}/username",
                         "trust": [
                           { "type": "x5c", "anchors": ["{anchorBase64}"] }
                         ]

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/AuthenticationProfileSamples.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/AuthenticationProfileSamples.java
@@ -121,6 +121,47 @@ public final class AuthenticationProfileSamples {
         return new ProfileSample(json, MDOC_PRIMARY_PROFILE_ID);
     }
 
+    /**
+     * Single primary mso_mdoc credential whose identity is derived from the standard ISO 18013-5
+     * mDL {@code document_number} claim instead of {@code sub}/{@code username} (issue 001).
+     */
+    public static ProfileSample mdocPrimaryWithMdlIdentity() {
+        return mdocPrimaryWithMdlIdentity(MdocBaseTest.getIssuerCertBase64());
+    }
+
+    /**
+     * Like {@link #mdocPrimaryWithMdlIdentity()} but secures the primary mDoc credential with the
+     * given x5c trust anchor (Base64) instead of the default issuer certificate.
+     */
+    public static ProfileSample mdocPrimaryWithMdlIdentity(String anchorBase64) {
+        String json = """
+                [
+                  {
+                    "id": "{mdocPrimaryProfileId}",
+                    "displayCta": { "en": "Sign in with an mDoc wallet" },
+                    "credentials": [
+                      {
+                        "id": "primary",
+                        "role": "primary",
+                        "format": "mso_mdoc",
+                        "credentialTypes": ["{docType}"],
+                        "claims": ["{namespace}/document_number", "{namespace}/given_name"],
+                        "subjectClaim": "{namespace}/document_number",
+                        "usernameClaim": "{namespace}/document_number",
+                        "trust": [
+                          { "type": "x5c", "anchors": ["{anchorBase64}"] }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+                """.replace("{mdocPrimaryProfileId}", MDOC_PRIMARY_PROFILE_ID)
+                .replace("{docType}", MdocBaseTest.DOC_TYPE)
+                .replace("{namespace}", MdocBaseTest.NAMESPACE)
+                .replace("{anchorBase64}", anchorBase64);
+        return new ProfileSample(json, MDOC_PRIMARY_PROFILE_ID);
+    }
+
     /** SD-JWT primary + mso_mdoc supporting, x5c-trusted, bound on username. */
     public static ProfileSample sdjwtMdocDual() {
         String json = """

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -381,6 +381,26 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
     }
 
     @Test
+    public void shouldAuthenticateSuccessfully_WithMdocPrimaryCredential_MdlIdentityClaim() throws Exception {
+        // Regression for issue 001: a standard ISO 18013-5 mDL carries no sub/username claims, so
+        // identity must be derivable from a configured standard mDL claim (document_number). The
+        // presented mDoc below deliberately contains no sub/username claims.
+        withAuthenticationProfile(
+                AuthenticationProfileSamples.mdocPrimaryWithMdlIdentity(), (apiFlow, requestObject) -> {
+                    Map<String, Object> mdocClaims =
+                            Map.of(MdocBaseTest.NAMESPACE, Map.of("document_number", TEST_USER, "given_name", "Alice"));
+                    String mdocToken = presentMdoc(requestObject, mdocClaims);
+
+                    TestOpts opts = TestOpts.getDefault()
+                            .setAuthContext(apiFlow.authContext())
+                            .setCodeVerifier(apiFlow.codeVerifier())
+                            .setShouldForceUnencryptedResponse(true);
+
+                    testSuccessfulAuthenticationWithVPTokenMap(Map.of(PRIMARY_CREDENTIAL_ID, mdocToken), opts);
+                });
+    }
+
+    @Test
     public void shouldAuthenticateSuccessfully_WithMdocPrimaryCredential_EncryptedResponse_IsoTranscript()
             throws Exception {
         // Wallet-generated nonce, conveyed Base64URL-encoded in the JWE `apu` header. The server

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -385,6 +385,11 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
         // Regression for issue 001: a standard ISO 18013-5 mDL carries no sub/username claims, so
         // identity must be derivable from a configured standard mDL claim (document_number). The
         // presented mDoc below deliberately contains no sub/username claims.
+        //
+        // Both subjectClaim and usernameClaim resolve to the same value (TEST_USER = document_number)
+        // because mDocs have only one identity value. Authentication works because the recovery
+        // fallback tries getUserById(subject) first (misses, not a UUID), then falls back to
+        // getUserByUsername(username) which hits the user created with that document number.
         withAuthenticationProfile(
                 AuthenticationProfileSamples.mdocPrimaryWithMdlIdentity(), (apiFlow, requestObject) -> {
                     Map<String, Object> mdocClaims =

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
@@ -62,6 +62,31 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
     }
 
     @Test
+    void validatesStandardIsoMdlWithoutSubOrUsernameClaims() {
+        // Regression for issue 001: a standard ISO 18013-5 mDL (spec sample) carries no
+        // sub/username claims, so requesting standard mDL claims only must pass pre-validation.
+        String token = readResource("/mdoc/spec-sample.txt");
+        Credential credential = credentialWithDocTypeAndClaims(
+                "org.iso.18013.5.1.mDL",
+                claim("document-number", "org.iso.18013.5.1", "document_number"),
+                claim("given-name", "org.iso.18013.5.1", "given_name"));
+
+        assertDoesNotThrow(() -> capability.validatePresentation(credential, token));
+    }
+
+    @Test
+    void rejectsStandardIsoMdlWhenSubClaimIsRequested() {
+        // The pre-fix behavior: requesting the sub claim path rejects every standard ISO mDL.
+        String token = readResource("/mdoc/spec-sample.txt");
+        Credential credential =
+                credentialWithDocTypeAndClaims("org.iso.18013.5.1.mDL", claim("sub", "org.iso.18013.5.1", "sub"));
+
+        VerificationException error =
+                assertThrows(VerificationException.class, () -> capability.validatePresentation(credential, token));
+        assertEquals("Presented mDoc does not satisfy DCQL claim path: [org.iso.18013.5.1, sub]", error.getMessage());
+    }
+
+    @Test
     void validatesPresentationWithNoRequestedClaims() throws Exception {
         String token = mdocToken(Map.of(NAMESPACE, Map.of("given_name", "Alice")), DOC_TYPE);
         Credential credential = credentialWithClaims();

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/dcql/MdocDcqlCredentialCapabilityTest.java
@@ -75,18 +75,6 @@ class MdocDcqlCredentialCapabilityTest extends MdocBaseTest {
     }
 
     @Test
-    void rejectsStandardIsoMdlWhenSubClaimIsRequested() {
-        // The pre-fix behavior: requesting the sub claim path rejects every standard ISO mDL.
-        String token = readResource("/mdoc/spec-sample.txt");
-        Credential credential =
-                credentialWithDocTypeAndClaims("org.iso.18013.5.1.mDL", claim("sub", "org.iso.18013.5.1", "sub"));
-
-        VerificationException error =
-                assertThrows(VerificationException.class, () -> capability.validatePresentation(credential, token));
-        assertEquals("Presented mDoc does not satisfy DCQL claim path: [org.iso.18013.5.1, sub]", error.getMessage());
-    }
-
-    @Test
     void validatesPresentationWithNoRequestedClaims() throws Exception {
         String token = mdocToken(Map.of(NAMESPACE, Map.of("given_name", "Alice")), DOC_TYPE);
         Credential credential = credentialWithClaims();

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
@@ -310,6 +310,85 @@ public class OID4VPProfileConfigTest {
     }
 
     @Test
+    void shouldAcceptCredentialIdentityPrimaryWithConfiguredIdentityClaims() {
+        AuthenticatorConfigModel config = new AuthenticatorConfigModel();
+        config.setConfig(Map.of(PROFILES_CONFIG, """
+                [
+                  {
+                    "id": "login",
+                    "credentials": [
+                      {
+                        "id": "primary",
+                        "role": "primary",
+                        "format": "mso_mdoc",
+                        "credentialTypes": ["org.iso.18013.5.1.mDL"],
+                        "claims": ["org.iso.18013.5.1/document_number", "org.iso.18013.5.1/given_name"],
+                        "subjectClaim": "org.iso.18013.5.1/document_number",
+                        "usernameClaim": "org.iso.18013.5.1/document_number",
+                        "trust": [{ "type": "x5c", "anchors": ["%s"] }]
+                      }
+                    ]
+                  }
+                ]
+                """.formatted(MdocBaseTest.getIssuerCertBase64())));
+
+        assertDoesNotThrow(() -> new OID4VPProfileConfig(config));
+    }
+
+    @Test
+    void shouldRejectCredentialIdentityPrimaryMissingConfiguredIdentityClaim() {
+        AuthenticatorConfigModel config = new AuthenticatorConfigModel();
+        config.setConfig(Map.of(PROFILES_CONFIG, """
+                [
+                  {
+                    "id": "login",
+                    "credentials": [
+                      {
+                        "id": "primary",
+                        "role": "primary",
+                        "credentialTypes": ["main-vct"],
+                        "claims": ["given_name"],
+                        "subjectClaim": "given_name",
+                        "usernameClaim": "family_name"
+                      }
+                    ]
+                  }
+                ]
+                """));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, () -> new OID4VPProfileConfig(config));
+        assertEquals(
+                "OpenID4VP primary credential must request identity claims given_name and family_name: login/primary",
+                error.getMessage());
+    }
+
+    @Test
+    void shouldRejectCredentialIdentityPrimaryWithBlankConfiguredIdentityClaim() {
+        AuthenticatorConfigModel config = new AuthenticatorConfigModel();
+        config.setConfig(Map.of(PROFILES_CONFIG, """
+                [
+                  {
+                    "id": "login",
+                    "credentials": [
+                      {
+                        "id": "primary",
+                        "role": "primary",
+                        "credentialTypes": ["main-vct"],
+                        "claims": ["sub", "username"],
+                        "usernameClaim": ""
+                      }
+                    ]
+                  }
+                ]
+                """));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, () -> new OID4VPProfileConfig(config));
+        assertEquals(
+                "OpenID4VP primary credential subjectClaim and usernameClaim must not be blank: login/primary",
+                error.getMessage());
+    }
+
+    @Test
     void shouldAcceptSessionIdentityPrimaryWithoutSubUsernameWhenBindingRulesPresent() {
         AuthenticatorConfigModel config = new AuthenticatorConfigModel();
         config.setConfig(Map.of(PROFILES_CONFIG, """

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
@@ -277,6 +277,8 @@ public class OID4VPProfileConfigTest {
                         "format": "mso_mdoc",
                         "credentialTypes": ["com.example.doctype"],
                         "claims": ["com.example.namespace1/sub", "com.example.namespace1/username"],
+                        "subjectClaim": "com.example.namespace1/sub",
+                        "usernameClaim": "com.example.namespace1/username",
                         "trust": [{ "type": "x5c", "anchors": ["%s"] }]
                       }
                     ]
@@ -306,7 +308,9 @@ public class OID4VPProfileConfigTest {
                 """));
 
         IllegalStateException error = assertThrows(IllegalStateException.class, () -> new OID4VPProfileConfig(config));
-        assertEquals("OpenID4VP primary credential must request sub and username: login/primary", error.getMessage());
+        assertEquals(
+                "OpenID4VP primary credential must request identity claims subjectClaim='sub' and usernameClaim='username': login/primary",
+                error.getMessage());
     }
 
     @Test
@@ -358,12 +362,13 @@ public class OID4VPProfileConfigTest {
 
         IllegalStateException error = assertThrows(IllegalStateException.class, () -> new OID4VPProfileConfig(config));
         assertEquals(
-                "OpenID4VP primary credential must request identity claims given_name and family_name: login/primary",
+                "OpenID4VP primary credential must request identity claims subjectClaim='given_name' and usernameClaim='family_name': login/primary",
                 error.getMessage());
     }
 
     @Test
-    void shouldRejectCredentialIdentityPrimaryWithBlankConfiguredIdentityClaim() {
+    void shouldAcceptCredentialIdentityPrimaryWithBlankUsernameClaim() {
+        // usernameClaim is optional — a blank value means subjectClaim alone is sufficient.
         AuthenticatorConfigModel config = new AuthenticatorConfigModel();
         config.setConfig(Map.of(PROFILES_CONFIG, """
                 [
@@ -382,10 +387,63 @@ public class OID4VPProfileConfigTest {
                 ]
                 """));
 
+        assertDoesNotThrow(() -> new OID4VPProfileConfig(config));
+    }
+
+    @Test
+    void shouldRejectMdocPrimaryCredentialWithBareSubjectClaim() {
+        // forkimenjeckayang comment: bare subjectClaim is ambiguous for mso_mdoc because
+        // MdocCredentialVerifier.readClaim() searches every namespace and returns the first match.
+        AuthenticatorConfigModel config = new AuthenticatorConfigModel();
+        config.setConfig(Map.of(PROFILES_CONFIG, """
+                [
+                  {
+                    "id": "login",
+                    "credentials": [
+                      {
+                        "id": "primary",
+                        "role": "primary",
+                        "format": "mso_mdoc",
+                        "credentialTypes": ["org.iso.18013.5.1.mDL"],
+                        "claims": ["org.iso.18013.5.1/document_number", "org.iso.18013.5.1/given_name"],
+                        "subjectClaim": "document_number",
+                        "usernameClaim": "org.iso.18013.5.1/document_number",
+                        "trust": [{ "type": "x5c", "anchors": ["%s"] }]
+                      }
+                    ]
+                  }
+                ]
+                """.formatted(MdocBaseTest.getIssuerCertBase64())));
+
         IllegalStateException error = assertThrows(IllegalStateException.class, () -> new OID4VPProfileConfig(config));
-        assertEquals(
-                "OpenID4VP primary credential subjectClaim and usernameClaim must not be blank: login/primary",
-                error.getMessage());
+        assertTrue(error.getMessage().contains("mDoc primary credential subjectClaim must be namespace-qualified"));
+    }
+
+    @Test
+    void shouldRejectMdocPrimaryCredentialWithBareUsernameClaim() {
+        AuthenticatorConfigModel config = new AuthenticatorConfigModel();
+        config.setConfig(Map.of(PROFILES_CONFIG, """
+                [
+                  {
+                    "id": "login",
+                    "credentials": [
+                      {
+                        "id": "primary",
+                        "role": "primary",
+                        "format": "mso_mdoc",
+                        "credentialTypes": ["org.iso.18013.5.1.mDL"],
+                        "claims": ["org.iso.18013.5.1/document_number", "org.iso.18013.5.1/given_name"],
+                        "subjectClaim": "org.iso.18013.5.1/document_number",
+                        "usernameClaim": "document_number",
+                        "trust": [{ "type": "x5c", "anchors": ["%s"] }]
+                      }
+                    ]
+                  }
+                ]
+                """.formatted(MdocBaseTest.getIssuerCertBase64())));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, () -> new OID4VPProfileConfig(config));
+        assertTrue(error.getMessage().contains("mDoc primary credential usernameClaim must be namespace-qualified"));
     }
 
     @Test
@@ -612,6 +670,8 @@ public class OID4VPProfileConfigTest {
                     "format": "mso_mdoc",
                     "credentialTypes": ["com.example.doctype"],
                     "claims": ["com.example.ns/sub", "com.example.ns/username"],
+                    "subjectClaim": "com.example.ns/sub",
+                    "usernameClaim": "com.example.ns/username",
                     {trust}
                   }
                 ]

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
@@ -392,8 +392,9 @@ public class OID4VPProfileConfigTest {
 
     @Test
     void shouldRejectMdocPrimaryCredentialWithBareSubjectClaim() {
-        // forkimenjeckayang comment: bare subjectClaim is ambiguous for mso_mdoc because
-        // MdocCredentialVerifier.readClaim() searches every namespace and returns the first match.
+        // Bare subjectClaim is rejected for mso_mdoc because
+        // MdocCredentialVerifier.readClaim() searches all namespaces,
+        // so a bare name like "document_number" could match in the wrong namespace.
         AuthenticatorConfigModel config = new AuthenticatorConfigModel();
         config.setConfig(Map.of(PROFILES_CONFIG, """
                 [


### PR DESCRIPTION
#### Summary
 
The primary credential was hard-coded to require `sub` and `username` claims to
recover the authenticating user. Standard ISO 18013-5 mDLs carry neither their
identity attributes live in namespaces (e.g. `org.iso.18013.5.1/document_number`)
so every valid mDoc presentation was rejected at DCQL pre-validation before the
signature was even checked.
 
#### Change
 
- Add optional `subjectClaim` / `usernameClaim` to `CredentialRequirement`,
  defaulting to `sub` / `username` for full backward compatibility.
- Validate the configured identity claims in `OID4VPProfileConfig` (blank guard,
  namespaced and bare forms supported, old error message preserved for defaults).
- Use the configured claims for user recovery in `OID4VPAuthenticator`.
- mDoc profiles can now map identity to `org.iso.18013.5.1/document_number`.
 
#### Testing
 
- 6 new regression tests (config validation, DCQL pre-validation, end-to-end auth
  with an mDoc containing only standard mDL claims).
- Full suite: 395 tests, 0 failures.
- OIDF conformance happy-flow passes end-to-end on both HAIP and plain_vp.

Closes https://github.com/ADORSYS-GIS/keycloak-oid4vp-plugin/issues/153