### PR TITLE
refactor: unify credential configuration resolution

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oidc/CredentialRequestResolver.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oidc/CredentialRequestResolver.java
@@ -1,0 +1,220 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.oidc;
+
+import static org.keycloak.OID4VCConstants.OPENID_CREDENTIAL;
+import static org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils.findCredentialScopeModelByConfigurationId;
+import static org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils.findCredentialScopeModelByName;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.presentation.GuardedCredentialScope;
+import jakarta.ws.rs.BadRequestException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.jboss.logging.Logger;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferState;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
+import org.keycloak.protocol.oid4vc.model.IssuerState;
+import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
+import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpoint;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.util.JsonSerialization;
+import org.keycloak.utils.StringUtil;
+
+/**
+ * Shared server-side resolver for the credential configuration requested by an OID4VCI
+ * authorization request. The resolution follows a strict priority order:
+ *
+ * <ol>
+ *   <li>{@code issuer_state} — the server-side credential offer bound to the issuer state,
+ *   <li>{@code authorization_details} — the JSON-encoded OID4VCI authorization details,
+ *   <li>{@code scope} — the OAuth 2.0 scope parameter (credential configuration name).
+ * </ol>
+ *
+ * <p><strong>Cardinality contract:</strong> this resolver rejects requests that reference
+ * multiple credential configurations. The OID4VCI credential endpoint issues one credential
+ * at a time, so multiple configurations in a single request are not supported. Callers
+ * relying on this resolver can assume a single credential scope or {@code null}.
+ */
+public final class CredentialRequestResolver {
+
+    private static final Logger logger = Logger.getLogger(CredentialRequestResolver.class);
+
+    private static final String ISSUER_STATE_NOTE =
+            AuthorizationEndpoint.LOGIN_SESSION_NOTE_ADDITIONAL_REQ_PARAMS_PREFIX + OAuth2Constants.ISSUER_STATE;
+
+    private CredentialRequestResolver() {}
+
+    /**
+     * Resolves the requested credential scope from the raw authorization request parameters.
+     *
+     * <p>The resolution priority is: {@code issuer_state} → {@code authorization_details} →
+     * {@code scope}. Returns {@code null} when no credential configuration can be resolved,
+     * or throws {@link BadRequestException} when multiple credential configurations are requested.
+     *
+     * @param realm the realm to search client scopes in
+     * @param client the client the request is for
+     * @param scope the OAuth 2.0 scope parameter, or {@code null}
+     * @param authorizationDetails the OID4VCI authorization_details JSON, or {@code null}
+     * @param offerState the resolved credential offer state (from issuer_state), or {@code null}
+     * @return the resolved guarded credential scope, or {@code null} when no credential is requested
+     * @throws BadRequestException when multiple credential configurations are requested
+     */
+    public static GuardedCredentialScope resolveCredentialScope(
+            RealmModel realm,
+            ClientModel client,
+            String scope,
+            String authorizationDetails,
+            CredentialOfferState offerState) {
+
+        if (client == null) {
+            return null;
+        }
+
+        // Credentials can be requested either via issuer state, authorization details, or the scope param
+        List<CredentialScopeModel> candidates = Optional.ofNullable(resolveFromIssuerState(realm, client, offerState))
+                .orElseGet(
+                        () -> Optional.ofNullable(resolveFromAuthorizationDetails(realm, client, authorizationDetails))
+                                .orElseGet(() -> resolveFromScope(realm, client, scope)));
+
+        if (candidates == null || candidates.isEmpty()) {
+            return null;
+        }
+
+        if (candidates.size() > 1) {
+            String errorMessage = "Credential endpoint does not support issuing multiple credential types";
+            logger.debugf(
+                    "%s (resolved %d credential configurations under request for issuance)",
+                    errorMessage, candidates.size());
+            throw new BadRequestException(errorMessage);
+        }
+
+        return GuardedCredentialScope.from(candidates.getFirst());
+    }
+
+    /**
+     * Resolves a credential offer from an encoded issuer state string.
+     *
+     * @return resolved offer state or {@code null} if no issuer state provided
+     * @throws IllegalArgumentException if the issuer state is invalid or references an unknown offer
+     */
+    public static CredentialOfferState resolveCredentialOffer(KeycloakSession session, String issuerState) {
+        if (StringUtil.isBlank(issuerState)) {
+            return null;
+        }
+
+        try {
+            String offerId = IssuerState.fromEncodedString(issuerState).getCredentialsOfferId();
+            if (StringUtil.isBlank(offerId)) {
+                throw new IllegalArgumentException("No credentials_offer_id from issuer_state");
+            }
+
+            CredentialOfferState offerState =
+                    session.getProvider(CredentialOfferStorage.class).getOfferStateById(offerId);
+            if (offerState == null) {
+                throw new IllegalArgumentException("Unknown or expired issuer_state");
+            }
+
+            return offerState;
+        } catch (RuntimeException e) {
+            logger.debugf(e, "Could not resolve credential offer from issuer_state");
+            throw new IllegalArgumentException("Invalid issuer_state", e);
+        }
+    }
+
+    /**
+     * Resolves the credential offer referenced by an issuer state note stored on the
+     * authentication session. Invalid or unknown issuer states are treated as absent so
+     * they cannot turn ordinary login into presentation during issuance.
+     *
+     * @return resolved offer state or {@code null} if no issuer state or invalid
+     */
+    public static CredentialOfferState resolveCredentialOffer(
+            KeycloakSession session, AuthenticationSessionModel authSession) {
+        String issuerState = Optional.ofNullable(authSession)
+                .map(s -> s.getClientNote(ISSUER_STATE_NOTE))
+                .orElse(null);
+
+        try {
+            return resolveCredentialOffer(session, issuerState);
+        } catch (IllegalArgumentException e) {
+            logger.debugf(e, "Could not resolve credential offer from issuer_state");
+            return null;
+        }
+    }
+
+    /**
+     * Resolves the requested credential from the server-side credential offer referenced by issuer_state.
+     */
+    private static List<CredentialScopeModel> resolveFromIssuerState(
+            RealmModel realm, ClientModel client, CredentialOfferState offerState) {
+        if (offerState == null) {
+            return null;
+        }
+
+        return offerState.getAuthorizationDetails().stream()
+                .map(OID4VCAuthorizationDetail::getCredentialConfigurationId)
+                .filter(Objects::nonNull)
+                .map(credentialConfigurationId -> findCredentialScopeModelByConfigurationId(
+                        realm, () -> client.getClientScopes(false).values().stream(), credentialConfigurationId))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    /**
+     * Resolves the requested credential from the OID4VCI authorization_details JSON parameter.
+     */
+    private static List<CredentialScopeModel> resolveFromAuthorizationDetails(
+            RealmModel realm, ClientModel client, String authorizationDetails) {
+        if (StringUtil.isBlank(authorizationDetails)) {
+            return null;
+        }
+
+        var credentialConfigurationIds = parseCredentialConfigurationIds(authorizationDetails);
+        return credentialConfigurationIds.stream()
+                .map(credentialConfigurationId -> findCredentialScopeModelByConfigurationId(
+                        realm, () -> client.getClientScopes(false).values().stream(), credentialConfigurationId))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    /**
+     * Resolves the requested credential from the OAuth 2.0 scope parameter.
+     * The scope parameter may contain multiple space-separated values; each is looked up
+     * by name against the client's OID4VC client scopes.
+     */
+    private static List<CredentialScopeModel> resolveFromScope(RealmModel realm, ClientModel client, String scope) {
+        if (StringUtil.isBlank(scope)) {
+            return null;
+        }
+
+        return Arrays.stream(scope.split("\\s"))
+                .map(name -> findCredentialScopeModelByName(
+                        realm, () -> client.getClientScopes(false).values().stream(), name))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    /**
+     * Parses the OID4VCI authorization_details JSON and extracts credential configuration IDs
+     * for entries with type {@code openid_credential}.
+     */
+    private static List<String> parseCredentialConfigurationIds(String authorizationDetails) {
+        try {
+            var details = JsonSerialization.mapper.readValue(authorizationDetails, OID4VCAuthorizationDetail[].class);
+            return Arrays.stream(details)
+                    .filter(d -> d != null && OPENID_CREDENTIAL.equals(d.getType()))
+                    .map(OID4VCAuthorizationDetail::getCredentialConfigurationId)
+                    .filter(Objects::nonNull)
+                    .toList();
+        } catch (JsonProcessingException e) {
+            logger.debugf("Unable to parse authorization details", e);
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oidc/CredentialRequestResolver.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oidc/CredentialRequestResolver.java
@@ -37,7 +37,7 @@ import org.keycloak.utils.StringUtil;
  * </ol>
  *
  * <p><strong>Cardinality contract:</strong> this resolver rejects requests that reference
- * multiple credential configurations. The OID4VCI credential endpoint issues one credential
+ * multiple credential configurations. The OID4VCI credential endpoint processes one credential type
  * at a time, so multiple configurations in a single request are not supported. Callers
  * relying on this resolver can assume a single credential scope or {@code null}.
  */
@@ -59,18 +59,18 @@ public final class CredentialRequestResolver {
      *
      * @param realm the realm to search client scopes in
      * @param client the client the request is for
-     * @param scope the OAuth 2.0 scope parameter, or {@code null}
-     * @param authorizationDetails the OID4VCI authorization_details JSON, or {@code null}
      * @param offerState the resolved credential offer state (from issuer_state), or {@code null}
+     * @param authorizationDetails the OID4VCI authorization_details JSON, or {@code null}
+     * @param scope the OAuth 2.0 scope parameter, or {@code null}
      * @return the resolved guarded credential scope, or {@code null} when no credential is requested
      * @throws BadRequestException when multiple credential configurations are requested
      */
     public static GuardedCredentialScope resolveCredentialScope(
             RealmModel realm,
             ClientModel client,
-            String scope,
+            CredentialOfferState offerState,
             String authorizationDetails,
-            CredentialOfferState offerState) {
+            String scope) {
 
         if (client == null) {
             return null;

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oidc/PresentationDuringIssuanceService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oidc/PresentationDuringIssuanceService.java
@@ -1,33 +1,15 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oidc;
 
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.PresentationDuringIssuanceMode.NESTED_OID4VP_FLOW;
-import static org.keycloak.OID4VCConstants.OPENID_CREDENTIAL;
-import static org.keycloak.constants.OID4VCIConstants.OID4VC_PROTOCOL;
-import static org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils.findCredentialScopeModelByConfigurationId;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.patch.metadata.OID4VCIssuerMetadataProvider;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.presentation.GuardedCredentialScope;
-import jakarta.ws.rs.BadRequestException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
-import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferState;
-import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
-import org.keycloak.protocol.oid4vc.model.IssuerState;
-import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
-import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpoint;
 import org.keycloak.sessions.AuthenticationSessionModel;
-import org.keycloak.util.JsonSerialization;
-import org.keycloak.utils.StringUtil;
 
 /**
  * Detects and resolves presentation-during-issuance state from a running OIDC authentication session.
@@ -36,13 +18,11 @@ import org.keycloak.utils.StringUtil;
  * {@code oid4vci.presentation_during_issuance}: when it is unset or false, no session is treated as
  * requiring nested presentation, so the login flow renders an ordinary login and the issuance gate
  * still refuses gated credentials for want of a verified-presentation marker.
+ *
+ * <p>Credential request resolution (issuer_state / authorization_details / scope) is delegated to
+ * {@link CredentialRequestResolver}, which enforces a single-credential cardinality contract.
  */
 public final class PresentationDuringIssuanceService {
-
-    private static final Logger logger = Logger.getLogger(PresentationDuringIssuanceService.class);
-
-    private static final String ISSUER_STATE_NOTE =
-            AuthorizationEndpoint.LOGIN_SESSION_NOTE_ADDITIONAL_REQ_PARAMS_PREFIX + OAuth2Constants.ISSUER_STATE;
 
     private final RealmModel realm;
     private final GuardedCredentialScope requestedCredentialScope;
@@ -50,7 +30,7 @@ public final class PresentationDuringIssuanceService {
 
     public PresentationDuringIssuanceService(KeycloakSession session, AuthenticationSessionModel authSession) {
         this.realm = authSession == null ? null : authSession.getRealm();
-        this.requestedCredentialOfferState = resolveCredentialOffer(session, authSession);
+        this.requestedCredentialOfferState = CredentialRequestResolver.resolveCredentialOffer(session, authSession);
         this.requestedCredentialScope = resolveRequestedCredential(authSession, requestedCredentialOfferState);
     }
 
@@ -89,7 +69,9 @@ public final class PresentationDuringIssuanceService {
     }
 
     /**
-     * Resolve credential requested for issuance if any.
+     * Resolves the credential requested for issuance, if any. Delegates to
+     * {@link CredentialRequestResolver} for the shared issuer_state / authorization_details /
+     * scope resolution with its single-credential cardinality contract.
      */
     private static GuardedCredentialScope resolveRequestedCredential(
             AuthenticationSessionModel authSession, CredentialOfferState requestedCredentialOfferState) {
@@ -97,142 +79,11 @@ public final class PresentationDuringIssuanceService {
             return null;
         }
 
-        // Credentials can be requested either via issuer state, authorization details, or the scope param
-        List<CredentialScopeModel> requestedCredentials = Optional.ofNullable(
-                        resolveFromIssuerState(authSession, requestedCredentialOfferState))
-                .orElseGet(() -> Optional.ofNullable(resolveFromAuthorizationDetails(authSession))
-                        .orElseGet(() -> resolveFromScope(authSession)));
-
-        if (requestedCredentials == null || requestedCredentials.isEmpty()) {
-            return null;
-        }
-
-        if (requestedCredentials.size() > 1) {
-            String errorMessage = "Credential endpoint does not support issuing multiple credential types";
-            logger.debugf(
-                    "%s (resolved %d credential configurations under request for issuance)",
-                    errorMessage, requestedCredentials.size());
-            throw new BadRequestException(errorMessage);
-        }
-
-        return GuardedCredentialScope.from(requestedCredentials.getFirst());
-    }
-
-    /**
-     * Resolves the requested credential from the server-side credential offer referenced by issuer_state.
-     */
-    private static List<CredentialScopeModel> resolveFromIssuerState(
-            AuthenticationSessionModel authSession, CredentialOfferState requestedCredentialOfferState) {
-        if (requestedCredentialOfferState == null) {
-            return null;
-        }
-
-        return requestedCredentialOfferState.getAuthorizationDetails().stream()
-                .map(OID4VCAuthorizationDetail::getCredentialConfigurationId)
-                .filter(Objects::nonNull)
-                .map(credentialConfigurationId -> findCredentialScopeModelByConfigurationId(
-                        authSession.getClient().getRealm(),
-                        () -> authSession.getClient().getClientScopes(false).values().stream(),
-                        credentialConfigurationId))
-                .filter(Objects::nonNull)
-                .toList();
-    }
-
-    /**
-     * Resolves the requested credential from the session's authorization details.
-     */
-    private static List<CredentialScopeModel> resolveFromAuthorizationDetails(AuthenticationSessionModel authSession) {
-        String authorizationDetails = authSession.getClientNote(OAuth2Constants.AUTHORIZATION_DETAILS);
-        if (StringUtil.isBlank(authorizationDetails)) {
-            return null;
-        }
-
-        var credentialConfigurationIds = findCredentialConfigurationIds(authorizationDetails);
-        return credentialConfigurationIds.stream()
-                .map(credentialConfigurationId -> findCredentialScopeModelByConfigurationId(
-                        authSession.getClient().getRealm(),
-                        () -> authSession.getClient().getClientScopes(false).values().stream(),
-                        credentialConfigurationId))
-                .filter(Objects::nonNull)
-                .toList();
-    }
-
-    /**
-     * Resolves the requested credential from requested scopes.
-     */
-    private static List<CredentialScopeModel> resolveFromScope(AuthenticationSessionModel authSession) {
-        String scopeParam = authSession.getClientNote(OAuth2Constants.SCOPE);
-        if (StringUtil.isBlank(scopeParam)) {
-            return null;
-        }
-
-        Map<String, ClientScopeModel> clientScopes = authSession.getClient().getClientScopes(false);
-        return Arrays.stream(scopeParam.split("\\s"))
-                .map(clientScopes::get)
-                .filter(clientScope -> clientScope != null && OID4VC_PROTOCOL.equals(clientScope.getProtocol()))
-                .map(CredentialScopeModel::new)
-                .toList();
-    }
-
-    /**
-     * Resolves the credential offer referenced by an issuer state note. Invalid or unknown issuer
-     * states are treated as absent so they cannot turn ordinary login into presentation during issuance.
-     */
-    public static CredentialOfferState resolveCredentialOffer(
-            KeycloakSession session, AuthenticationSessionModel authSession) {
-        String issuerState = Optional.ofNullable(authSession)
-                .map(s -> s.getClientNote(ISSUER_STATE_NOTE))
-                .orElse(null);
-
-        try {
-            return resolveCredentialOffer(session, issuerState);
-        } catch (IllegalArgumentException e) {
-            logger.debugf(e, "Could not resolve credential offer from issuer_state");
-            return null;
-        }
-    }
-
-    /**
-     * Resolves a credential offer from an issuer state note.
-     *
-     * @return resolved offer state or {@code null} if no issuer state provided
-     * @throws IllegalArgumentException if invalid issuer_state
-     */
-    public static CredentialOfferState resolveCredentialOffer(KeycloakSession session, String issuerState) {
-        if (StringUtil.isBlank(issuerState)) {
-            return null;
-        }
-
-        try {
-            String offerId = IssuerState.fromEncodedString(issuerState).getCredentialsOfferId();
-            if (StringUtil.isBlank(offerId)) {
-                throw new IllegalArgumentException("No credentials_offer_id from issuer_state");
-            }
-
-            CredentialOfferState offerState =
-                    session.getProvider(CredentialOfferStorage.class).getOfferStateById(offerId);
-            if (offerState == null) {
-                throw new IllegalArgumentException("Unknown or expired issuer_state");
-            }
-
-            return offerState;
-        } catch (RuntimeException e) {
-            logger.debugf(e, "Could not resolve credential offer from issuer_state");
-            throw new IllegalArgumentException("Invalid issuer_state", e);
-        }
-    }
-
-    private static List<String> findCredentialConfigurationIds(String authorizationDetails) {
-        try {
-            var details = JsonSerialization.mapper.readValue(authorizationDetails, OID4VCAuthorizationDetail[].class);
-            return Arrays.stream(details)
-                    .filter(d -> d != null && OPENID_CREDENTIAL.equals(d.getType()))
-                    .map(OID4VCAuthorizationDetail::getCredentialConfigurationId)
-                    .filter(Objects::nonNull)
-                    .toList();
-        } catch (JsonProcessingException e) {
-            logger.debugf("Unable to parse authorization details", e);
-            return List.of();
-        }
+        return CredentialRequestResolver.resolveCredentialScope(
+                authSession.getClient().getRealm(),
+                authSession.getClient(),
+                authSession.getClientNote(OAuth2Constants.SCOPE),
+                authSession.getClientNote(OAuth2Constants.AUTHORIZATION_DETAILS),
+                requestedCredentialOfferState);
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oidc/PresentationDuringIssuanceService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oidc/PresentationDuringIssuanceService.java
@@ -82,8 +82,8 @@ public final class PresentationDuringIssuanceService {
         return CredentialRequestResolver.resolveCredentialScope(
                 authSession.getClient().getRealm(),
                 authSession.getClient(),
-                authSession.getClientNote(OAuth2Constants.SCOPE),
+                requestedCredentialOfferState,
                 authSession.getClientNote(OAuth2Constants.AUTHORIZATION_DETAILS),
-                requestedCredentialOfferState);
+                authSession.getClientNote(OAuth2Constants.SCOPE));
     }
 }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/presentation/AuthorizationChallengeEndpoint.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/presentation/AuthorizationChallengeEndpoint.java
@@ -248,7 +248,7 @@ public class AuthorizationChallengeEndpoint extends OID4VPUserAuthEndpointBase i
             }
 
             GuardedCredentialScope credentialScope = CredentialRequestResolver.resolveCredentialScope(
-                    realm, client, scope, authorizationDetails, offerState);
+                    realm, client, offerState, authorizationDetails, scope);
             if (credentialScope == null) {
                 return null;
             }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/presentation/AuthorizationChallengeEndpoint.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/presentation/AuthorizationChallengeEndpoint.java
@@ -1,8 +1,5 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.presentation;
 
-import static org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils.findCredentialScopeModelByConfigurationId;
-import static org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils.findCredentialScopeModelByName;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.OID4VPUserAuthEndpoint;
@@ -15,7 +12,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.dto.Authorizat
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.AuthenticationSessionStore;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.AuthorizationRequestService.CodeChallengeDetails;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.service.CorsService;
-import io.github.adorsysgis.keycloak.protocol.oid4vc.oidc.PresentationDuringIssuanceService;
+import io.github.adorsysgis.keycloak.protocol.oid4vc.oidc.CredentialRequestResolver;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.FormParam;
@@ -35,9 +32,7 @@ import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferState;
-import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpoint;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.services.Urls;
@@ -154,7 +149,7 @@ public class AuthorizationChallengeEndpoint extends OID4VPUserAuthEndpointBase i
         // Treat it as untrusted input and resolve it against server-side offer state before creating a session.
         CredentialOfferState offerState;
         try {
-            offerState = PresentationDuringIssuanceService.resolveCredentialOffer(session, issuerState);
+            offerState = CredentialRequestResolver.resolveCredentialOffer(session, issuerState);
         } catch (IllegalArgumentException e) {
             logger.debugf(e, "Could not resolve credential offer from issuer_state");
             throw badRequest("Invalid issuer_state");
@@ -252,8 +247,8 @@ public class AuthorizationChallengeEndpoint extends OID4VPUserAuthEndpointBase i
                 return null;
             }
 
-            GuardedCredentialScope credentialScope = GuardedCredentialScope.from(
-                    resolveRequestedCredentialScope(client, scope, authorizationDetails, offerState));
+            GuardedCredentialScope credentialScope = CredentialRequestResolver.resolveCredentialScope(
+                    realm, client, scope, authorizationDetails, offerState);
             if (credentialScope == null) {
                 return null;
             }
@@ -268,52 +263,6 @@ public class AuthorizationChallengeEndpoint extends OID4VPUserAuthEndpointBase i
             return credentialScope.getPresentationProfileId();
         } catch (RuntimeException e) {
             logger.debugf(e, "Could not resolve an enforced OpenID4VP profile for the requested credential");
-            return null;
-        }
-    }
-
-    private CredentialScopeModel resolveRequestedCredentialScope(
-            ClientModel client, String scope, String authorizationDetails, CredentialOfferState offerState) {
-        String credentialConfigurationId = credentialConfigurationIdFromOffer(offerState);
-        if (StringUtil.isBlank(credentialConfigurationId)) {
-            credentialConfigurationId = credentialConfigurationIdFromAuthorizationDetails(authorizationDetails);
-        }
-        if (StringUtil.isNotBlank(credentialConfigurationId)) {
-            CredentialScopeModel byConfigId = findCredentialScopeModelByConfigurationId(
-                    realm, () -> client.getClientScopes(false).values().stream(), credentialConfigurationId);
-            if (byConfigId != null) {
-                return byConfigId;
-            }
-        }
-        return findCredentialScopeModelByName(realm, () -> client.getClientScopes(false).values().stream(), scope);
-    }
-
-    private String credentialConfigurationIdFromOffer(CredentialOfferState offerState) {
-        if (offerState == null) {
-            return null;
-        }
-        return offerState.getAuthorizationDetails().stream()
-                .map(OID4VCAuthorizationDetail::getCredentialConfigurationId)
-                .filter(StringUtil::isNotBlank)
-                .findFirst()
-                .orElse(null);
-    }
-
-    private String credentialConfigurationIdFromAuthorizationDetails(String authorizationDetails) {
-        if (StringUtil.isBlank(authorizationDetails)) {
-            return null;
-        }
-        try {
-            OID4VCAuthorizationDetail[] details =
-                    JsonSerialization.mapper.readValue(authorizationDetails, OID4VCAuthorizationDetail[].class);
-            for (OID4VCAuthorizationDetail detail : details) {
-                if (detail != null && StringUtil.isNotBlank(detail.getCredentialConfigurationId())) {
-                    return detail.getCredentialConfigurationId();
-                }
-            }
-            return null;
-        } catch (IOException | RuntimeException e) {
-            logger.debugf(e, "Could not resolve credential_configuration_id from authorization_details");
             return null;
         }
     }


### PR DESCRIPTION
## Problem

`PresentationDuringIssuanceService` and `AuthorizationChallengeEndpoint` both determine which credential configuration is expected from an OID4VC authorization request.

However, they handled some cases differently:

* The PDI service rejected requests with multiple credential configurations, while ACE used the first one.
* The PDI service filtered `authorization_details` by `type=openid_credential`, while ACE did not.
* Both classes contained duplicated logic for parsing the request and resolving the credential configuration.

## Solution

Introduced a shared `CredentialRequestResolver` that:

1. Uses the same resolution order: `issuer_state → authorization_details → scope`
2. Rejects requests that resolve to multiple credential configurations
3. Applies the same `openid_credential` filtering
4. Contains the shared credential offer resolution logic

Both `PresentationDuringIssuanceService` and `AuthorizationChallengeEndpoint` now use the resolver, removing the duplicated logic and ensuring consistent behavior.

Closes #163