### PR TITLE
Hide empty "Or sign in with" when OpenID4VP is not configured

### DIFF
--- a/src/main/resources/theme/keycloak.v2+oid4vp/login/login-default.ftl
+++ b/src/main/resources/theme/keycloak.v2+oid4vp/login/login-default.ftl
@@ -40,7 +40,9 @@
         </div>
         <@passkeys.conditionalUIData />
     <#elseif section = "socialProviders" >
-        <#if realm.password && (social.providers?? && social.providers?has_content || oid4vp??)>
+        <#assign hasSocial = social.providers?? && social.providers?has_content>
+        <#assign hasOid4vp = oid4vp?? && oid4vp.loginProfiles?? && oid4vp.loginProfiles?has_content>
+        <#if realm.password && (hasSocial || hasOid4vp)>
             <@identityProviders.show social=social/>
         </#if>
     <#elseif section = "info" >

--- a/src/main/resources/theme/keycloak.v2+oid4vp/login/social-providers.ftl
+++ b/src/main/resources/theme/keycloak.v2+oid4vp/login/social-providers.ftl
@@ -1,7 +1,8 @@
 <#macro show social>
-    <#assign socialProviders = (social.providers)![]>
-    <#assign oid4vpProviders = []>
-    <#if oid4vp?? && oid4vp.loginProfiles?? && oid4vp.loginProfiles?has_content>
+<div id = "kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
+
+    <#if oid4vp?? && oid4vp.loginProfiles?? && (oid4vp.loginProfiles?size > 0)>
+        <#assign oid4vpProviders = []>
         <#list oid4vp.loginProfiles as profile>
             <#assign oid4vpProviders = oid4vpProviders + [{
                 "alias": "oid4vp-wallet-${profile.id}",
@@ -9,13 +10,10 @@
                 "loginUrl": "${profile.loginUrl}"
             }]>
         </#list>
+        <#assign providers = oid4vpProviders + social.providers>
+    <#else>
+        <#assign providers = social.providers>
     </#if>
-    <#assign providers = oid4vpProviders + socialProviders>
-    <#if !providers?has_content>
-        <#return>
-    </#if>
-
-<div id = "kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
 
     <div class="${properties.kcLoginMainFooterBand!}">
         <span class="${properties.kcLoginMainFooterBandItem!} ${properties.kcLoginMainFooterHelperText!}">

--- a/src/main/resources/theme/keycloak.v2+oid4vp/login/social-providers.ftl
+++ b/src/main/resources/theme/keycloak.v2+oid4vp/login/social-providers.ftl
@@ -1,8 +1,7 @@
 <#macro show social>
-<div id = "kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
-
-    <#if oid4vp?? && oid4vp.loginProfiles?? && (oid4vp.loginProfiles?size > 0)>
-        <#assign oid4vpProviders = []>
+    <#assign socialProviders = (social.providers)![]>
+    <#assign oid4vpProviders = []>
+    <#if oid4vp?? && oid4vp.loginProfiles?? && oid4vp.loginProfiles?has_content>
         <#list oid4vp.loginProfiles as profile>
             <#assign oid4vpProviders = oid4vpProviders + [{
                 "alias": "oid4vp-wallet-${profile.id}",
@@ -10,10 +9,13 @@
                 "loginUrl": "${profile.loginUrl}"
             }]>
         </#list>
-        <#assign providers = oid4vpProviders + social.providers>
-    <#else>
-        <#assign providers = social.providers>
     </#if>
+    <#assign providers = oid4vpProviders + socialProviders>
+    <#if !providers?has_content>
+        <#return>
+    </#if>
+
+<div id = "kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
 
     <div class="${properties.kcLoginMainFooterBand!}">
         <span class="${properties.kcLoginMainFooterBandItem!} ${properties.kcLoginMainFooterHelperText!}">

