### PR TITLE
Backport client-binding fix for authorization-code credential offers

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedCredentialOfferProvider.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedCredentialOfferProvider.java
@@ -33,12 +33,7 @@ public final class PatchedCredentialOfferProvider implements CredentialOfferProv
             Integer expireAt) {
         String effectiveTargetClientId = AUTH_CODE_GRANT_TYPE.equals(grantType) ? null : targetClientId;
         return delegate.createCredentialOffer(
-                user,
-                grantType,
-                credentialConfigurationIds,
-                effectiveTargetClientId,
-                targetUserId,
-                expireAt);
+                user, grantType, credentialConfigurationIds, effectiveTargetClientId, targetUserId, expireAt);
     }
 
     @Override
@@ -46,4 +41,3 @@ public final class PatchedCredentialOfferProvider implements CredentialOfferProv
         delegate.close();
     }
 }
-

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedCredentialOfferProvider.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedCredentialOfferProvider.java
@@ -1,0 +1,49 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.patch.issuance;
+
+import static org.keycloak.protocol.oid4vc.model.AuthorizationCodeGrant.AUTH_CODE_GRANT_TYPE;
+
+import java.util.List;
+import java.util.Objects;
+import org.keycloak.models.UserModel;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferProvider;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferState;
+
+/**
+ * Temporary backport that prevents authorization-code credential offers from being bound to the
+ * client that created the offer.
+ *
+ * <p>Pre-authorized-code offers retain their client binding. Remove this decorator once the
+ * corresponding fix is available in the supported Keycloak release.
+ */
+public final class PatchedCredentialOfferProvider implements CredentialOfferProvider {
+
+    private final CredentialOfferProvider delegate;
+
+    public PatchedCredentialOfferProvider(CredentialOfferProvider delegate) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+    }
+
+    @Override
+    public CredentialOfferState createCredentialOffer(
+            UserModel user,
+            String grantType,
+            List<String> credentialConfigurationIds,
+            String targetClientId,
+            String targetUserId,
+            Integer expireAt) {
+        String effectiveTargetClientId = AUTH_CODE_GRANT_TYPE.equals(grantType) ? null : targetClientId;
+        return delegate.createCredentialOffer(
+                user,
+                grantType,
+                credentialConfigurationIds,
+                effectiveTargetClientId,
+                targetUserId,
+                expireAt);
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+}
+

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedCredentialOfferProviderFactory.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedCredentialOfferProviderFactory.java
@@ -22,4 +22,3 @@ public final class PatchedCredentialOfferProviderFactory extends DefaultCredenti
         return super.order() + 9;
     }
 }
-

--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedCredentialOfferProviderFactory.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedCredentialOfferProviderFactory.java
@@ -1,0 +1,25 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.patch.issuance;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferProvider;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.DefaultCredentialOfferProviderFactory;
+
+/**
+ * Overrides the default credential-offer provider with a higher-priority decorated instance.
+ *
+ * <p>Remove this factory together with {@link PatchedCredentialOfferProvider} once the fix is part
+ * of the supported Keycloak release.
+ */
+public final class PatchedCredentialOfferProviderFactory extends DefaultCredentialOfferProviderFactory {
+
+    @Override
+    public CredentialOfferProvider create(KeycloakSession session) {
+        return new PatchedCredentialOfferProvider(super.create(session));
+    }
+
+    @Override
+    public int order() {
+        return super.order() + 9;
+    }
+}
+

