### PR TITLE
ci: skip load tests when the commit is unchanged

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -20,6 +20,7 @@ on:
         default: '60'
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -27,8 +28,80 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-changes:
+    name: Check for changes since the last successful run
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - name: Decide whether load tests are needed
+        id: check
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const finish = async (shouldRun, reason) => {
+              const decision = shouldRun ? 'run' : 'skip';
+              core.setOutput('should-run', String(shouldRun));
+              core.notice(`Decision: ${decision} load tests. ${reason}`);
+              await core.summary
+                .addHeading('Load-test decision')
+                .addTable([
+                  [{ data: 'Decision', header: true }, { data: 'Reason', header: true }],
+                  [decision, reason],
+                ])
+                .write();
+            };
+
+            // A manual dispatch is an explicit request to run the tests, potentially
+            // with different load parameters, so it must not be deduplicated.
+            if (context.eventName === 'workflow_dispatch') {
+              await finish(true, 'The workflow was started manually.');
+              return;
+            }
+
+            try {
+              const branch = context.ref.replace(/^refs\/heads\//, '');
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'perf.yml',
+                branch,
+                status: 'success',
+                per_page: 1,
+              });
+
+              const previousRun = data.workflow_runs[0];
+              if (!previousRun) {
+                await finish(true, `No successful load-test run exists for ${branch}.`);
+                return;
+              }
+
+              if (previousRun.head_sha !== context.sha) {
+                await finish(
+                  true,
+                  `The commit changed from ${previousRun.head_sha} to ${context.sha}.`,
+                );
+                return;
+              }
+
+              await finish(
+                false,
+                `Commit ${context.sha} was already covered by successful run ${previousRun.id}.`,
+              );
+            } catch (error) {
+              // Fail open: an API problem must not silently suppress load testing.
+              core.warning(`Could not inspect previous workflow runs: ${error.message}`);
+              await finish(true, 'Previous runs could not be inspected, so the safe fallback is to run.');
+            }
+
   load-test:
     name: Run Gatling Simulations
+    needs: check-changes
+    if: >-
+      !cancelled() &&
+      (needs.check-changes.result != 'success' || needs.check-changes.outputs.should-run == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   check-changes:
-    name: Check for changes since the last successful run
+    name: Check for changes since the last successful scheduled run
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
@@ -68,13 +68,14 @@ jobs:
                 repo: context.repo.repo,
                 workflow_id: 'perf.yml',
                 branch,
+                event: 'schedule',
                 status: 'success',
                 per_page: 1,
               });
 
               const previousRun = data.workflow_runs[0];
               if (!previousRun) {
-                await finish(true, `No successful load-test run exists for ${branch}.`);
+                await finish(true, `No successful scheduled load-test run exists for ${branch}.`);
                 return;
               }
 
@@ -88,7 +89,7 @@ jobs:
 
               await finish(
                 false,
-                `Commit ${context.sha} was already covered by successful run ${previousRun.id}.`,
+                `Commit ${context.sha} was already covered by successful scheduled run ${previousRun.id}.`,
               );
             } catch (error) {
               // Fail open: an API problem must not silently suppress load testing.


### PR DESCRIPTION
## Summary

The scheduled load-testing workflow was running Gatling repeatedly even when the repository commit had not changed since the previous successful run.

This change adds a lightweight check that:

- retrieves the latest successful load-testing workflow run for the current branch
- compares its commit SHA with the current commit
- skips the expensive build and Gatling jobs when the commit was already tested successfully
- always permits manually dispatched load tests
- reruns tests when a new commit has not succeeded yet
- runs the tests as a safe fallback if the workflow history cannot be retrieved
- respects workflow cancellation

The workflow also records its decision and reason in the GitHub Actions job summary.

Closes #196