### PR TITLE
fix: cap OID4VP request nonce at 43 characters for wallet interoperability

### DIFF
--- a/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -35,8 +35,6 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 import org.jboss.logging.Logger;
@@ -63,8 +61,12 @@ public class AuthorizationRequestService {
     public static final String AUTH_REQ_JWT = "oauth-authz-req+jwt";
     public static final String X509_ATTR_CN = "CN";
     // The number of bytes to generate for secure random strings,
-    // including request IDs, transaction IDs, and nonces (doubled).
+    // including the random component of request IDs and transaction IDs.
     public static final int SECURE_RANDOM_ENTROPY = 20;
+    // Entropy of the OID4VP request nonce in bytes. 32 bytes encode to exactly 43 base64url
+    // characters (no padding), the longest nonce the OID4VP conformance suite accepts
+    // (OID4VP-1FINAL-5.2 warns for anything longer), while providing 256 bits of entropy.
+    public static final int NONCE_RANDOM_ENTROPY = 32;
 
     // Note: "https://self-issued.me/v2" is a symbolic string and can be used
     // as an aud Claim value even when this specification is used standalone,
@@ -209,11 +211,18 @@ public class AuthorizationRequestService {
     }
 
     /**
-     * Generates a cryptographically secure random string.
+     * Generates a cryptographically secure random string from {@link #SECURE_RANDOM_ENTROPY} bytes.
      */
     private static String generateRandomString() {
+        return generateRandomString(SECURE_RANDOM_ENTROPY);
+    }
+
+    /**
+     * Generates a cryptographically secure random string from the given number of bytes.
+     */
+    private static String generateRandomString(int entropyBytes) {
         // Generate a cryptographically secure random byte array
-        byte[] randomBytes = JWEUtils.generateSecret(SECURE_RANDOM_ENTROPY);
+        byte[] randomBytes = JWEUtils.generateSecret(entropyBytes);
 
         // Convert the random number to a Base64 string
         return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
@@ -249,10 +258,11 @@ public class AuthorizationRequestService {
             AuthenticationProfile profile,
             String requestId,
             PresentationDuringIssuanceSession pdiSession) {
-        // Generate nonce
-        String nonce = Stream.generate(AuthorizationRequestService::generateRandomString)
-                .limit(2)
-                .collect(Collectors.joining("."));
+        // Generate nonce. A single 32-byte segment (43 base64url characters, 256-bit entropy) stays
+        // within the 43-character interoperability limit for wallets. Two 20-byte segments joined
+        // with '.' produced 55 characters, which the OID4VP conformance suite flags as too long
+        // (OID4VP-1FINAL-5.2) and strict wallets may reject.
+        String nonce = generateRandomString(NONCE_RANDOM_ENTROPY);
 
         // Build DCQL query from the selected authentication profile
         DcqlQuery dcqlQuery =

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -106,6 +106,13 @@ public class OID4VPUserAuthEndpointTest extends OID4VPBaseUserAuthEndpointTest {
         String actualSessionId = pruneAuthSessionId(requestObject.getState());
         assertEquals(expectedSessionId, actualSessionId);
 
+        // Assert: The nonce must not exceed 43 characters (OID4VP-1FINAL-5.2 interop limit —
+        // the conformance suite warns for longer nonces, which strict wallets may reject).
+        assertNotNull(requestObject.getNonce(), "Nonce should be present");
+        assertTrue(
+                requestObject.getNonce().length() <= 43,
+                "Nonce must not exceed 43 characters, but was: " + requestObject.getNonce());
+
         // Assert: Ensure the request object contains a final-spec DCQL query.
         DcqlQueryGeneratorTest.assertDcqlQuery(
                 requestObject.getDcqlQuery(),


### PR DESCRIPTION

 
#### Summary
 
The OpenID4VP conformance suite (`OID4VP-1FINAL-5.2`) warns that the nonce in our signed request objects is **55 characters** and flags anything longer than **43 characters** as a wallet-interoperability concern. This change reduces the nonce to exactly 43 characters while _increasing_ its entropy to 256 bits.
 
### Files changed
 
- `src/main/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java`, added `NONCE_RANDOM_ENTROPY = 32`, overloaded `generateRandomString(int)`, single-segment nonce
- `src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java`, assert generated nonce ≤ 43 characters in `shouldResolveRequestURIs`
 
#$## Testing
 
- `OID4VPUserAuthEndpointTest` , 48 run, 0 failures
- `OID4VPUserAuthEndpointHAIPTest`, 11 run, 0 failures
- Spotless check passes
- Verified live: decoded request-object nonce is now **43 characters** (was 55)
 
#### Acceptance criteria
 
- [ ] Generated nonce is ≤ 43 characters (unit test asserts this)
- [ ] Entropy remains ≥ 128 bits (256 bits)
- [ ] OID4VP verifier conformance run no longer reports `VP1FinalCheckNonceMaximumLength`

Closes https://github.com/ADORSYS-GIS/keycloak-oid4vp-plugin/issues/187
