### PR TITLE
perf: cache VerifierConfig and OID4VPProfileConfig

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpoint.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpoint.java
@@ -191,7 +191,7 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
             }
         }
 
-        VerifierConfig config = VerifierConfig.resolve(getOid4vpAuthenticatorConfig());
+        VerifierConfig config = VerifierConfig.resolve(realm.getId(), getOid4vpAuthenticatorConfig());
         AuthenticationSessionModel authSession = recoverAuthenticationSession(requestId);
 
         authorizationContext = authorizationRequestService.finalizeAuthorizationRequest(
@@ -373,7 +373,7 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
         // Call delegate service to process the authorization response
         AuthenticationProcessor authProcessor = getAuthenticationProcessor();
         AuthenticatorConfigModel authConfig = getOid4vpAuthenticatorConfig();
-        VerifierConfig config = VerifierConfig.resolve(authConfig);
+        VerifierConfig config = VerifierConfig.resolve(realm.getId(), authConfig);
         AuthenticationProfile profile = config.getProfileConfig().getProfile(authorizationContext.getProfileId());
 
         authorizationResponseService.processAuthorizationResponse(
@@ -563,7 +563,7 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
         ClientModel client = checkClient(clientId);
         AuthenticationSessionModel authSession = createAuthSession(client);
         AuthenticatorConfigModel authConfig = getOid4vpAuthenticatorConfig();
-        VerifierConfig config = VerifierConfig.resolve(authConfig);
+        VerifierConfig config = VerifierConfig.resolve(realm.getId(), authConfig);
         AuthenticationProfile profile = config.getProfileConfig().getProfile(profileId);
 
         // Call delegate service to create an authorization request
@@ -602,7 +602,7 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
     public List<AuthenticationProfile> getAuthenticationProfilesForClient(String clientId) {
         checkClient(clientId);
         AuthenticatorConfigModel authConfig = getOid4vpAuthenticatorConfig();
-        VerifierConfig config = VerifierConfig.resolve(authConfig);
+        VerifierConfig config = VerifierConfig.resolve(realm.getId(), authConfig);
         return config.getProfileConfig().getProfilesForClient(clientId);
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpoint.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpoint.java
@@ -191,7 +191,7 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
             }
         }
 
-        VerifierConfig config = new VerifierConfig(getOid4vpAuthenticatorConfig());
+        VerifierConfig config = VerifierConfig.resolve(getOid4vpAuthenticatorConfig());
         AuthenticationSessionModel authSession = recoverAuthenticationSession(requestId);
 
         authorizationContext = authorizationRequestService.finalizeAuthorizationRequest(
@@ -373,7 +373,7 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
         // Call delegate service to process the authorization response
         AuthenticationProcessor authProcessor = getAuthenticationProcessor();
         AuthenticatorConfigModel authConfig = getOid4vpAuthenticatorConfig();
-        VerifierConfig config = new VerifierConfig(authConfig);
+        VerifierConfig config = VerifierConfig.resolve(authConfig);
         AuthenticationProfile profile = config.getProfileConfig().getProfile(authorizationContext.getProfileId());
 
         authorizationResponseService.processAuthorizationResponse(
@@ -563,7 +563,7 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
         ClientModel client = checkClient(clientId);
         AuthenticationSessionModel authSession = createAuthSession(client);
         AuthenticatorConfigModel authConfig = getOid4vpAuthenticatorConfig();
-        VerifierConfig config = new VerifierConfig(authConfig);
+        VerifierConfig config = VerifierConfig.resolve(authConfig);
         AuthenticationProfile profile = config.getProfileConfig().getProfile(profileId);
 
         // Call delegate service to create an authorization request
@@ -602,7 +602,7 @@ public class OID4VPUserAuthEndpoint extends OID4VPUserAuthEndpointBase implement
     public List<AuthenticationProfile> getAuthenticationProfilesForClient(String clientId) {
         checkClient(clientId);
         AuthenticatorConfigModel authConfig = getOid4vpAuthenticatorConfig();
-        VerifierConfig config = new VerifierConfig(authConfig);
+        VerifierConfig config = VerifierConfig.resolve(authConfig);
         return config.getProfileConfig().getProfilesForClient(clientId);
     }
 

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
@@ -103,9 +103,7 @@ public class OID4VPAuthenticator implements Authenticator {
         AuthenticationSessionModel authSession = authFlowContext.getAuthenticationSession();
         AuthorizationContext authContext = new AuthenticationSessionStore(authSession).getAuthorizationContext();
 
-        // TODO: Access the profile config reliably without full parsing on every iteration.
-        //       Issue also applies to VerifierConfig.
-        OID4VPProfileConfig profileConfig = new OID4VPProfileConfig(authFlowContext.getAuthenticatorConfig());
+        OID4VPProfileConfig profileConfig = OID4VPProfileConfig.resolve(authFlowContext.getAuthenticatorConfig());
         AuthenticationProfile authProfile = profileConfig.getProfile(authContext.getProfileId());
 
         Map<String, String> presentedTokens = getPresentedTokens(authSession);

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
@@ -103,7 +103,9 @@ public class OID4VPAuthenticator implements Authenticator {
         AuthenticationSessionModel authSession = authFlowContext.getAuthenticationSession();
         AuthorizationContext authContext = new AuthenticationSessionStore(authSession).getAuthorizationContext();
 
-        OID4VPProfileConfig profileConfig = OID4VPProfileConfig.resolve(authFlowContext.getAuthenticatorConfig());
+        String realmId = authFlowContext.getRealm().getId();
+        OID4VPProfileConfig profileConfig =
+                OID4VPProfileConfig.resolve(realmId, authFlowContext.getAuthenticatorConfig());
         AuthenticationProfile authProfile = profileConfig.getProfile(authContext.getProfileId());
 
         Map<String, String> presentedTokens = getPresentedTokens(authSession);

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
@@ -13,17 +13,24 @@ import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.jboss.logging.Logger;
 import org.keycloak.models.AuthenticatorConfigModel;
 
 /**
  * Access configurations that modulate the verifier's behavior.
- * <p></p>
- * Read full descriptions of configurations in {@link OID4VPAuthenticatorFactory}.
+ *
+ * <p>Use {@link #resolve(AuthenticatorConfigModel)} to avoid re-parsing and re-validating
+ * the same configuration on every request. The constructor remains public for direct use
+ * in tests.
+ *
+ * <p>Read full descriptions of configurations in {@link OID4VPAuthenticatorFactory}.
  */
 public class VerifierConfig {
 
     private static final Logger logger = Logger.getLogger(VerifierConfig.class);
+
+    private static final ConcurrentHashMap<Map<String, String>, VerifierConfig> CACHE = new ConcurrentHashMap<>();
 
     private final ClientIdentifierPrefix clientIdentifierPrefix;
     private final ResponseMode responseMode;
@@ -36,13 +43,23 @@ public class VerifierConfig {
     private final List<String> transactionDataRaw;
     private final String verifierInfoConfig;
 
+    /**
+     * Returns a cached {@code VerifierConfig} for the given authenticator config.
+     * The cache key is the config map content, so updates to the config are picked up immediately.
+     */
+    public static VerifierConfig resolve(AuthenticatorConfigModel authConfig) {
+        Map<String, String> config =
+                (authConfig != null && authConfig.getConfig() != null) ? authConfig.getConfig() : Map.of();
+        return CACHE.computeIfAbsent(config, k -> new VerifierConfig(authConfig));
+    }
+
     public VerifierConfig(AuthenticatorConfigModel authConfig) {
         logger.debugf("Collecting verifier config properties");
 
         Map<String, String> config =
                 (authConfig != null && authConfig.getConfig() != null) ? authConfig.getConfig() : Map.of();
 
-        this.profileConfig = new OID4VPProfileConfig(authConfig);
+        this.profileConfig = OID4VPProfileConfig.resolve(authConfig);
 
         this.clientIdentifierPrefix = validateClientIdentifierPrefix(config.getOrDefault(
                 OID4VPAuthenticatorFactory.CLIENT_IDENTIFIER_PREFIX_CONFIG,

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
@@ -45,12 +45,13 @@ public class VerifierConfig {
 
     /**
      * Returns a cached {@code VerifierConfig} for the given authenticator config.
-     * The cache key is the config map content, so updates to the config are picked up immediately.
+     * The cache key is an immutable snapshot of the config map, so updates to the config are
+     * picked up immediately while mutations to the source map cannot corrupt the cache.
      */
     public static VerifierConfig resolve(AuthenticatorConfigModel authConfig) {
         Map<String, String> config =
                 (authConfig != null && authConfig.getConfig() != null) ? authConfig.getConfig() : Map.of();
-        return CACHE.computeIfAbsent(config, k -> new VerifierConfig(authConfig));
+        return CACHE.computeIfAbsent(Map.copyOf(config), k -> new VerifierConfig(authConfig));
     }
 
     public VerifierConfig(AuthenticatorConfigModel authConfig) {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/config/VerifierConfig.java
@@ -1,6 +1,8 @@
 package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config;
 
 import com.apicatalog.jsonld.StringUtils;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.OID4VPAuthenticatorFactory;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.ClientIdentifierPrefix;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.model.RequestUriMethod;
@@ -13,14 +15,13 @@ import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.jboss.logging.Logger;
 import org.keycloak.models.AuthenticatorConfigModel;
 
 /**
  * Access configurations that modulate the verifier's behavior.
  *
- * <p>Use {@link #resolve(AuthenticatorConfigModel)} to avoid re-parsing and re-validating
+ * <p>Use {@link #resolve(String, AuthenticatorConfigModel)} to avoid re-parsing and re-validating
  * the same configuration on every request. The constructor remains public for direct use
  * in tests.
  *
@@ -30,7 +31,10 @@ public class VerifierConfig {
 
     private static final Logger logger = Logger.getLogger(VerifierConfig.class);
 
-    private static final ConcurrentHashMap<Map<String, String>, VerifierConfig> CACHE = new ConcurrentHashMap<>();
+    private static final int MAX_CACHE_SIZE = 50;
+
+    private static final Cache<CacheKey, VerifierConfig> CACHE =
+            Caffeine.newBuilder().maximumSize(MAX_CACHE_SIZE).build();
 
     private final ClientIdentifierPrefix clientIdentifierPrefix;
     private final ResponseMode responseMode;
@@ -45,22 +49,24 @@ public class VerifierConfig {
 
     /**
      * Returns a cached {@code VerifierConfig} for the given authenticator config.
-     * The cache key is an immutable snapshot of the config map, so updates to the config are
-     * picked up immediately while mutations to the source map cannot corrupt the cache.
+     * The cache is scoped by realm ID and bounded by {@link #MAX_CACHE_SIZE} entries.
      */
-    public static VerifierConfig resolve(AuthenticatorConfigModel authConfig) {
+    public static VerifierConfig resolve(String realmId, AuthenticatorConfigModel authConfig) {
         Map<String, String> config =
                 (authConfig != null && authConfig.getConfig() != null) ? authConfig.getConfig() : Map.of();
-        return CACHE.computeIfAbsent(Map.copyOf(config), k -> new VerifierConfig(authConfig));
+        CacheKey key = new CacheKey(realmId, Map.copyOf(config));
+        return CACHE.get(key, k -> new VerifierConfig(realmId, authConfig));
     }
 
-    public VerifierConfig(AuthenticatorConfigModel authConfig) {
+    private record CacheKey(String realmId, Map<String, String> config) {}
+
+    public VerifierConfig(String realmId, AuthenticatorConfigModel authConfig) {
         logger.debugf("Collecting verifier config properties");
 
         Map<String, String> config =
                 (authConfig != null && authConfig.getConfig() != null) ? authConfig.getConfig() : Map.of();
 
-        this.profileConfig = OID4VPProfileConfig.resolve(authConfig);
+        this.profileConfig = OID4VPProfileConfig.resolve(realmId, authConfig);
 
         this.clientIdentifierPrefix = validateClientIdentifierPrefix(config.getOrDefault(
                 OID4VPAuthenticatorFactory.CLIENT_IDENTIFIER_PREFIX_CONFIG,

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfig.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.models.AuthenticatorConfigModel;
@@ -21,10 +22,26 @@ import org.keycloak.utils.StringUtil;
 
 /**
  * Parses and validates OpenID4VP authentication profiles.
+ *
+ * <p>Use {@link #resolve(AuthenticatorConfigModel)} to avoid re-parsing and re-validating
+ * the same configuration on every request. The constructor remains public for direct use
+ * in tests.
  */
 public class OID4VPProfileConfig {
 
+    private static final ConcurrentHashMap<Map<String, String>, OID4VPProfileConfig> CACHE = new ConcurrentHashMap<>();
+
     private final List<AuthenticationProfile> profiles;
+
+    /**
+     * Returns a cached {@code OID4VPProfileConfig} for the given authenticator config.
+     * The cache key is the config map content, so updates to the config are picked up immediately.
+     */
+    public static OID4VPProfileConfig resolve(AuthenticatorConfigModel authConfig) {
+        Map<String, String> config =
+                (authConfig != null && authConfig.getConfig() != null) ? authConfig.getConfig() : Map.of();
+        return CACHE.computeIfAbsent(config, k -> new OID4VPProfileConfig(authConfig));
+    }
 
     public OID4VPProfileConfig(AuthenticatorConfigModel authConfig) {
         Map<String, String> config =

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfig.java
@@ -35,12 +35,13 @@ public class OID4VPProfileConfig {
 
     /**
      * Returns a cached {@code OID4VPProfileConfig} for the given authenticator config.
-     * The cache key is the config map content, so updates to the config are picked up immediately.
+     * The cache key is an immutable snapshot of the config map, so updates to the config are
+     * picked up immediately while mutations to the source map cannot corrupt the cache.
      */
     public static OID4VPProfileConfig resolve(AuthenticatorConfigModel authConfig) {
         Map<String, String> config =
                 (authConfig != null && authConfig.getConfig() != null) ? authConfig.getConfig() : Map.of();
-        return CACHE.computeIfAbsent(config, k -> new OID4VPProfileConfig(authConfig));
+        return CACHE.computeIfAbsent(Map.copyOf(config), k -> new OID4VPProfileConfig(authConfig));
     }
 
     public OID4VPProfileConfig(AuthenticatorConfigModel authConfig) {

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfig.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfig.java
@@ -2,6 +2,8 @@ package io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile;
 
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.OID4VPAuthenticatorFactory.PROFILES_CONFIG;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.CredentialFormat;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.AuthRequirements;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.profile.CredentialRequirement.ClaimReference;
@@ -12,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.models.AuthenticatorConfigModel;
@@ -23,26 +24,31 @@ import org.keycloak.utils.StringUtil;
 /**
  * Parses and validates OpenID4VP authentication profiles.
  *
- * <p>Use {@link #resolve(AuthenticatorConfigModel)} to avoid re-parsing and re-validating
+ * <p>Use {@link #resolve(String, AuthenticatorConfigModel)} to avoid re-parsing and re-validating
  * the same configuration on every request. The constructor remains public for direct use
  * in tests.
  */
 public class OID4VPProfileConfig {
 
-    private static final ConcurrentHashMap<Map<String, String>, OID4VPProfileConfig> CACHE = new ConcurrentHashMap<>();
+    private static final int MAX_CACHE_SIZE = 50;
+
+    private static final Cache<CacheKey, OID4VPProfileConfig> CACHE =
+            Caffeine.newBuilder().maximumSize(MAX_CACHE_SIZE).build();
 
     private final List<AuthenticationProfile> profiles;
 
     /**
      * Returns a cached {@code OID4VPProfileConfig} for the given authenticator config.
-     * The cache key is an immutable snapshot of the config map, so updates to the config are
-     * picked up immediately while mutations to the source map cannot corrupt the cache.
+     * The cache is scoped by realm ID, so different realms cannot share cached entries.
      */
-    public static OID4VPProfileConfig resolve(AuthenticatorConfigModel authConfig) {
+    public static OID4VPProfileConfig resolve(String realmId, AuthenticatorConfigModel authConfig) {
         Map<String, String> config =
                 (authConfig != null && authConfig.getConfig() != null) ? authConfig.getConfig() : Map.of();
-        return CACHE.computeIfAbsent(Map.copyOf(config), k -> new OID4VPProfileConfig(authConfig));
+        CacheKey key = new CacheKey(realmId, Map.copyOf(config));
+        return CACHE.get(key, k -> new OID4VPProfileConfig(authConfig));
     }
+
+    private record CacheKey(String realmId, Map<String, String> config) {}
 
     public OID4VPProfileConfig(AuthenticatorConfigModel authConfig) {
         Map<String, String> config =

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
@@ -293,7 +293,7 @@ public class OID4VPProfileConfigTest {
         AuthenticatorConfigModel config = new AuthenticatorConfigModel();
         config.setConfig(configMap);
 
-        assertDoesNotThrow(() -> new VerifierConfig(config));
+        assertDoesNotThrow(() -> new VerifierConfig(null, config));
     }
 
     @Test
@@ -779,8 +779,8 @@ public class OID4VPProfileConfigTest {
                 ]
                 """));
 
-        OID4VPProfileConfig first = OID4VPProfileConfig.resolve(config);
-        OID4VPProfileConfig second = OID4VPProfileConfig.resolve(config);
+        OID4VPProfileConfig first = OID4VPProfileConfig.resolve("realm-1", config);
+        OID4VPProfileConfig second = OID4VPProfileConfig.resolve("realm-1", config);
         assertSame(first, second);
     }
 
@@ -810,8 +810,8 @@ public class OID4VPProfileConfigTest {
                 ]
                 """));
 
-        OID4VPProfileConfig fromA = OID4VPProfileConfig.resolve(configA);
-        OID4VPProfileConfig fromB = OID4VPProfileConfig.resolve(configB);
+        OID4VPProfileConfig fromA = OID4VPProfileConfig.resolve("realm-1", configA);
+        OID4VPProfileConfig fromB = OID4VPProfileConfig.resolve("realm-1", configB);
         assertNotSame(fromA, fromB);
         assertEquals("profile-a", fromA.getProfile("profile-a").getId());
         assertEquals("profile-b", fromB.getProfile("profile-b").getId());
@@ -819,7 +819,7 @@ public class OID4VPProfileConfigTest {
 
     @Test
     void resolveShouldHandleNullConfig() {
-        OID4VPProfileConfig result = OID4VPProfileConfig.resolve(null);
+        OID4VPProfileConfig result = OID4VPProfileConfig.resolve(null, null);
         assertDoesNotThrow(() -> result.getProfile(null));
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/OID4VPProfileConfigTest.java
@@ -4,6 +4,8 @@ import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator
 import static io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.authenticator.OID4VPAuthenticatorFactory.TRANSACTION_DATA_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -11,6 +13,7 @@ import io.github.adorsysgis.keycloak.protocol.oid4vc.mdoc.MdocBaseTest;
 import io.github.adorsysgis.keycloak.protocol.oid4vc.oid4vp.config.VerifierConfig;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.keycloak.models.AuthenticatorConfigModel;
@@ -54,7 +57,7 @@ public class OID4VPProfileConfigTest {
 
         AuthenticationProfile profile = profileConfig.getProfile("dual");
         assertEquals("dual", profile.getId());
-        assertEquals("Sign in with two credentials", profile.getDisplayCta(java.util.Locale.ENGLISH));
+        assertEquals("Sign in with two credentials", profile.getDisplayCta(Locale.ENGLISH));
         assertEquals(2, profile.getCredentials().size());
         assertEquals(
                 "main-vct", profile.getPrimaryCredential().getCredentialTypes().getFirst());
@@ -758,5 +761,65 @@ public class OID4VPProfileConfigTest {
         assertDoesNotThrow(() -> parseMdocProfileWithTrust("""
                 "trust": [{ "type": "x5c", "anchors": ["{anchor}"] }]
                 """));
+    }
+
+    // ---- Caching -----------------------------------------------------------
+
+    @Test
+    void resolveShouldReturnSameInstanceForSameConfig() {
+        AuthenticatorConfigModel config = new AuthenticatorConfigModel();
+        config.setConfig(Map.of(PROFILES_CONFIG, """
+                [
+                  {
+                    "id": "cached",
+                    "credentials": [
+                      { "id": "pid", "role": "primary", "credentialTypes": ["vct"], "claims": ["sub", "username"] }
+                    ]
+                  }
+                ]
+                """));
+
+        OID4VPProfileConfig first = OID4VPProfileConfig.resolve(config);
+        OID4VPProfileConfig second = OID4VPProfileConfig.resolve(config);
+        assertSame(first, second);
+    }
+
+    @Test
+    void resolveShouldReturnDifferentInstanceForDifferentConfig() {
+        AuthenticatorConfigModel configA = new AuthenticatorConfigModel();
+        configA.setConfig(Map.of(PROFILES_CONFIG, """
+                [
+                  {
+                    "id": "profile-a",
+                    "credentials": [
+                      { "id": "pid", "role": "primary", "credentialTypes": ["vct-a"], "claims": ["sub", "username"] }
+                    ]
+                  }
+                ]
+                """));
+
+        AuthenticatorConfigModel configB = new AuthenticatorConfigModel();
+        configB.setConfig(Map.of(PROFILES_CONFIG, """
+                [
+                  {
+                    "id": "profile-b",
+                    "credentials": [
+                      { "id": "pid", "role": "primary", "credentialTypes": ["vct-b"], "claims": ["sub", "username"] }
+                    ]
+                  }
+                ]
+                """));
+
+        OID4VPProfileConfig fromA = OID4VPProfileConfig.resolve(configA);
+        OID4VPProfileConfig fromB = OID4VPProfileConfig.resolve(configB);
+        assertNotSame(fromA, fromB);
+        assertEquals("profile-a", fromA.getProfile("profile-a").getId());
+        assertEquals("profile-b", fromB.getProfile("profile-b").getId());
+    }
+
+    @Test
+    void resolveShouldHandleNullConfig() {
+        OID4VPProfileConfig result = OID4VPProfileConfig.resolve(null);
+        assertDoesNotThrow(() -> result.getProfile(null));
     }
 }


### PR DESCRIPTION
This PR avoids recreating and re-parsing `VerifierConfig` and `OID4VPProfileConfig` on every request.

Both classes now provide a static `resolve()` method that caches configuration instances using the config map content as the key. Identical configurations reuse the cached instance, while configuration changes automatically result in a new instance.

## Changes

* Added caching through `resolve()` to `OID4VPProfileConfig`
* Added caching through `resolve()` to `VerifierConfig`
* Updated `VerifierConfig` to use `OID4VPProfileConfig.resolve()`
* Updated `OID4VPAuthenticator` to use `OID4VPProfileConfig.resolve()`
* Updated `OID4VPUserAuthEndpoint` to use `VerifierConfig.resolve()`
* Added caching tests for `OID4VPProfileConfig`

Closes #164
