### PR TITLE
Update Keycloak compatibility to 26.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This plugin has been tested with:
 | **Requirement** | **Version** |
 |-----------------|-------------|
 | **Java**        | 21          |
-| **Keycloak**    | 26.7.0      |
+| **Keycloak**    | 26.7.3      |
 
 While it may work with other versions, compatibility is not guaranteed. Ensure your environment matches the tested
 versions for best results.

--- a/demo/_common.sh
+++ b/demo/_common.sh
@@ -31,7 +31,7 @@ fi
 
 # ---- Defaults ----
 DEMO_COMPOSE_PROJECT="${DEMO_COMPOSE_PROJECT:-oid4vp-demo}"
-KEYCLOAK_IMAGE="${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.7.0}"
+KEYCLOAK_IMAGE="${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.7.3}"
 KC_ADMIN_USER="${KC_ADMIN_USER:-admin}"
 KC_ADMIN_PASS="${KC_ADMIN_PASS:-admin}"
 KC_HTTP_PORT="${KC_HTTP_PORT:-18080}"

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   keycloak:
-    image: ${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.7.0}
+    image: ${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.7.3}
     command: start-dev --features=oid4vc-vci --log-level=${KC_LOG_LEVEL:-INFO}
     environment:
       - KC_BOOTSTRAP_ADMIN_USERNAME=${KC_ADMIN_USER:-admin}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   keycloak-oid4vp:
-    image: quay.io/keycloak/keycloak:26.7.0
+    image: quay.io/keycloak/keycloak:26.7.3
     command: start-dev --features=oid4vc-vci --log-level=DEBUG
     environment:
       - KC_BOOTSTRAP_ADMIN_USERNAME=admin

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <revision>999.0.0-SNAPSHOT</revision>
-        <keycloak.version>26.7.0</keycloak.version>
+        <keycloak.version>26.7.3</keycloak.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationResponseService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationResponseService.java
@@ -285,9 +285,15 @@ public class AuthorizationResponseService {
 
         OAuth2Code codeData = new OAuth2Code(
                 code,
+                clientSession.getClient().getId(),
                 (int) expiration,
                 nonce,
                 OAuth2Constants.SCOPE_OPENID,
+                null,
+                null,
+                null,
+                null,
+                null,
                 clientSession.getUserSession().getId());
 
         return OAuth2CodeParser.persistCode(session, clientSession, codeData);

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/KeycloakTestContainer.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/KeycloakTestContainer.java
@@ -15,7 +15,7 @@ public final class KeycloakTestContainer {
 
     private static final Logger logger = Logger.getLogger(KeycloakTestContainer.class);
 
-    public static final String TEST_KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:26.7.0";
+    public static final String TEST_KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:26.7.3";
     public static final String TEST_SHADED_PLUGIN_JAR = "target/keycloak-oid4vp-plugin-999.0.0-SNAPSHOT.jar";
 
     private KeycloakTestContainer() {}


### PR DESCRIPTION
## Summary
- update Keycloak dependencies, runtime images, demo defaults, and documentation to 26.7.3
- adapt authorization-code creation to the expanded Keycloak OAuth2Code API
- bind generated authorization codes to their client session

## Testing
- full Maven test suite passes