--- a/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPLoginActionsServiceTest.java
+++ b/src/test/java/io/github/adorsysgis/keycloak/protocol/oid4vc/oid4vp/OID4VPLoginActionsServiceTest.java
@@ -180,20 +180,29 @@ public class OID4VPLoginActionsServiceTest extends OID4VPBaseUserAuthEndpointTes
                                     .json());
             updateAuthenticatorConfig(updatedConfig);
 
-            String authEndpoint = new URIBuilder(getAuthEndpointURI())
-                    .addParameter(OAuth2Constants.CLIENT_ID, TEST_CLIENT_ID)
-                    .addParameter(OAuth2Constants.RESPONSE_TYPE, OAuth2Constants.CODE)
-                    .addParameter(OAuth2Constants.REDIRECT_URI, TEST_CLIENT_REDIRECT_URI)
-                    .build()
-                    .toString();
-
-            HttpResponse response = httpClient.execute(new HttpGet(authEndpoint));
-            assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
-
-            String html = EntityUtils.toString(response.getEntity());
-            String text = Jsoup.parse(html).text();
+            var html = Jsoup.parse(fetchDefaultLoginPageHtml());
+            String text = html.text();
+            assertNotNull(html.selectFirst("form#kc-form-login"));
+            assertNotNull(html.selectFirst("#kc-social-providers"));
             assertTrue(text.contains("Sign in with a wallet"));
             assertFalse(text.contains("Presentation during issuance"));
+        } finally {
+            updateAuthenticatorConfig(originalConfig);
+        }
+    }
+
+    @Test
+    public void shouldHideSocialProvidersSectionWhenOid4vpProfilesAreUnusable() throws Exception {
+        var originalConfig = getAuthenticatorConfig();
+        try {
+            var updatedConfig = getAuthenticatorConfig();
+            updatedConfig.getConfig().put(PROFILES_CONFIG, "not-json");
+            updateAuthenticatorConfig(updatedConfig);
+
+            var html = Jsoup.parse(fetchDefaultLoginPageHtml());
+            assertNotNull(html.selectFirst("form#kc-form-login"));
+            assertNull(html.selectFirst("#kc-social-providers"));
+            assertFalse(html.text().contains("Or sign in with"));
         } finally {
             updateAuthenticatorConfig(originalConfig);
         }
@@ -382,4 +391,17 @@ public class OID4VPLoginActionsServiceTest extends OID4VPBaseUserAuthEndpointTes
     }
 
     public record TestFlowDataV2(FormData formData, ResponseToWallet responseToWallet) {}
+
+    private String fetchDefaultLoginPageHtml() throws Exception {
+        String authEndpoint = new URIBuilder(getAuthEndpointURI())
+                .addParameter(OAuth2Constants.CLIENT_ID, TEST_CLIENT_ID)
+                .addParameter(OAuth2Constants.RESPONSE_TYPE, OAuth2Constants.CODE)
+                .addParameter(OAuth2Constants.REDIRECT_URI, TEST_CLIENT_REDIRECT_URI)
+                .build()
+                .toString();
+
+        HttpResponse response = httpClient.execute(new HttpGet(authEndpoint));
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+        return EntityUtils.toString(response.getEntity());
+    }
 }


### PR DESCRIPTION
### Summary
- The `keycloak.v2+oid4vp` login page showed **Or sign in with** with no buttons when OID4VP was not configured, because the theme treated the always-injected `oid4vp` bean as a reason to render the social footer.

### Test plan
- [ ] Login with OID4VP unconfigured and no social IdPs: username/password only (no "Or sign in with")
- [ ] Login with a wallet profile configured: heading + wallet CTA shown

<img width="777" height="602" alt="Screenshot from 2026-09-09 13-37-40" src="https://github.com/user-attachments/assets/d6ba5651-e500-4b7b-86d8-b6a0798d81f8" />


Closes https://github.com/ADORSYS-GIS/keycloak-oid4vp-plugin/issues/200