### PR TITLE
chore: set up Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+# Dependabot configuration for keycloak-oid4vp-plugin
+#
+# Monitors: Maven dependencies, GitHub Actions, and npm
+
+version: 2
+updates:
+  # Maven dependencies and plugins
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    open-pull-requests-limit: 10
+    groups:
+      # Only group Keycloak patches — minor/major upgrades can break SPI
+      keycloak:
+        patterns: ["org.keycloak:*"]
+        update-types:
+          - "patch"
+      # Group minor and patch updates to reduce PR noise
+      maven-dependencies:
+        patterns: ["*"]
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Keycloak major upgrades require manual migration work
+      - dependency-name: "org.keycloak:*"
+        update-types:
+          - "version-update:semver-major"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    open-pull-requests-limit: 5
+
+  # Documentation npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "monthly"
+      time: "06:00"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,12 +17,9 @@ updates:
       timezone: "Africa/Douala"
     open-pull-requests-limit: 10
     groups:
-      # All Keycloak packages share the same version — group them together
+      # All Keycloak packages share the same version — group them together.
       keycloak:
         patterns: ["org.keycloak:*"]
-        update-types:
-          - "minor"
-          - "patch"
       # Group minor and patch updates to reduce PR noise
       maven-dependencies:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,21 @@ updates:
   # Maven dependencies and plugins
   - package-ecosystem: "maven"
     directory: "/"
+    target-branch: "main"
+    cooldown:
+      default-days: 14
     schedule:
       interval: "weekly"
       day: "monday"
       time: "06:00"
+      timezone: "Africa/Douala"
     open-pull-requests-limit: 10
     groups:
-      # Only group Keycloak patches — minor/major upgrades can break SPI
+      # All Keycloak packages share the same version — group them together
       keycloak:
         patterns: ["org.keycloak:*"]
         update-types:
+          - "minor"
           - "patch"
       # Group minor and patch updates to reduce PR noise
       maven-dependencies:
@@ -25,24 +30,33 @@ updates:
           - "minor"
           - "patch"
     ignore:
-      # Keycloak major upgrades require manual migration work
+      # Keycloak minor and major upgrades break SPI compatibility — require manual migration
       - dependency-name: "org.keycloak:*"
         update-types:
+          - "version-update:semver-minor"
           - "version-update:semver-major"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "main"
+    cooldown:
+      default-days: 14
     schedule:
       interval: "weekly"
       day: "monday"
       time: "06:00"
+      timezone: "Africa/Douala"
     open-pull-requests-limit: 5
 
   # Documentation npm dependencies
   - package-ecosystem: "npm"
     directory: "/docs"
+    target-branch: "main"
+    cooldown:
+      default-days: 14
     schedule:
       interval: "monthly"
       time: "06:00"
+      timezone: "Africa/Douala"
     open-pull-requests-limit: 5


### PR DESCRIPTION
#### Summary
 
Adds `.github/dependabot.yml` to enable automated dependency version updates via GitHub Dependabot.
 
#### What this configures
 
| Ecosystem | Directory | Schedule | PR limit |
|-----------|-----------|----------|----------|
| Maven | `/` | Weekly (Mon 06:00 UTC) | 10 |
| GitHub Actions | `/` | Weekly (Mon 06:00 UTC) | 5 |
| npm | `/docs` | Monthly (06:00 UTC) | 5 |
 
#### Key decisions
 
- **Keycloak major updates ignored** — major versions break SPI compatibility and require manual migration
- **Keycloak patches grouped** — separate group for focused review of security/bug fixes
- **Maven minor/patch grouped** — reduces PR noise for routine updates
- **Docker excluded** — no Dockerfiles exist in the repository (only docker-compose images)
 
#### What this does NOT do
 
- Does not auto-merge PRs
- Does not modify application code or dependency versions
- Does not change CI/CD workflows
 
Closes https://github.com/ADORSYS-GIS/keycloak-oid4vp-plugin/issues/168