--- a/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferProviderFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferProviderFactory
@@ -1,0 +1,2 @@
+io.github.adorsysgis.keycloak.protocol.oid4vc.patch.issuance.PatchedCredentialOfferProviderFactory
+

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedCredentialOfferProviderTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedCredentialOfferProviderTest.java
@@ -31,12 +31,7 @@ class PatchedCredentialOfferProviderTest {
         CredentialOfferState expected = mock(CredentialOfferState.class);
         UserModel user = mock(UserModel.class);
         when(delegate.createCredentialOffer(
-                        user,
-                        AUTH_CODE_GRANT_TYPE,
-                        CREDENTIAL_CONFIGURATION_IDS,
-                        null,
-                        TARGET_USER_ID,
-                        EXPIRE_AT))
+                        user, AUTH_CODE_GRANT_TYPE, CREDENTIAL_CONFIGURATION_IDS, null, TARGET_USER_ID, EXPIRE_AT))
                 .thenReturn(expected);
 
         CredentialOfferState actual = new PatchedCredentialOfferProvider(delegate)
@@ -51,12 +46,7 @@ class PatchedCredentialOfferProviderTest {
         assertSame(expected, actual);
         verify(delegate)
                 .createCredentialOffer(
-                        user,
-                        AUTH_CODE_GRANT_TYPE,
-                        CREDENTIAL_CONFIGURATION_IDS,
-                        null,
-                        TARGET_USER_ID,
-                        EXPIRE_AT);
+                        user, AUTH_CODE_GRANT_TYPE, CREDENTIAL_CONFIGURATION_IDS, null, TARGET_USER_ID, EXPIRE_AT);
         verifyNoMoreInteractions(delegate);
     }
 
@@ -71,32 +61,17 @@ class PatchedCredentialOfferProviderTest {
         CredentialOfferState expected = mock(CredentialOfferState.class);
         UserModel user = mock(UserModel.class);
         when(delegate.createCredentialOffer(
-                        user,
-                        grantType,
-                        CREDENTIAL_CONFIGURATION_IDS,
-                        TARGET_CLIENT_ID,
-                        TARGET_USER_ID,
-                        EXPIRE_AT))
+                        user, grantType, CREDENTIAL_CONFIGURATION_IDS, TARGET_CLIENT_ID, TARGET_USER_ID, EXPIRE_AT))
                 .thenReturn(expected);
 
         CredentialOfferState actual = new PatchedCredentialOfferProvider(delegate)
                 .createCredentialOffer(
-                        user,
-                        grantType,
-                        CREDENTIAL_CONFIGURATION_IDS,
-                        TARGET_CLIENT_ID,
-                        TARGET_USER_ID,
-                        EXPIRE_AT);
+                        user, grantType, CREDENTIAL_CONFIGURATION_IDS, TARGET_CLIENT_ID, TARGET_USER_ID, EXPIRE_AT);
 
         assertSame(expected, actual);
         verify(delegate)
                 .createCredentialOffer(
-                        user,
-                        grantType,
-                        CREDENTIAL_CONFIGURATION_IDS,
-                        TARGET_CLIENT_ID,
-                        TARGET_USER_ID,
-                        EXPIRE_AT);
+                        user, grantType, CREDENTIAL_CONFIGURATION_IDS, TARGET_CLIENT_ID, TARGET_USER_ID, EXPIRE_AT);
         verifyNoMoreInteractions(delegate);
     }
 
@@ -110,4 +85,3 @@ class PatchedCredentialOfferProviderTest {
         verifyNoMoreInteractions(delegate);
     }
 }
