### PR TITLE
feat: improve claim binding comparison

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/OID4VPAuthenticator.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
@@ -215,7 +216,14 @@ public class OID4VPAuthenticator implements Authenticator {
                                     String.format("Unsupported binding rule type: %s", rule.getType()));
                     };
 
-            if (!resolveComparator(session, rule).matches(actualValue, expectedValue)) {
+            String normalizedActual = actualValue != null ? actualValue.strip() : actualValue;
+            String normalizedExpected = expectedValue != null ? expectedValue.strip() : expectedValue;
+            if (rule.getCaseInsensitive() && normalizedActual != null && normalizedExpected != null) {
+                normalizedActual = normalizedActual.toLowerCase(Locale.ROOT);
+                normalizedExpected = normalizedExpected.toLowerCase(Locale.ROOT);
+            }
+
+            if (!resolveComparator(session, rule).matches(normalizedActual, normalizedExpected)) {
                 throw new VerificationException(String.format(
                         "Credential '%s' failed binding rule '%s'", credentialReq.getId(), rule.getType()));
             }

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/BindingRule.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/profile/BindingRule.java
@@ -30,6 +30,13 @@ public class BindingRule {
     @JsonProperty("comparator")
     private String comparator;
 
+    /**
+     * When {@code true}, the claim comparison ignores case. Leading and trailing whitespace is
+     * always trimmed regardless of this flag.
+     */
+    @JsonProperty("caseInsensitive")
+    private boolean caseInsensitive;
+
     public String getType() {
         return type;
     }
@@ -72,6 +79,15 @@ public class BindingRule {
 
     public BindingRule setComparator(String comparator) {
         this.comparator = comparator;
+        return this;
+    }
+
+    public boolean getCaseInsensitive() {
+        return caseInsensitive;
+    }
+
+    public BindingRule setCaseInsensitive(boolean caseInsensitive) {
+        this.caseInsensitive = caseInsensitive;
         return this;
     }
 }

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtPrimaryBindingTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtPrimaryBindingTest.java
@@ -97,6 +97,32 @@ class SdJwtPrimaryBindingTest {
         authenticator.applyBindingRules(ctx, authenticatingUser, primary, claims);
     }
 
+    @Test
+    void passesWhenClaimMatchesWithTrailingSpaces() {
+        when(user.getUsername()).thenReturn("  test-user  ");
+        assertDoesNotThrow(() -> apply(primaryWithUserAttributeBinding()));
+    }
+
+    @Test
+    void passesWhenClaimMatchesCaseInsensitive() {
+        when(user.getUsername()).thenReturn("TEST-USER");
+        assertDoesNotThrow(() -> apply(primaryWithCaseInsensitiveBinding()));
+    }
+
+    @Test
+    void throwsWhenClaimDoesNotMatchCaseInsensitive() {
+        when(user.getUsername()).thenReturn("someone-else");
+        VerificationException error =
+                assertThrows(VerificationException.class, () -> apply(primaryWithCaseInsensitiveBinding()));
+        assertEquals("Credential 'pid' failed binding rule 'claim_equals_user_attribute'", error.getMessage());
+    }
+
+    @Test
+    void passesWhenClaimMatchesWithTrailingSpacesAndCaseInsensitive() {
+        when(user.getUsername()).thenReturn("  TEST-USER  ");
+        assertDoesNotThrow(() -> apply(primaryWithCaseInsensitiveBinding()));
+    }
+
     private static CredentialRequirement primaryWithUserAttributeBinding() {
         return new CredentialRequirement()
                 .setId("pid")
@@ -105,5 +131,16 @@ class SdJwtPrimaryBindingTest {
                         .setType(BindingRule.CLAIM_EQUALS_USER_ATTRIBUTE)
                         .setCredentialClaim("username")
                         .setUserAttribute("username")));
+    }
+
+    private static CredentialRequirement primaryWithCaseInsensitiveBinding() {
+        return new CredentialRequirement()
+                .setId("pid")
+                .setRole(CredentialRole.PRIMARY)
+                .setBinding(List.of(new BindingRule()
+                        .setType(BindingRule.CLAIM_EQUALS_USER_ATTRIBUTE)
+                        .setCredentialClaim("username")
+                        .setUserAttribute("username")
+                        .setCaseInsensitive(true)));
     }
 }


### PR DESCRIPTION
This PR improves the claim binding comparison by trimming whitespace and supporting optional case-insensitive matching.

## Changes

* Added `caseInsensitive` to `BindingRule`
* Trimmed leading and trailing whitespace before comparing claim values
* Added optional case-insensitive matching
* Kept case-sensitive matching as the default for backward compatibility
* Added tests for trimming, case-insensitive matching, and both together

## Configuration Example

```json
{
    "id": "my-profile",
    "credentials": [
        {
            "id": "identity",
            "role": "identity",
            "credentialTypes": [
                "identity-vct"
            ],
            "claims": [
                "family_name"
            ],
            "binding": [
                {
                    "type": "claim_equals_user_attribute",
                    "credentialClaim": "family_name",
                    "userAttribute": "lastName",
                    "caseInsensitive": true // Ignore case when comparing
                }
            ]
        }
    ]
}
```

Closes #179
