### PR TITLE
fix: replace deprecated Keycloak APIs across the codebase

### DIFF
--- a/demo/lib/WalletPresentationService.java
+++ b/demo/lib/WalletPresentationService.java
@@ -31,7 +31,7 @@ public final class WalletPresentationService {
     }
 
     private String buildCredential(CredentialScenario scenario) throws Exception {
-        long now = Time.currentTime();
+        long now = Time.currentTimeSeconds();
 
         ObjectNode claimSet = JsonSerialization.mapper.createObjectNode();
         claimSet.put(OAuth2Constants.ISSUER, cfg.issuer());
@@ -64,7 +64,7 @@ public final class WalletPresentationService {
         // The wallet proves possession of the bound holder key with a KB-JWT that echoes
         // the verifier-provided nonce and audience from the request object.
         JsonWebToken kbJwtClaims = new JsonWebToken();
-        long now = Time.currentTime();
+        long now = Time.currentTimeSeconds();
         kbJwtClaims.iat(now);
         kbJwtClaims.exp(now + KB_JWT_LIFESPAN_SECS);
         kbJwtClaims.getOtherClaims().put("nonce", requestObject.getNonce());

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/trust/EudiPidTrustListProvider.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/trust/EudiPidTrustListProvider.java
@@ -9,9 +9,10 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import org.keycloak.broker.provider.util.SimpleHttp;
+import org.apache.http.client.config.RequestConfig;
 import org.keycloak.common.util.Time;
 import org.keycloak.crypto.SignatureVerifierContext;
+import org.keycloak.http.simple.SimpleHttp;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.utils.StringUtil;
@@ -58,11 +59,15 @@ public class EudiPidTrustListProvider {
 
     protected String fetchTrustList(String url) throws EudiPidTrustException {
         try {
-            return SimpleHttp.doGet(url, session)
+            RequestConfig requestConfig = RequestConfig.custom()
+                    .setConnectTimeout(TRUST_LIST_FETCH_TIMEOUT_MILLIS)
+                    .setConnectionRequestTimeout(TRUST_LIST_FETCH_TIMEOUT_MILLIS)
+                    .setSocketTimeout(TRUST_LIST_FETCH_TIMEOUT_MILLIS)
+                    .build();
+            return SimpleHttp.create(session)
+                    .withRequestConfig(requestConfig)
+                    .doGet(url)
                     .header("Accept", "application/trustlist+jwt")
-                    .connectTimeoutMillis(TRUST_LIST_FETCH_TIMEOUT_MILLIS)
-                    .connectionRequestTimeoutMillis(TRUST_LIST_FETCH_TIMEOUT_MILLIS)
-                    .socketTimeOutMillis(TRUST_LIST_FETCH_TIMEOUT_MILLIS)
                     .asString();
         } catch (Exception e) {
             throw new EudiPidTrustException("Could not fetch EUDI PID trust list: " + url, e);

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/tokenstatus/http/SimpleStatusListJwtFetcher.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/tokenstatus/http/SimpleStatusListJwtFetcher.java
@@ -1,7 +1,7 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.http;
 
 import io.github.adorsysgis.keycloak.protocol.oid4vc.tokenstatus.ReferencedTokenValidator.ReferencedTokenValidationException;
-import org.keycloak.broker.provider.util.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttp;
 import org.keycloak.models.KeycloakSession;
 
 /**
@@ -30,7 +30,8 @@ public class SimpleStatusListJwtFetcher implements StatusListJwtFetcher {
 
     protected String fetchStatusListFromUri(String uri) throws ReferencedTokenValidationException {
         try {
-            return SimpleHttp.doGet(uri, session)
+            return SimpleHttp.create(session)
+                    .doGet(uri)
                     .header("Accept", STATUS_LIST_JWT_ACCEPT_HEADER)
                     .asString();
         } catch (Exception e) {

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/mdoc/MdocVerificationTest.java
@@ -53,7 +53,7 @@ public class MdocVerificationTest extends MdocBaseTest {
 
         try {
             // The test vector dates back to 2024, so we move back in time to bypass expiration checks.
-            Time.setOffset(1714338150 - Time.currentTime());
+            Time.setOffset((int) (1714338150 - Time.currentTimeSeconds()));
             new MdocVerificationContext(mdoc).verifyPresentation(opts, reqs, trust);
         } finally {
             Time.setOffset(0);

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/utils/SdJwtVPTestUtils.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/utils/SdJwtVPTestUtils.java
@@ -231,7 +231,7 @@ public class SdJwtVPTestUtils {
         ObjectNode claimSet = JsonSerialization.mapper.createObjectNode();
         claimSet.put(OAuth2Constants.ISSUER, iss);
         claimSet.put(CLAIM_NAME_VCT, vct);
-        claimSet.put(CLAIM_NAME_EXP, Time.currentTime() + ISSUER_SIGNED_JWT_LIFESPAN_SECS);
+        claimSet.put(CLAIM_NAME_EXP, Time.currentTimeSeconds() + ISSUER_SIGNED_JWT_LIFESPAN_SECS);
         if (setStatusClaim) {
             claimSet.set(
                     STATUS_FIELD,
@@ -286,7 +286,7 @@ public class SdJwtVPTestUtils {
             throws Exception {
         JsonWebToken kbJwtClaims = new JsonWebToken();
 
-        long currentTime = Time.currentTime();
+        long currentTime = Time.currentTimeSeconds();
         kbJwtClaims.iat(currentTime);
         kbJwtClaims.exp(currentTime + kbJwtLifespan);
 


### PR DESCRIPTION
#### Description
 
Replace deprecated Keycloak APIs with their current replacements to eliminate compiler deprecation warnings and prevent breakage when Keycloak 27.0 removes the old APIs.
 
#### Changes
 
| File | Deprecated API | Replacement |
|------|---------------|-------------|
| `EudiPidTrustListProvider.java` | `o.k.broker.provider.util.SimpleHttp` | `o.k.http.simple.SimpleHttp` |
| `SimpleStatusListJwtFetcher.java` | `o.k.broker.provider.util.SimpleHttp` | `o.k.http.simple.SimpleHttp` |
| `MdocVerificationTest.java` | `Time.currentTime()` | `Time.currentTimeSeconds()` |
| `SdJwtVPTestUtils.java` | `Time.currentTime()` | `Time.currentTimeSeconds()` |
| `WalletPresentationService.java` | `Time.currentTime()` | `Time.currentTimeSeconds()` |
 
#### Why
 
- `SimpleHttp` (old package) deprecated since KC 26.4.0, removed in KC 27.0
- `Time.currentTime()` deprecated, returns `int`, overflows in 2038
 
 Closes https://github.com/ADORSYS-GIS/keycloak-oid4vp-plugin/issues/170