-

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedCredentialOfferProviderTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/patch/issuance/PatchedCredentialOfferProviderTest.java
@@ -1,0 +1,113 @@
+package io.github.adorsysgis.keycloak.protocol.oid4vc.patch.issuance;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.keycloak.protocol.oid4vc.model.AuthorizationCodeGrant.AUTH_CODE_GRANT_TYPE;
+import static org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.keycloak.models.UserModel;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferProvider;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferState;
+
+class PatchedCredentialOfferProviderTest {
+
+    private static final List<String> CREDENTIAL_CONFIGURATION_IDS = List.of("credential-config");
+    private static final String TARGET_CLIENT_ID = "offer-creating-client";
+    private static final String TARGET_USER_ID = "target-user";
+    private static final Integer EXPIRE_AT = 123456789;
+
+    @Test
+    void removesTargetClientForAuthorizationCodeGrant() {
+        CredentialOfferProvider delegate = mock(CredentialOfferProvider.class);
+        CredentialOfferState expected = mock(CredentialOfferState.class);
+        UserModel user = mock(UserModel.class);
+        when(delegate.createCredentialOffer(
+                        user,
+                        AUTH_CODE_GRANT_TYPE,
+                        CREDENTIAL_CONFIGURATION_IDS,
+                        null,
+                        TARGET_USER_ID,
+                        EXPIRE_AT))
+                .thenReturn(expected);
+
+        CredentialOfferState actual = new PatchedCredentialOfferProvider(delegate)
+                .createCredentialOffer(
+                        user,
+                        AUTH_CODE_GRANT_TYPE,
+                        CREDENTIAL_CONFIGURATION_IDS,
+                        TARGET_CLIENT_ID,
+                        TARGET_USER_ID,
+                        EXPIRE_AT);
+
+        assertSame(expected, actual);
+        verify(delegate)
+                .createCredentialOffer(
+                        user,
+                        AUTH_CODE_GRANT_TYPE,
+                        CREDENTIAL_CONFIGURATION_IDS,
+                        null,
+                        TARGET_USER_ID,
+                        EXPIRE_AT);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    static Stream<Arguments> grantsRetainingTargetClient() {
+        return Stream.of(Arguments.of(PRE_AUTH_GRANT_TYPE), Arguments.of("custom-grant"), Arguments.of((String) null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("grantsRetainingTargetClient")
+    void retainsTargetClientForAllOtherGrantTypes(String grantType) {
+        CredentialOfferProvider delegate = mock(CredentialOfferProvider.class);
+        CredentialOfferState expected = mock(CredentialOfferState.class);
+        UserModel user = mock(UserModel.class);
+        when(delegate.createCredentialOffer(
+                        user,
+                        grantType,
+                        CREDENTIAL_CONFIGURATION_IDS,
+                        TARGET_CLIENT_ID,
+                        TARGET_USER_ID,
+                        EXPIRE_AT))
+                .thenReturn(expected);
+
+        CredentialOfferState actual = new PatchedCredentialOfferProvider(delegate)
+                .createCredentialOffer(
+                        user,
+                        grantType,
+                        CREDENTIAL_CONFIGURATION_IDS,
+                        TARGET_CLIENT_ID,
+                        TARGET_USER_ID,
+                        EXPIRE_AT);
+
+        assertSame(expected, actual);
+        verify(delegate)
+                .createCredentialOffer(
+                        user,
+                        grantType,
+                        CREDENTIAL_CONFIGURATION_IDS,
+                        TARGET_CLIENT_ID,
+                        TARGET_USER_ID,
+                        EXPIRE_AT);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    void closesDelegate() {
+        CredentialOfferProvider delegate = mock(CredentialOfferProvider.class);
+
+        new PatchedCredentialOfferProvider(delegate).close();
+
+        verify(delegate).close();
+        verifyNoMoreInteractions(delegate);
+    }
+}
+


### PR DESCRIPTION
## Summary
- decorate Keycloak's default `CredentialOfferProvider` with a temporary backport
- clear `targetClientId` for authorization-code credential offers
- preserve the client binding for pre-authorized-code offers
- register the higher-priority provider factory through the internal Keycloak SPI
- add unit coverage for authorization-code, pre-authorized-code, unknown, and missing grant types
## Rationale
Authorization-code credential offers must not be bound to the client that creates the offer. Pre-authorized-code offers must retain their existing client binding. This mirrors the upstream fix while keeping the Keycloak core dependency unchanged.
The implementation uses an internal Keycloak SPI and is intentionally scoped to the Keycloak 26.7.3 compatibility branch. It should be removed once the supported Keycloak release contains the upstream fix.
## Testing
The tests, including the new provider unit tests, pass successfully.
## Dependency
This is a stacked PR based on `fix/keycloak-26.7.3-compatibility`. It can be retargeted to `main` after that compatibility change is merged.